### PR TITLE
feat: release workflow, open-source docs, and CI cleanup

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,35 @@
+---
+name: Bug Report
+about: Report a bug or unexpected behavior
+title: ''
+labels: bug
+assignees: ''
+---
+
+## Description
+
+A clear description of the bug.
+
+## Steps to Reproduce
+
+1. Go to '...'
+2. Tap on '...'
+3. See error
+
+## Expected Behavior
+
+What you expected to happen.
+
+## Actual Behavior
+
+What actually happened.
+
+## Environment
+
+- **Device**: (e.g., Pixel 7, Samsung Galaxy S24)
+- **Android version**: (e.g., Android 14)
+- **App version**: (e.g., 1.1.0)
+
+## Screenshots / Logs
+
+If applicable, add screenshots or relevant log output.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,23 @@
+---
+name: Feature Request
+about: Suggest a new feature or improvement
+title: ''
+labels: enhancement
+assignees: ''
+---
+
+## Problem
+
+What problem does this feature solve? (e.g., "I'm frustrated when...")
+
+## Proposed Solution
+
+Describe the feature or change you'd like.
+
+## Alternatives Considered
+
+Any alternative approaches you've thought about.
+
+## Additional Context
+
+Screenshots, mockups, or links to related issues.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,22 @@
+## Summary
+
+Brief description of what this PR does.
+
+## Related Issue
+
+Closes #
+
+## Type of Change
+
+- [ ] Bug fix
+- [ ] New feature
+- [ ] Refactor
+- [ ] Documentation
+- [ ] CI/CD
+
+## Checklist
+
+- [ ] Code compiles without errors (`./gradlew assembleDebug -x cargoBuild`)
+- [ ] Tests pass (`./gradlew test -x cargoBuild`)
+- [ ] No secrets or private keys committed
+- [ ] Tested on a physical device or emulator

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,19 +31,33 @@ jobs:
           key: gradle-${{ hashFiles('android/**/*.gradle.kts', 'android/gradle/libs.versions.toml') }}
           restore-keys: gradle-
 
-      - name: Create dummy google-services.json
+      - name: Write google-services.json
+        env:
+          GOOGLE_SERVICES_JSON: ${{ secrets.GOOGLE_SERVICES_JSON }}
         run: |
-          cat > android/app/google-services.json << 'GSEOF'
-          {
-            "project_info": { "project_number": "0", "project_id": "dummy", "storage_bucket": "dummy.appspot.com" },
-            "client": [{ "client_info": { "mobilesdk_app_id": "1:0:android:0", "android_client_info": { "package_name": "com.rjnr.pocketnode" } }, "api_key": [{ "current_key": "dummy" }] }],
-            "configuration_version": "1"
-          }
+          if [ -n "$GOOGLE_SERVICES_JSON" ]; then
+            echo "$GOOGLE_SERVICES_JSON" > android/app/google-services.json
+          else
+            # Fallback dummy config — Firebase features will be non-functional
+            cat > android/app/google-services.json << 'GSEOF'
+            {
+              "project_info": { "project_number": "0", "project_id": "dummy", "storage_bucket": "dummy.appspot.com" },
+              "client": [{ "client_info": { "mobilesdk_app_id": "1:0:android:0", "android_client_info": { "package_name": "com.rjnr.pocketnode" } }, "api_key": [{ "current_key": "dummy" }] }],
+              "configuration_version": "1"
+            }
           GSEOF
+            echo "::warning::GOOGLE_SERVICES_JSON secret not set — using dummy config. Firebase features will be non-functional."
+          fi
 
       - name: Decode keystore
-        run: echo "${{ secrets.KEYSTORE_BASE64 }}" | base64 -d > android/app/release.jks
+        env:
+          KEYSTORE_BASE64: ${{ secrets.KEYSTORE_BASE64 }}
+        run: echo "$KEYSTORE_BASE64" | base64 -d > android/app/release.jks
 
+      # NOTE: -x cargoBuild skips the Rust JNI build. The pre-built .so files
+      # must be present in android/app/src/main/jniLibs/ (checked below).
+      # Full CI native build will be enabled once the light-client-db-common
+      # dependency is resolved upstream.
       - name: Build signed release APK
         working-directory: android
         env:
@@ -52,6 +66,16 @@ jobs:
           KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
           KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
         run: ./gradlew assembleRelease -x cargoBuild
+
+      - name: Verify native library is packaged
+        run: |
+          APK=$(find android/app/build/outputs/apk/release -name '*.apk' | head -1)
+          if ! unzip -l "$APK" | grep -q 'libckb_light_client_lib.so'; then
+            echo "::error::Release APK does not contain libckb_light_client_lib.so — the app will crash on JNI calls."
+            echo "Ensure pre-built .so files are in android/app/src/main/jniLibs/ before tagging a release."
+            exit 1
+          fi
+          echo "Native library found in APK."
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,17 +1,12 @@
-name: Android CI
+name: Release
 
 on:
   push:
-    branches: [main]
-  pull_request:
-    branches: [main]
-
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+    tags:
+      - 'v*'
 
 jobs:
-  build:
+  release:
     runs-on: ubuntu-latest
     timeout-minutes: 30
 
@@ -36,10 +31,6 @@ jobs:
           key: gradle-${{ hashFiles('android/**/*.gradle.kts', 'android/gradle/libs.versions.toml') }}
           restore-keys: gradle-
 
-      # JNI library build is skipped — Rust workspace has a missing dependency
-      # (light-client-db-common). Full JNI CI will be restored in Issue #7.
-      # For now, CI validates Kotlin compilation and unit tests.
-
       - name: Create dummy google-services.json
         run: |
           cat > android/app/google-services.json << 'GSEOF'
@@ -50,18 +41,20 @@ jobs:
           }
           GSEOF
 
-      - name: Build debug APK
-        working-directory: android
-        run: ./gradlew assembleDebug -x cargoBuild
+      - name: Decode keystore
+        run: echo "${{ secrets.KEYSTORE_BASE64 }}" | base64 -d > android/app/release.jks
 
-      - name: Run unit tests
+      - name: Build signed release APK
         working-directory: android
-        run: ./gradlew test -x cargoBuild
+        env:
+          KEYSTORE_PATH: ${{ github.workspace }}/android/app/release.jks
+          KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
+          KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
+          KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
+        run: ./gradlew assembleRelease -x cargoBuild
 
-      - name: Upload test results
-        if: failure()
-        uses: actions/upload-artifact@v4
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
         with:
-          name: test-results
-          path: android/app/build/reports/tests/
-          retention-days: 7
+          files: android/app/build/outputs/apk/release/*.apk
+          generate_release_notes: true

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,7 +56,7 @@ Data flows unidirectionally: UI observes StateFlow from ViewModels. ViewModels c
 ## Project Structure
 
 ```
-ckb-wallet-gateway/
+pocket-node/
 ├── android/                         # Android project root
 │   ├── app/
 │   │   ├── build.gradle.kts         # App build config, dependencies, cargo task

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,106 @@
+# Contributing to Pocket Node
+
+Thank you for your interest in contributing to Pocket Node! This document covers the development setup, coding conventions, and PR process.
+
+## Prerequisites
+
+- **Android Studio** (latest stable)
+- **JDK 17**
+- **Android SDK** (min SDK 26, target SDK 35, compile SDK 36)
+- **Rust toolchain** with Android cross-compilation targets (for JNI library changes):
+  ```bash
+  rustup target add aarch64-linux-android armv7-linux-androideabi x86_64-linux-android i686-linux-android
+  ```
+- **Android NDK** (auto-detected by Gradle or at `~/Library/Android/sdk/ndk/`)
+
+## Development Setup
+
+1. Clone the repository:
+   ```bash
+   git clone https://github.com/RaheemJnr/Light-Client-Gateway.git
+   cd Light-Client-Gateway
+   ```
+
+2. Open the `android/` directory in Android Studio.
+
+3. Build and run:
+   ```bash
+   cd android
+   ./gradlew assembleDebug -x cargoBuild  # Skip JNI build for Kotlin-only work
+   ./gradlew installDebug                  # Install on connected device
+   ```
+
+4. Run tests:
+   ```bash
+   cd android
+   ./gradlew test -x cargoBuild
+   ```
+
+## Code Style
+
+### Kotlin
+
+- Follow standard [Kotlin coding conventions](https://kotlinlang.org/docs/coding-conventions.html)
+- Use `@Serializable` with `@SerialName("snake_case")` for JSON models
+- Use `Result<T>` with `runCatching {}` for error handling in repositories
+- Use `StateFlow` for observable state in ViewModels
+- Prefer `_uiState.update { it.copy(...) }` for state mutations
+
+### Jetpack Compose
+
+- One `@Composable` screen function per file (e.g., `HomeScreen.kt`)
+- Use `hiltViewModel()` for ViewModel injection
+- Use `collectAsState()` to observe StateFlow
+- Material 3 components exclusively (no XML layouts)
+
+### Naming
+
+- ViewModels: `{Screen}ViewModel` with `{Screen}UiState` data class
+- Screens: `@Composable fun {Name}Screen()`
+- Packages: `com.rjnr.pocketnode.{layer}.{feature}`
+- Branches: `feature/{issue-number}-short-description`
+
+## Branch Workflow
+
+1. Create a feature branch from `main`:
+   ```bash
+   git checkout -b feature/{issue-number}-short-description
+   ```
+
+2. Make your changes and commit:
+   ```bash
+   git commit -m "feat: brief description of change"
+   ```
+
+3. Push and open a PR against `main`:
+   ```bash
+   git push -u origin feature/{issue-number}-short-description
+   ```
+
+### Commit Messages
+
+Use conventional-style prefixes:
+
+- `feat:` — new feature
+- `fix:` — bug fix
+- `refactor:` — code restructuring without behavior change
+- `chore:` — build, CI, dependency updates
+- `docs:` — documentation only
+
+## Pull Requests
+
+- Link the related issue in the PR description
+- Describe what changed and why
+- Ensure CI passes (build + tests)
+- Keep PRs focused — one issue per PR when possible
+
+## Security
+
+- Never commit secrets, private keys, or keystore files
+- Never log sensitive data (private keys, mnemonics, PINs)
+- Release builds strip all `Log.*` calls via ProGuard — but still avoid logging sensitive data in source
+- See [SECURITY.md](SECURITY.md) for the vulnerability reporting process
+
+## Questions?
+
+Open an issue or start a discussion on the repository.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,8 +17,8 @@ Thank you for your interest in contributing to Pocket Node! This document covers
 
 1. Clone the repository:
    ```bash
-   git clone https://github.com/RaheemJnr/Light-Client-Gateway.git
-   cd Light-Client-Gateway
+   git clone https://github.com/RaheemJnr/pocket-node.git
+   cd pocket-node
    ```
 
 2. Open the `android/` directory in Android Studio.

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 CKB Wallet Gateway Contributors
+Copyright (c) 2025 Pocket Node Contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A sovereign Android wallet for [Nervos CKB](https://www.nervos.org/) that runs an embedded light client directly on your device via JNI. No remote servers, no third-party dependencies for blockchain access — your keys, your node, your wallet.
 
-![CI](https://github.com/RaheemJnr/Light-Client-Gateway/actions/workflows/android-ci.yml/badge.svg)
+![CI](https://github.com/RaheemJnr/pocket-node/actions/workflows/android-ci.yml/badge.svg)
 ![Platform](https://img.shields.io/badge/platform-Android-green)
 ![Kotlin](https://img.shields.io/badge/kotlin-2.1-blue)
 ![Min SDK](https://img.shields.io/badge/minSdk-26-brightgreen)
@@ -46,7 +46,7 @@ Data flows unidirectionally: UI observes StateFlow from ViewModels. ViewModels c
 ## Project Structure
 
 ```
-Light-Client-Gateway/
+pocket-node/
 ├── android/                         # Android project root
 │   ├── app/
 │   │   ├── build.gradle.kts         # Build config, dependencies, signing

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Data flows unidirectionally: UI observes StateFlow from ViewModels. ViewModels c
 ## Project Structure
 
 ```
-ckb-wallet-gateway/
+Light-Client-Gateway/
 ├── android/                         # Android project root
 │   ├── app/
 │   │   ├── build.gradle.kts         # Build config, dependencies, signing

--- a/README.md
+++ b/README.md
@@ -1,311 +1,197 @@
-# CKB Wallet Gateway
+# Pocket Node
 
-A complete mobile wallet solution for [Nervos CKB](https://www.nervos.org/) blockchain, featuring an Android app with Jetpack Compose and a Rust backend gateway that interfaces with the CKB light client.
+A sovereign Android wallet for [Nervos CKB](https://www.nervos.org/) that runs an embedded light client directly on your device via JNI. No remote servers, no third-party dependencies for blockchain access — your keys, your node, your wallet.
 
+![CI](https://github.com/RaheemJnr/Light-Client-Gateway/actions/workflows/android-ci.yml/badge.svg)
 ![Platform](https://img.shields.io/badge/platform-Android-green)
-![Kotlin](https://img.shields.io/badge/kotlin-1.9+-blue)
-![Rust](https://img.shields.io/badge/rust-1.70+-orange)
+![Kotlin](https://img.shields.io/badge/kotlin-2.1-blue)
+![Min SDK](https://img.shields.io/badge/minSdk-26-brightgreen)
 ![License](https://img.shields.io/badge/license-MIT-lightgrey)
 
 ## Features
 
-- **Wallet Management**: Secure key generation and encrypted storage
-- **Balance Tracking**: Real-time balance updates with sync progress
-- **Send Transactions**: Full transaction lifecycle with status tracking
-- **Transaction History**: Detailed transaction views with confirmations
-- **QR Code Scanner**: Scan CKB addresses for easy transfers
-- **Flexible Sync Modes**: Choose how much blockchain history to sync
-- **Testnet Support**: Currently supports CKB testnet (Pudge)
+- **Embedded Light Client** — Rust CKB light client runs natively on-device via JNI
+- **BIP39 Mnemonic** — 12-word seed phrase generation, backup verification, and import/recovery
+- **Biometric Auth** — Fingerprint/face unlock with 6-digit PIN fallback and lockout protection
+- **Hardware-Backed Encryption** — Private keys and mnemonic encrypted with TEE/StrongBox AES-256-GCM
+- **Mainnet Ready** — Address network validation, transaction size checks, retry logic
+- **Send & Receive CKB** — Full transaction lifecycle with real-time status polling
+- **QR Code Scanner** — CameraX + ML Kit barcode scanning for addresses
+- **Flexible Sync Modes** — New wallet, recent (30 days), full history, or custom block height
+- **Transaction History** — Detailed views with confirmation tracking
 
 ## Architecture
 
 ```
 ┌─────────────────────────────────────────────────────────────┐
 │                    Android App (Kotlin)                      │
-│                    Jetpack Compose + Hilt                    │
+│              Jetpack Compose + Hilt + MVVM                  │
 └──────────────────────────┬──────────────────────────────────┘
-                           │ HTTP/REST
+                           │ JNI (in-process)
                            ▼
 ┌─────────────────────────────────────────────────────────────┐
-│                 Rust Gateway Server (Axum)                   │
-│                    REST API Wrapper                          │
+│              Rust CKB Light Client (libckb)                  │
+│            Embedded native library (.so)                     │
 └──────────────────────────┬──────────────────────────────────┘
-                           │ JSON-RPC
+                           │ P2P Network
                            ▼
 ┌─────────────────────────────────────────────────────────────┐
-│                    CKB Light Client                          │
-│                  (Nervos Network Testnet)                    │
+│                  CKB Mainnet Network                         │
+│                   (15 bootnodes)                             │
 └─────────────────────────────────────────────────────────────┘
 ```
+
+Data flows unidirectionally: UI observes StateFlow from ViewModels. ViewModels call Repository suspend functions. Repository delegates to the JNI bridge or local crypto classes. The light client syncs directly with CKB mainnet peers — no intermediary server.
 
 ## Project Structure
 
 ```
 ckb-wallet-gateway/
-├── android/                    # Android app
-│   └── app/
-│       └── src/main/java/com/example/ckbwallet/
-│           ├── data/
-│           │   ├── crypto/     # Blake2b hashing
-│           │   ├── gateway/    # API client & repository
-│           │   ├── transaction/# Transaction builder
-│           │   └── wallet/     # Key management
-│           ├── di/             # Hilt dependency injection
-│           └── ui/
-│               └── screens/    # Compose UI screens
-├── server/                     # Rust gateway server
-│   └── src/
-│       ├── main.rs             # Entry point
-│       ├── routes.rs           # API endpoints
-│       ├── light_client.rs     # CKB light client wrapper
-│       └── models.rs           # Data models
-├── deployment/                 # Docker & VPS deployment files
-├── docs/                       # Documentation
-├── scripts/                    # Utility scripts
-└── WEEKLY_PROGRESS_LOGS.md     # Development progress
+├── android/                         # Android project root
+│   ├── app/
+│   │   ├── build.gradle.kts         # Build config, dependencies, signing
+│   │   ├── proguard-rules.pro       # R8 rules (log stripping, JNI keeps)
+│   │   └── src/main/
+│   │       ├── AndroidManifest.xml
+│   │       ├── assets/mainnet.toml   # Light client config (bootnodes, RPC)
+│   │       └── java/com/rjnr/pocketnode/
+│   │           ├── data/
+│   │           │   ├── auth/          # AuthManager, PinManager
+│   │           │   ├── crypto/        # Blake2b wrapper
+│   │           │   ├── gateway/       # GatewayRepository (central hub)
+│   │           │   ├── transaction/   # TransactionBuilder
+│   │           │   ├── validation/    # NetworkValidator
+│   │           │   └── wallet/        # KeyManager, MnemonicManager, AddressUtils
+│   │           ├── di/                # Hilt dependency injection
+│   │           └── ui/screens/        # Compose screens (Home, Send, Receive, etc.)
+│   └── gradle/libs.versions.toml     # Version catalog
+├── external/
+│   └── ckb-light-client/             # Rust CKB light client (JNI library)
+└── docs/                             # Specs and implementation docs
 ```
 
 ## Prerequisites
 
-### For the Gateway Server
-- Rust 1.70 or higher
-- [CKB Light Client](https://github.com/nervosnetwork/ckb-light-client) running
+- **Android Studio** (latest stable)
+- **JDK 17**
+- **Android SDK** (min 26, target 35, compile 36)
+- **Rust toolchain** with Android cross-compilation targets:
+  ```bash
+  rustup target add aarch64-linux-android armv7-linux-androideabi x86_64-linux-android i686-linux-android
+  ```
+- **Android NDK** (auto-detected or at `~/Library/Android/sdk/ndk/`)
 
-### For the Android App
-- Android Studio Hedgehog (2023.1.1) or later
-- JDK 17
-- Android SDK 26+ (target SDK 35)
-- Physical device or emulator with camera (for QR scanning)
-
-## Quick Start
-
-### 1. Start the CKB Light Client
-
-```bash
-# Clone and build the light client
-git clone https://github.com/nervosnetwork/ckb-light-client.git
-cd ckb-light-client
-cargo build --release -p light-client-bin
-
-# Run with testnet configuration
-./target/release/ckb-light-client run --config-file config/testnet.toml
-```
-
-The light client will start syncing with the CKB testnet. This may take some time for the initial sync.
-
-### 2. Start the Gateway Server
-
-```bash
-cd server
-
-# Create environment file (optional)
-echo "LIGHT_CLIENT_URL=http://127.0.0.1:9000" > .env
-echo "SERVER_PORT=8080" >> .env
-
-# Run the server
-cargo run
-```
-
-The gateway server will start at `http://localhost:8080`.
-
-### 3. Run the Android App
+## Build & Run
 
 ```bash
 cd android
 
-# Build and run (ensure emulator is running or device is connected)
+# Debug build (skips JNI library compilation if already built)
+./gradlew assembleDebug
+
+# Release build (R8 minification + resource shrinking)
+./gradlew assembleRelease
+
+# Install on connected device
 ./gradlew installDebug
 ```
 
-**Note for Emulators**: The app is configured to connect to `http://10.0.2.2:8080` which routes to your host machine's localhost(recommended).
-
-**Note for Physical Devices**: Update the gateway URL in `app/build.gradle.kts`:
-```kotlin
-buildConfigField("String", "GATEWAY_URL", "\"http://YOUR_LOCAL_IP:8080\"")
-```
-
-## API Endpoints
-
-| Method | Endpoint | Description |
-|--------|----------|-------------|
-| `GET` | `/v1/status` | Gateway health check |
-| `POST` | `/v1/accounts/register` | Register address for tracking |
-| `GET` | `/v1/accounts/:address/status` | Account sync status |
-| `GET` | `/v1/accounts/:address/balance` | Get account balance |
-| `GET` | `/v1/accounts/:address/cells` | Get spendable cells (UTXOs) |
-| `GET` | `/v1/accounts/:address/transactions` | Transaction history |
-| `POST` | `/v1/transactions/send` | Broadcast signed transaction |
-| `GET` | `/v1/transactions/:tx_hash/status` | Transaction status & confirmations |
-
-### Example: Register an Account
+The Gradle `preBuild` task automatically triggers the Cargo build for the Rust JNI library. To skip it during Kotlin-only development:
 
 ```bash
-# Register with default sync (last 30 days)
-curl -X POST http://localhost:8080/v1/accounts/register \
-  -H "Content-Type: application/json" \
-  -d '{"address": "ckt1qzda0cr08m85hc8jlnfp3zer7xulejywt49kt2rr0vthywaa50xwsq..."}'
-
-# Register with full history sync
-curl -X POST http://localhost:8080/v1/accounts/register \
-  -H "Content-Type: application/json" \
-  -d '{"address": "ckt1q...", "from_block": "genesis"}'
+./gradlew assembleDebug -x cargoBuild
 ```
 
 ## Sync Modes
 
-The wallet supports flexible sync options for different use cases:
-
 | Mode | Description | Use Case |
 |------|-------------|----------|
 | **New Wallet** | Sync from current tip only | Fresh wallets with no history |
-| **Recent** (default) | Last ~30 days | Most users |
+| **Recent** (default) | Last ~30 days (~200K blocks) | Most users |
 | **Full History** | From genesis block | Complete transaction history |
 | **Custom** | Specific block height | Advanced users |
 
-## Testing with Testnet CKB
+## Security Model
 
-1. Generate a wallet in the app (automatic on first launch)
-2. Copy your testnet address from the Receive screen
-3. Get testnet CKB from the [Nervos Faucet](https://faucet.nervos.org/)
-4. Wait for sync to complete and see your balance update
+| Layer | Protection |
+|-------|-----------|
+| Key Storage | AES-256-GCM via Android Keystore (TEE/StrongBox-backed) |
+| Mnemonic | Encrypted in EncryptedSharedPreferences, never logged |
+| App Access | Biometric (BIOMETRIC_STRONG) + 6-digit PIN with lockout |
+| Backup | `allowBackup=false` — prevents ADB key extraction |
+| Release Builds | All `Log.*` calls stripped by ProGuard |
+| Transaction Signing | Performed locally — private keys never leave the device |
+| Network Validation | Addresses validated against expected network before sending |
 
 ## Tech Stack
 
-### Android App
-- **Language**: Kotlin 1.9+
-- **UI**: Jetpack Compose + Material 3
-- **Architecture**: MVVM with Repository pattern
-- **DI**: Hilt
-- **Networking**: Ktor Client
-- **Crypto**: CKB SDK Java, secp256k1-kmp, BouncyCastle
-- **Camera**: CameraX + ML Kit (barcode scanning)
-- **Storage**: EncryptedSharedPreferences, Room
+| Layer | Technology |
+|-------|-----------|
+| Language | Kotlin 2.1.0 |
+| UI | Jetpack Compose + Material 3 |
+| DI | Hilt 2.57.2 |
+| State | StateFlow + MutableStateFlow |
+| Serialization | kotlinx.serialization 1.8.0 |
+| Blockchain | JNI bridge to Rust CKB light client |
+| Storage | EncryptedSharedPreferences, Room 2.8.4 |
+| Crypto | CKB SDK Java 4.0.0, BouncyCastle 1.70, secp256k1-kmp 0.21.0 |
+| Auth | AndroidX Biometric 1.1.0, Blake2b PIN hashing |
+| Camera | CameraX 1.4.2 + ML Kit Barcode 17.3.0 |
+| Build | AGP 8.13.2, Gradle Kotlin DSL |
 
-### Gateway Server
-- **Language**: Rust 2021 Edition
-- **Framework**: Axum 0.7
-- **Async Runtime**: Tokio
-- **HTTP Client**: Reqwest
-- **Serialization**: Serde
+## CKB-Specific Notes
 
-## Development
-
-### Building the Server
-
-```bash
-cd server
-cargo build --release
-```
-
-### Building the Android App
-
-```bash
-cd android
-./gradlew assembleDebug      # Debug build
-./gradlew assembleRelease    # Release build (requires signing)
-```
-
-### Running Tests
-
-```bash
-# Server tests
-cd server && cargo test
-
-# Android tests (coming soon)
-cd android && ./gradlew test
-```
-
-## Configuration
-
-### Server Environment Variables
-
-| Variable | Default | Description |
-|----------|---------|-------------|
-| `LIGHT_CLIENT_URL` | `http://127.0.0.1:9000` | CKB light client RPC URL |
-| `SERVER_PORT` | `8080` | Gateway server port |
-| `RUST_LOG` | `info` | Log level (debug, info, warn, error) |
-
-### Android Build Config
-
-Located in `android/app/build.gradle.kts`:
-
-```kotlin
-// Gateway URL for debug builds (10.0.2.2 = host localhost from emulator)
-buildConfigField("String", "GATEWAY_URL", "\"http://10.0.2.2:8080\"")
-```
-
-## Deployment
-
-For production deployment to a VPS, see the [Deployment Guide](deployment/README.md).
-
-### Quick Deploy to VPS
-
-```bash
-# SSH into your VPS (Ubuntu 22.04 / Debian 12)
-ssh root@YOUR_SERVER_IP
-
-# Run the automated setup script
-curl -sSL https://raw.githubusercontent.com/RaheemJnr/Light-Client-Gateway/main/deployment/setup-vps.sh -o setup-vps.sh
-chmod +x setup-vps.sh
-sudo ./setup-vps.sh
-
-# With SSL certificate for a domain
-sudo ./setup-vps.sh --domain api.yourdomain.com
-```
-
-### Using Docker Compose
-
-```bash
-cd deployment
-docker compose up -d
-```
-
-See [deployment/README.md](deployment/README.md) for detailed instructions.
+- CKB uses a **Cell (UTXO-like) model**, not an account model
+- Minimum cell capacity: **61 CKB** (6,100,000,000 shannons)
+- 1 CKB = 100,000,000 shannons (8 decimal places)
+- Lock script: secp256k1-blake160 (`0x9bd7...cce8`)
+- BIP44 derivation path: `m/44'/309'/0'/0/0`
+- Default transaction fee: 100,000 shannons (0.001 CKB)
 
 ## Roadmap
 
-- [x] Core wallet functionality
-- [x] Transaction sending and receiving
-- [x] Transaction status polling
+- [x] Core wallet functionality (send, receive, balance)
+- [x] Transaction history with confirmations
 - [x] QR code scanning
 - [x] Flexible sync modes
-- [x] Transaction history with details
-- [ ] Mainnet support
-- [ ] Unit tests
-- [ ] BIP39 mnemonic backup/recovery
-- [ ] Biometric authentication
+- [x] BIP39 mnemonic backup/recovery
+- [x] Biometric + PIN authentication
+- [x] Mainnet production hardening
+- [x] CI/CD pipeline
+- [ ] Testnet support with network switching
+- [ ] Nervos DAO integration (deposit, withdraw)
 - [ ] Multiple wallet support
+- [ ] Google Play Store release
+
+## DAO Grant
+
+This project is funded by a [CKB Community DAO grant](https://talk.nervos.org/t/dis-mobile-ready-ckb-light-client-pocket-node-for-android/9879) ($15,000 over 4 months):
+
+| Milestone | Scope | Status |
+|-----------|-------|--------|
+| M1 | Mainnet ready, BIP39, biometrics, PIN, CI/CD | In Progress |
+| M2 | Nervos DAO integration | Planned |
+| M3 | Multi-wallet, sync optimization | Planned |
+| M4 | Address book, Play Store launch | Planned |
 
 ## Contributing
 
-Contributions are welcome! Please feel free to submit issues and pull requests.
-
-1. Fork the repository
-2. Create your feature branch (`git checkout -b feature/amazing-feature`)
-3. Commit your changes (`git commit -m 'Add amazing feature'`)
-4. Push to the branch (`git push origin feature/amazing-feature`)
-5. Open a Pull Request
+See [CONTRIBUTING.md](CONTRIBUTING.md) for development setup, code style, and PR guidelines.
 
 ## Security
 
-- Private keys are stored in Android's EncryptedSharedPreferences
-- Keys never leave the device
-- All transactions are signed locally before being sent to the gateway
-- The gateway server only broadcasts pre-signed transactions
-
-**⚠️ Warning**: This is development software. Use at your own risk and only on testnet until fully audited for mainnet use.
+See [SECURITY.md](SECURITY.md) for the security model and vulnerability reporting process.
 
 ## License
 
-This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.
+This project is licensed under the MIT License — see [LICENSE](LICENSE) for details.
 
 ## Resources
 
 - [Nervos CKB Documentation](https://docs.nervos.org/)
 - [CKB Light Client](https://github.com/nervosnetwork/ckb-light-client)
 - [CKB SDK Java](https://github.com/nervosnetwork/ckb-sdk-java)
-- [Nervos Testnet Faucet](https://faucet.nervos.org/)
-- [CKB Explorer (Testnet)](https://pudge.explorer.nervos.org/)
+- [CKB Explorer (Mainnet)](https://explorer.nervos.org/)
 
 ## Acknowledgments
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,82 @@
+# Security Policy
+
+## Reporting Vulnerabilities
+
+If you discover a security vulnerability in Pocket Node, please report it responsibly:
+
+1. **Do NOT open a public issue.** Security vulnerabilities should be reported privately.
+2. Use [GitHub Security Advisories](https://github.com/RaheemJnr/Light-Client-Gateway/security/advisories/new) to report the vulnerability.
+3. Include:
+   - Description of the vulnerability
+   - Steps to reproduce
+   - Potential impact
+   - Suggested fix (if any)
+
+We will acknowledge receipt within 48 hours and provide a timeline for resolution.
+
+## Security Model
+
+### Key Storage
+
+Private keys and BIP39 mnemonics are encrypted using Android's `EncryptedSharedPreferences` backed by the Android Keystore system:
+
+- **Encryption**: AES-256-GCM
+- **Key backing**: StrongBox HSM (Pixel 3+, Galaxy S9+) or TEE (all Android 8.0+ devices)
+- **Key generation**: `MasterKey` with `setRequestStrongBoxBacked(true)`, automatic TEE fallback
+
+### Authentication
+
+- **Biometric**: `BiometricPrompt` with `BIOMETRIC_STRONG` authenticators
+- **PIN fallback**: 6-digit PIN, hashed with Blake2b + per-device salt
+- **Lockout**: 5 failed attempts triggers 30-second lockout
+
+### Transaction Security
+
+- All transaction signing is performed locally on-device
+- Private keys never leave the device or are transmitted over the network
+- Address network validation prevents cross-network sends (mainnet vs testnet)
+- Transaction size checked against CKB protocol limits before broadcast
+
+### Build Security
+
+- `android:allowBackup="false"` prevents ADB backup of key material
+- Release builds strip all `android.util.Log` calls via ProGuard (`-assumenosideeffects`)
+- R8 code shrinking and resource shrinking enabled for release builds
+- Release signing uses environment-variable-based keystore configuration
+
+### Light Client
+
+- The embedded CKB light client communicates directly with CKB mainnet peers via P2P
+- RPC binds to `127.0.0.1:9000` (localhost only, not exposed externally)
+- No intermediary servers — the app is fully self-sovereign
+
+## Known Limitations
+
+- This software has **not undergone a formal security audit**
+- Single wallet support only (no wallet isolation between accounts)
+- No certificate pinning for any network connections
+- Light client P2P traffic is not encrypted beyond CKB protocol-level protections
+
+## Supported Versions
+
+| Version | Supported |
+|---------|-----------|
+| 1.1.x   | Yes       |
+| < 1.1.0 | No        |
+
+## Scope
+
+The following are in scope for security reports:
+
+- Private key or mnemonic exposure
+- Authentication bypass
+- Transaction manipulation
+- Data leakage through logs, backups, or unencrypted storage
+- JNI bridge vulnerabilities
+
+The following are **out of scope**:
+
+- CKB protocol-level vulnerabilities (report to [Nervos](https://github.com/nervosnetwork))
+- Social engineering attacks
+- Physical device access with a rooted/jailbroken device
+- Denial of service against the light client P2P network

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -5,7 +5,7 @@
 If you discover a security vulnerability in Pocket Node, please report it responsibly:
 
 1. **Do NOT open a public issue.** Security vulnerabilities should be reported privately.
-2. Use [GitHub Security Advisories](https://github.com/RaheemJnr/Light-Client-Gateway/security/advisories/new) to report the vulnerability.
+2. Use [GitHub Security Advisories](https://github.com/RaheemJnr/pocket-node/security/advisories/new) to report the vulnerability.
 3. Include:
    - Description of the vulnerability
    - Steps to reproduce


### PR DESCRIPTION
## Summary

- Add `release.yml` workflow — tag-triggered (`v*`), builds signed release APK, creates GitHub Release with APK attachment
- Rewrite `README.md` for current JNI-based architecture (removes all legacy Axum server references)
- Create `CONTRIBUTING.md` with dev setup, code style, branch naming, and PR guidelines
- Create `SECURITY.md` with security model overview and vulnerability disclosure process
- Add GitHub issue templates (bug report + feature request) and PR template
- CI cleanup: remove debug APK upload (~134MB/build savings), test results only on failure (7-day retention)

Closes #7
Closes #8

## Release workflow secrets needed

Before tagging a release, configure these repository secrets:
- `KEYSTORE_BASE64` — base64-encoded `.jks` file
- `KEYSTORE_PASSWORD`
- `KEY_ALIAS`
- `KEY_PASSWORD`

## Test plan

- [ ] CI workflow runs on this PR (build + tests pass)
- [ ] Review rendered README on GitHub
- [ ] Verify issue templates load when creating new issue
- [ ] Verify SECURITY.md shows in GitHub Security tab
- [ ] (Post-merge) Tag `v1.1.0` to test release workflow

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Rebranded README with on-device light client, updated build/run flow, security model, and roadmap
  * Added SECURITY.md for vulnerability reporting and security practices
  * Added CONTRIBUTING.md with contributor guidelines
  * Minor docs updates and license copyright text updated

* **Chores**
  * Added issue and pull-request templates
  * Updated CI workflow behavior and added a release workflow to build and publish APKs on tag releases
<!-- end of auto-generated comment: release notes by coderabbit.ai -->