### PR TITLE
feat: mnemonic-aware KeyManager with StrongBox encryption

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -122,6 +122,8 @@ dependencies {
 
     // Testing
     testImplementation("junit:junit:4.13.2")
+    testImplementation("org.robolectric:robolectric:4.14.1")
+    testImplementation("androidx.test:core:1.6.1")
 }
 
 tasks.register<Exec>("cargoBuild") {

--- a/android/app/src/main/java/com/rjnr/pocketnode/di/AppModule.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/di/AppModule.kt
@@ -25,8 +25,9 @@ object AppModule {
     @Provides
     @Singleton
     fun provideKeyManager(
-        @ApplicationContext context: Context
-    ): KeyManager = KeyManager(context)
+        @ApplicationContext context: Context,
+        mnemonicManager: MnemonicManager
+    ): KeyManager = KeyManager(context, mnemonicManager)
 
     @Provides
     @Singleton

--- a/android/app/src/test/java/com/rjnr/pocketnode/data/wallet/KeyManagerTest.kt
+++ b/android/app/src/test/java/com/rjnr/pocketnode/data/wallet/KeyManagerTest.kt
@@ -1,0 +1,152 @@
+package com.rjnr.pocketnode.data.wallet
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import org.junit.Assert.*
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [28], manifest = Config.NONE)
+class KeyManagerTest {
+
+    private lateinit var keyManager: KeyManager
+    private lateinit var mnemonicManager: MnemonicManager
+
+    private val testMnemonic = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about"
+        .split(" ")
+
+    @Before
+    fun setUp() {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        mnemonicManager = MnemonicManager()
+        keyManager = KeyManager(context, mnemonicManager)
+        // Use plain SharedPreferences for testing (EncryptedSharedPreferences needs real KeyStore)
+        keyManager.testPrefs = context.getSharedPreferences("test_keys", Context.MODE_PRIVATE)
+        keyManager.deleteWallet()
+    }
+
+    // -- Mnemonic generation --
+
+    @Test
+    fun `generateWalletWithMnemonic returns 12 words and valid wallet info`() {
+        val (info, words) = keyManager.generateWalletWithMnemonic()
+
+        assertEquals(12, words.size)
+        assertTrue(mnemonicManager.validateMnemonic(words))
+        assertNotNull(info.publicKey)
+        assertTrue(info.mainnetAddress.startsWith("ckb1"))
+        assertTrue(info.testnetAddress.startsWith("ckt1"))
+    }
+
+    @Test
+    fun `generateWalletWithMnemonic sets wallet type to mnemonic`() {
+        keyManager.generateWalletWithMnemonic()
+        assertEquals(KeyManager.WALLET_TYPE_MNEMONIC, keyManager.getWalletType())
+    }
+
+    @Test
+    fun `generateWallet sets wallet type to raw_key`() {
+        keyManager.generateWallet()
+        assertEquals(KeyManager.WALLET_TYPE_RAW_KEY, keyManager.getWalletType())
+    }
+
+    // -- Mnemonic storage and retrieval --
+
+    @Test
+    fun `getMnemonic returns stored words after mnemonic generation`() {
+        val (_, words) = keyManager.generateWalletWithMnemonic()
+        val retrieved = keyManager.getMnemonic()
+        assertEquals(words, retrieved)
+    }
+
+    @Test
+    fun `getMnemonic returns null for raw key wallet`() {
+        keyManager.generateWallet()
+        assertNull(keyManager.getMnemonic())
+    }
+
+    // -- Mnemonic import --
+
+    @Test
+    fun `importWalletFromMnemonic produces valid wallet`() {
+        val info = keyManager.importWalletFromMnemonic(testMnemonic)
+
+        assertNotNull(info.publicKey)
+        assertTrue(info.mainnetAddress.startsWith("ckb1"))
+        assertEquals(KeyManager.WALLET_TYPE_MNEMONIC, keyManager.getWalletType())
+    }
+
+    @Test
+    fun `importWalletFromMnemonic is deterministic`() {
+        val info1 = keyManager.importWalletFromMnemonic(testMnemonic)
+        keyManager.deleteWallet()
+        val info2 = keyManager.importWalletFromMnemonic(testMnemonic)
+
+        assertEquals(info1.publicKey, info2.publicKey)
+        assertEquals(info1.mainnetAddress, info2.mainnetAddress)
+    }
+
+    @Test
+    fun `importWalletFromMnemonic stores mnemonic`() {
+        keyManager.importWalletFromMnemonic(testMnemonic)
+        assertEquals(testMnemonic, keyManager.getMnemonic())
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun `importWalletFromMnemonic rejects invalid mnemonic`() {
+        keyManager.importWalletFromMnemonic(listOf("invalid", "words", "here"))
+    }
+
+    // -- Backup status --
+
+    @Test
+    fun `hasMnemonicBackup is false after generation`() {
+        keyManager.generateWalletWithMnemonic()
+        assertFalse(keyManager.hasMnemonicBackup())
+    }
+
+    @Test
+    fun `setMnemonicBackedUp updates status`() {
+        keyManager.generateWalletWithMnemonic()
+        assertFalse(keyManager.hasMnemonicBackup())
+
+        keyManager.setMnemonicBackedUp(true)
+        assertTrue(keyManager.hasMnemonicBackup())
+    }
+
+    // -- Delete --
+
+    @Test
+    fun `deleteWallet clears all stored data`() {
+        keyManager.generateWalletWithMnemonic()
+        assertTrue(keyManager.hasWallet())
+
+        keyManager.deleteWallet()
+        assertFalse(keyManager.hasWallet())
+        assertNull(keyManager.getMnemonic())
+        assertEquals(KeyManager.WALLET_TYPE_RAW_KEY, keyManager.getWalletType())
+    }
+
+    // -- Backward compatibility --
+
+    @Test
+    fun `existing generateWallet still works`() {
+        val info = keyManager.generateWallet()
+        assertTrue(keyManager.hasWallet())
+        assertNotNull(info.publicKey)
+        assertEquals(KeyManager.WALLET_TYPE_RAW_KEY, keyManager.getWalletType())
+    }
+
+    @Test
+    fun `existing importWallet still works`() {
+        val hex = "a".repeat(64)
+        val info = keyManager.importWallet(hex)
+        assertTrue(keyManager.hasWallet())
+        assertNotNull(info.publicKey)
+        assertEquals(KeyManager.WALLET_TYPE_RAW_KEY, keyManager.getWalletType())
+    }
+}


### PR DESCRIPTION
## Summary
- Integrates `MnemonicManager` (from #11) into `KeyManager` for BIP39 wallet creation and import
- Adds encrypted mnemonic storage, wallet type tracking (`mnemonic` vs `raw_key`), and backup status flag
- Enables StrongBox-backed `MasterKey` (falls back to TEE if unavailable)
- Adds 6 new methods to `GatewayRepository` as pass-through to KeyManager
- Existing raw-key wallet methods (`generateWallet`, `importWallet`) remain unchanged

## Changes
| File | Change |
|------|--------|
| `KeyManager.kt` | MnemonicManager injection, StrongBox, 7 new methods, updated `deleteWallet` |
| `AppModule.kt` | Updated `provideKeyManager` to pass `MnemonicManager` |
| `GatewayRepository.kt` | Added `createWalletWithMnemonic`, `importFromMnemonic`, and 4 delegation methods |
| `build.gradle.kts` | Added Robolectric + AndroidX test dependencies |
| `KeyManagerTest.kt` | 14 unit tests (Robolectric) covering all new and existing methods |

## Test plan
- [x] All 32 unit tests pass (`./gradlew :app:testDebugUnitTest -x cargoBuild`)
- [x] KeyManagerTest: 14/14 green — mnemonic generation, import, storage, backup status, delete, backward compat
- [x] MnemonicManagerTest: 18/18 green (unchanged from #11)
- [x] CI passes on push

Closes #2