### PR TITLE
feat: implement AuthManager and PinManager

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -94,6 +94,7 @@ dependencies {
     implementation(libs.kotlinx.serialization.json)
 
     // Security & Crypto
+    implementation(libs.androidx.biometric)
     implementation(libs.androidx.security.crypto)
     implementation(libs.secp256k1.kmp.jni.android)
     implementation(libs.kotlin.bip39)

--- a/android/app/src/main/java/com/rjnr/pocketnode/data/auth/AuthManager.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/auth/AuthManager.kt
@@ -1,0 +1,74 @@
+package com.rjnr.pocketnode.data.auth
+
+import android.content.Context
+import android.content.SharedPreferences
+import androidx.annotation.VisibleForTesting
+import androidx.biometric.BiometricManager
+import androidx.biometric.BiometricManager.Authenticators
+import dagger.hilt.android.qualifiers.ApplicationContext
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class AuthManager @Inject constructor(
+    @ApplicationContext private val context: Context
+) {
+    @VisibleForTesting
+    internal var testPrefs: SharedPreferences? = null
+
+    private val prefs: SharedPreferences
+        get() = testPrefs ?: defaultPrefs
+
+    private val defaultPrefs: SharedPreferences by lazy {
+        context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+    }
+
+    @VisibleForTesting
+    internal var testBiometricManager: BiometricManager? = null
+
+    private val biometricMgr: BiometricManager
+        get() = testBiometricManager ?: BiometricManager.from(context)
+
+    enum class BiometricStatus {
+        AVAILABLE,
+        NO_HARDWARE,
+        NOT_ENROLLED,
+        UNAVAILABLE
+    }
+
+    fun isBiometricAvailable(): BiometricStatus {
+        return when (biometricMgr.canAuthenticate(Authenticators.BIOMETRIC_STRONG)) {
+            BiometricManager.BIOMETRIC_SUCCESS -> BiometricStatus.AVAILABLE
+            BiometricManager.BIOMETRIC_ERROR_NO_HARDWARE -> BiometricStatus.NO_HARDWARE
+            BiometricManager.BIOMETRIC_ERROR_NONE_ENROLLED -> BiometricStatus.NOT_ENROLLED
+            else -> BiometricStatus.UNAVAILABLE
+        }
+    }
+
+    fun isBiometricEnrolled(): Boolean =
+        isBiometricAvailable() == BiometricStatus.AVAILABLE
+
+    fun isBiometricEnabled(): Boolean =
+        prefs.getBoolean(KEY_BIOMETRIC_ENABLED, false)
+
+    fun setBiometricEnabled(enabled: Boolean) {
+        prefs.edit().putBoolean(KEY_BIOMETRIC_ENABLED, enabled).apply()
+    }
+
+    fun hasDeviceCredential(): Boolean =
+        biometricMgr.canAuthenticate(Authenticators.DEVICE_CREDENTIAL) ==
+            BiometricManager.BIOMETRIC_SUCCESS
+
+    fun getAllowedAuthenticators(): Int {
+        return if (isBiometricEnrolled() && isBiometricEnabled()) {
+            Authenticators.BIOMETRIC_STRONG or Authenticators.DEVICE_CREDENTIAL
+        } else {
+            Authenticators.DEVICE_CREDENTIAL
+        }
+    }
+
+    companion object {
+        private const val PREFS_NAME = "ckb_auth_settings"
+        private const val KEY_BIOMETRIC_ENABLED = "biometric_enabled"
+    }
+}

--- a/android/app/src/main/java/com/rjnr/pocketnode/data/auth/PinManager.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/auth/PinManager.kt
@@ -1,0 +1,161 @@
+package com.rjnr.pocketnode.data.auth
+
+import android.content.Context
+import android.content.SharedPreferences
+import androidx.annotation.VisibleForTesting
+import androidx.security.crypto.EncryptedSharedPreferences
+import androidx.security.crypto.MasterKey
+import com.rjnr.pocketnode.data.crypto.Blake2b
+import dagger.hilt.android.qualifiers.ApplicationContext
+import java.security.SecureRandom
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class PinManager @Inject constructor(
+    @ApplicationContext private val context: Context,
+    private val blake2b: Blake2b
+) {
+    @VisibleForTesting
+    internal var testPrefs: SharedPreferences? = null
+
+    private val prefs: SharedPreferences
+        get() = testPrefs ?: encryptedPrefs
+
+    private val encryptedPrefs: SharedPreferences by lazy {
+        val masterKey = MasterKey.Builder(context)
+            .setKeyScheme(MasterKey.KeyScheme.AES256_GCM)
+            .setRequestStrongBoxBacked(true)
+            .build()
+
+        EncryptedSharedPreferences.create(
+            context,
+            PREFS_NAME,
+            masterKey,
+            EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
+            EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM
+        )
+    }
+
+    @VisibleForTesting
+    internal var timeProvider: () -> Long = { System.currentTimeMillis() }
+
+    fun setPin(pin: String) {
+        require(pin.length == PIN_LENGTH && pin.all { it.isDigit() }) {
+            "PIN must be exactly $PIN_LENGTH digits"
+        }
+        val hash = hashPin(pin)
+        prefs.edit()
+            .putString(KEY_PIN_HASH, hash)
+            .putInt(KEY_FAILED_ATTEMPTS, 0)
+            .remove(KEY_LOCKOUT_UNTIL)
+            .apply()
+    }
+
+    fun verifyPin(pin: String): Boolean {
+        if (isLockedOut()) return false
+        if (!hasPin()) return false
+
+        val storedHash = prefs.getString(KEY_PIN_HASH, null) ?: return false
+        val inputHash = hashPin(pin)
+
+        return if (inputHash == storedHash) {
+            resetFailedAttempts()
+            true
+        } else {
+            recordFailedAttempt()
+            false
+        }
+    }
+
+    fun hasPin(): Boolean = prefs.contains(KEY_PIN_HASH)
+
+    fun removePin() {
+        prefs.edit()
+            .remove(KEY_PIN_HASH)
+            .remove(KEY_SALT)
+            .remove(KEY_FAILED_ATTEMPTS)
+            .remove(KEY_LOCKOUT_UNTIL)
+            .apply()
+    }
+
+    fun getRemainingAttempts(): Int {
+        val failed = prefs.getInt(KEY_FAILED_ATTEMPTS, 0)
+        return (MAX_ATTEMPTS - failed).coerceAtLeast(0)
+    }
+
+    fun isLockedOut(): Boolean {
+        val lockoutUntil = prefs.getLong(KEY_LOCKOUT_UNTIL, 0L)
+        if (lockoutUntil == 0L) return false
+
+        return if (timeProvider() < lockoutUntil) {
+            true
+        } else {
+            prefs.edit()
+                .putInt(KEY_FAILED_ATTEMPTS, 0)
+                .remove(KEY_LOCKOUT_UNTIL)
+                .apply()
+            false
+        }
+    }
+
+    fun getLockoutRemainingMs(): Long {
+        val lockoutUntil = prefs.getLong(KEY_LOCKOUT_UNTIL, 0L)
+        if (lockoutUntil == 0L) return 0L
+        return (lockoutUntil - timeProvider()).coerceAtLeast(0L)
+    }
+
+    private fun recordFailedAttempt() {
+        val attempts = prefs.getInt(KEY_FAILED_ATTEMPTS, 0) + 1
+        val editor = prefs.edit().putInt(KEY_FAILED_ATTEMPTS, attempts)
+        if (attempts >= MAX_ATTEMPTS) {
+            editor.putLong(KEY_LOCKOUT_UNTIL, timeProvider() + LOCKOUT_DURATION_MS)
+        }
+        editor.apply()
+    }
+
+    private fun resetFailedAttempts() {
+        prefs.edit()
+            .putInt(KEY_FAILED_ATTEMPTS, 0)
+            .remove(KEY_LOCKOUT_UNTIL)
+            .apply()
+    }
+
+    private fun hashPin(pin: String): String {
+        val salt = getOrCreateSalt()
+        val input = salt + pin.toByteArray(Charsets.UTF_8)
+        val hash = blake2b.hash(input)
+        return hash.joinToString("") { "%02x".format(it) }
+    }
+
+    private fun getOrCreateSalt(): ByteArray {
+        val existingHex = prefs.getString(KEY_SALT, null)
+        if (existingHex != null) {
+            return hexToBytes(existingHex)
+        }
+        val salt = ByteArray(SALT_SIZE)
+        SecureRandom().nextBytes(salt)
+        val hex = salt.joinToString("") { "%02x".format(it) }
+        prefs.edit().putString(KEY_SALT, hex).apply()
+        return salt
+    }
+
+    private fun hexToBytes(hex: String): ByteArray {
+        return ByteArray(hex.length / 2) { i ->
+            hex.substring(i * 2, i * 2 + 2).toInt(16).toByte()
+        }
+    }
+
+    companion object {
+        internal const val PREFS_NAME = "ckb_pin_prefs"
+        internal const val PIN_LENGTH = 6
+        internal const val MAX_ATTEMPTS = 5
+        internal const val LOCKOUT_DURATION_MS = 30_000L
+        internal const val SALT_SIZE = 32
+
+        private const val KEY_PIN_HASH = "pin_hash"
+        private const val KEY_SALT = "pin_salt"
+        private const val KEY_FAILED_ATTEMPTS = "failed_attempts"
+        private const val KEY_LOCKOUT_UNTIL = "lockout_until"
+    }
+}

--- a/android/app/src/main/java/com/rjnr/pocketnode/di/AppModule.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/di/AppModule.kt
@@ -1,6 +1,8 @@
 package com.rjnr.pocketnode.di
 
 import android.content.Context
+import com.rjnr.pocketnode.data.auth.AuthManager
+import com.rjnr.pocketnode.data.auth.PinManager
 import com.rjnr.pocketnode.data.crypto.Blake2b
 import com.rjnr.pocketnode.data.gateway.GatewayRepository
 import com.rjnr.pocketnode.data.wallet.KeyManager
@@ -39,6 +41,19 @@ object AppModule {
         ignoreUnknownKeys = true 
         encodeDefaults = true
     }
+
+    @Provides
+    @Singleton
+    fun provideAuthManager(
+        @ApplicationContext context: Context
+    ): AuthManager = AuthManager(context)
+
+    @Provides
+    @Singleton
+    fun providePinManager(
+        @ApplicationContext context: Context,
+        blake2b: Blake2b
+    ): PinManager = PinManager(context, blake2b)
 
     @Provides
     @Singleton

--- a/android/app/src/test/java/com/rjnr/pocketnode/data/auth/AuthManagerTest.kt
+++ b/android/app/src/test/java/com/rjnr/pocketnode/data/auth/AuthManagerTest.kt
@@ -1,0 +1,57 @@
+package com.rjnr.pocketnode.data.auth
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import org.junit.Assert.*
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [28], manifest = Config.NONE)
+class AuthManagerTest {
+
+    private lateinit var authManager: AuthManager
+
+    @Before
+    fun setUp() {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        authManager = AuthManager(context)
+        authManager.testPrefs = context.getSharedPreferences("test_auth", Context.MODE_PRIVATE)
+        authManager.testPrefs!!.edit().clear().commit()
+    }
+
+    @Test
+    fun `isBiometricEnabled returns false by default`() {
+        assertFalse(authManager.isBiometricEnabled())
+    }
+
+    @Test
+    fun `setBiometricEnabled true then isBiometricEnabled returns true`() {
+        authManager.setBiometricEnabled(true)
+        assertTrue(authManager.isBiometricEnabled())
+    }
+
+    @Test
+    fun `setBiometricEnabled false after true returns false`() {
+        authManager.setBiometricEnabled(true)
+        authManager.setBiometricEnabled(false)
+        assertFalse(authManager.isBiometricEnabled())
+    }
+
+    @Test
+    fun `isBiometricAvailable returns valid status on emulator`() {
+        val status = authManager.isBiometricAvailable()
+        assertTrue(
+            status == AuthManager.BiometricStatus.NO_HARDWARE ||
+                status == AuthManager.BiometricStatus.UNAVAILABLE
+        )
+    }
+
+    @Test
+    fun `isBiometricEnrolled returns false on emulator`() {
+        assertFalse(authManager.isBiometricEnrolled())
+    }
+}

--- a/android/app/src/test/java/com/rjnr/pocketnode/data/auth/PinManagerTest.kt
+++ b/android/app/src/test/java/com/rjnr/pocketnode/data/auth/PinManagerTest.kt
@@ -1,0 +1,210 @@
+package com.rjnr.pocketnode.data.auth
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import com.rjnr.pocketnode.data.crypto.Blake2b
+import org.junit.Assert.*
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [28], manifest = Config.NONE)
+class PinManagerTest {
+
+    private lateinit var pinManager: PinManager
+    private lateinit var blake2b: Blake2b
+    private var fakeTimeMs: Long = 1_000_000L
+
+    @Before
+    fun setUp() {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        blake2b = Blake2b()
+        pinManager = PinManager(context, blake2b)
+        pinManager.testPrefs = context.getSharedPreferences("test_pin", Context.MODE_PRIVATE)
+        pinManager.timeProvider = { fakeTimeMs }
+        pinManager.testPrefs!!.edit().clear().commit()
+    }
+
+    // -- PIN set/verify --
+
+    @Test
+    fun `setPin and verifyPin with correct PIN returns true`() {
+        pinManager.setPin("123456")
+        assertTrue(pinManager.verifyPin("123456"))
+    }
+
+    @Test
+    fun `verifyPin with wrong PIN returns false`() {
+        pinManager.setPin("123456")
+        assertFalse(pinManager.verifyPin("654321"))
+    }
+
+    @Test
+    fun `hasPin returns false initially`() {
+        assertFalse(pinManager.hasPin())
+    }
+
+    @Test
+    fun `hasPin returns true after setPin`() {
+        pinManager.setPin("123456")
+        assertTrue(pinManager.hasPin())
+    }
+
+    @Test
+    fun `removePin clears stored PIN`() {
+        pinManager.setPin("123456")
+        assertTrue(pinManager.hasPin())
+        pinManager.removePin()
+        assertFalse(pinManager.hasPin())
+    }
+
+    @Test
+    fun `verifyPin returns false when no PIN set`() {
+        assertFalse(pinManager.verifyPin("123456"))
+    }
+
+    // -- PIN validation --
+
+    @Test(expected = IllegalArgumentException::class)
+    fun `setPin rejects PIN shorter than 6 digits`() {
+        pinManager.setPin("12345")
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun `setPin rejects PIN longer than 6 digits`() {
+        pinManager.setPin("1234567")
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun `setPin rejects non-digit characters`() {
+        pinManager.setPin("12345a")
+    }
+
+    // -- Hash consistency --
+
+    @Test
+    fun `same PIN always produces same hash`() {
+        pinManager.setPin("111111")
+        assertTrue(pinManager.verifyPin("111111"))
+        assertTrue(pinManager.verifyPin("111111"))
+        assertTrue(pinManager.verifyPin("111111"))
+    }
+
+    @Test
+    fun `changing PIN updates hash`() {
+        pinManager.setPin("123456")
+        assertTrue(pinManager.verifyPin("123456"))
+        pinManager.setPin("654321")
+        assertFalse(pinManager.verifyPin("123456"))
+        assertTrue(pinManager.verifyPin("654321"))
+    }
+
+    // -- Lockout cycle --
+
+    @Test
+    fun `getRemainingAttempts starts at MAX_ATTEMPTS`() {
+        pinManager.setPin("123456")
+        assertEquals(PinManager.MAX_ATTEMPTS, pinManager.getRemainingAttempts())
+    }
+
+    @Test
+    fun `failed attempts decrement remaining attempts`() {
+        pinManager.setPin("123456")
+        pinManager.verifyPin("000000")
+        assertEquals(PinManager.MAX_ATTEMPTS - 1, pinManager.getRemainingAttempts())
+    }
+
+    @Test
+    fun `lockout triggers after MAX_ATTEMPTS failed attempts`() {
+        pinManager.setPin("123456")
+        repeat(PinManager.MAX_ATTEMPTS) {
+            pinManager.verifyPin("000000")
+        }
+        assertTrue(pinManager.isLockedOut())
+        assertEquals(0, pinManager.getRemainingAttempts())
+    }
+
+    @Test
+    fun `verifyPin returns false during lockout even with correct PIN`() {
+        pinManager.setPin("123456")
+        repeat(PinManager.MAX_ATTEMPTS) {
+            pinManager.verifyPin("000000")
+        }
+        assertTrue(pinManager.isLockedOut())
+        assertFalse(pinManager.verifyPin("123456"))
+    }
+
+    @Test
+    fun `lockout expires after LOCKOUT_DURATION_MS`() {
+        pinManager.setPin("123456")
+        repeat(PinManager.MAX_ATTEMPTS) {
+            pinManager.verifyPin("000000")
+        }
+        assertTrue(pinManager.isLockedOut())
+
+        fakeTimeMs += PinManager.LOCKOUT_DURATION_MS + 1
+        assertFalse(pinManager.isLockedOut())
+        assertEquals(PinManager.MAX_ATTEMPTS, pinManager.getRemainingAttempts())
+    }
+
+    @Test
+    fun `getLockoutRemainingMs returns correct remaining time`() {
+        pinManager.setPin("123456")
+        repeat(PinManager.MAX_ATTEMPTS) {
+            pinManager.verifyPin("000000")
+        }
+        val remaining = pinManager.getLockoutRemainingMs()
+        assertTrue(remaining > 0)
+        assertTrue(remaining <= PinManager.LOCKOUT_DURATION_MS)
+    }
+
+    @Test
+    fun `getLockoutRemainingMs returns 0 when not locked out`() {
+        pinManager.setPin("123456")
+        assertEquals(0L, pinManager.getLockoutRemainingMs())
+    }
+
+    @Test
+    fun `successful verification resets failed attempts`() {
+        pinManager.setPin("123456")
+        pinManager.verifyPin("000000")
+        pinManager.verifyPin("000000")
+        assertEquals(PinManager.MAX_ATTEMPTS - 2, pinManager.getRemainingAttempts())
+
+        pinManager.verifyPin("123456")
+        assertEquals(PinManager.MAX_ATTEMPTS, pinManager.getRemainingAttempts())
+    }
+
+    @Test
+    fun `setPin resets failed attempts and lockout`() {
+        pinManager.setPin("123456")
+        repeat(PinManager.MAX_ATTEMPTS) {
+            pinManager.verifyPin("000000")
+        }
+        assertTrue(pinManager.isLockedOut())
+
+        pinManager.setPin("654321")
+        assertFalse(pinManager.isLockedOut())
+        assertEquals(PinManager.MAX_ATTEMPTS, pinManager.getRemainingAttempts())
+        assertTrue(pinManager.verifyPin("654321"))
+    }
+
+    @Test
+    fun `lockout state persists across PinManager instances`() {
+        pinManager.setPin("123456")
+        repeat(PinManager.MAX_ATTEMPTS) {
+            pinManager.verifyPin("000000")
+        }
+        assertTrue(pinManager.isLockedOut())
+
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        val newPinManager = PinManager(context, blake2b)
+        newPinManager.testPrefs = pinManager.testPrefs
+        newPinManager.timeProvider = { fakeTimeMs }
+
+        assertTrue(newPinManager.isLockedOut())
+    }
+}

--- a/android/gradle/libs.versions.toml
+++ b/android/gradle/libs.versions.toml
@@ -14,6 +14,7 @@ room = "2.8.4"
 ksp = "2.1.0-1.0.29"
 ckbSdk = "4.0.0"
 bouncycastle = "1.70"
+biometric = "1.1.0"
 bip39 = "1.0.8"
 cameraX = "1.4.2"
 mlkitBarcodeScanning = "17.3.0"
@@ -44,6 +45,7 @@ hilt-compiler = { group = "com.google.dagger", name = "hilt-compiler", version.r
 hilt-navigation-compose = { group = "androidx.hilt", name = "hilt-navigation-compose", version.ref = "hiltNavigationCompose" }
 
 # Security & Crypto
+androidx-biometric = { group = "androidx.biometric", name = "biometric", version.ref = "biometric" }
 androidx-security-crypto = { group = "androidx.security", name = "security-crypto", version.ref = "securityCrypto" }
 secp256k1-kmp-jni-android = { group = "fr.acinq.secp256k1", name = "secp256k1-kmp-jni-android", version.ref = "secp256k1" }
 kotlin-bip39 = { group = "cash.z.ecc.android", name = "kotlin-bip39", version.ref = "bip39" }


### PR DESCRIPTION
## Summary

- **AuthManager**: Biometric availability checking via `BiometricManager`, biometric enable/disable preference toggle, authenticator flag helper for `BiometricPrompt`
- **PinManager**: 6-digit PIN with Blake2b + per-device salt hashing, `EncryptedSharedPreferences` storage, 5-attempt lockout with 30-second cooldown, time-based lockout expiry

## Changes

| File | Action |
|------|--------|
| `gradle/libs.versions.toml` | Add `androidx.biometric:biometric:1.1.0` |
| `app/build.gradle.kts` | Add biometric implementation |
| `data/auth/AuthManager.kt` | New — biometric wrapper + preference toggle |
| `data/auth/PinManager.kt` | New — PIN hash/verify/lockout state machine |
| `di/AppModule.kt` | Add AuthManager and PinManager providers |
| `PinManagerTest.kt` | 21 unit tests |
| `AuthManagerTest.kt` | 5 unit tests |

## Test plan

- [x] `./gradlew assembleDebug -x cargoBuild` compiles
- [x] `./gradlew test -x cargoBuild` — all 58 tests pass (26 new + 32 existing)
- [x] CI passes

Closes #4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Biometric authentication support with device-credential fallback.
  * PIN-based authentication with encrypted storage, failed-attempt tracking, and automatic lockout.

* **Tests**
  * Added comprehensive test coverage for biometric and PIN authentication behavior and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->