### PR TITLE
feat: show sync mode selector after wallet import

### DIFF
--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/components/SyncOptionsDialog.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/components/SyncOptionsDialog.kt
@@ -49,7 +49,10 @@ internal val SyncDialogColorSecondary = Color(0xFFA0A0A0)
 internal fun SyncOptionsDialog(
     currentMode: SyncMode,
     onDismiss: () -> Unit,
-    onSelectMode: (SyncMode, Long?) -> Unit
+    onSelectMode: (SyncMode, Long?) -> Unit,
+    title: String = "Sync Options",
+    description: String = "Choose how much transaction history to sync:",
+    availableModes: List<SyncMode> = SyncMode.entries.toList()
 ) {
     var selectedMode by remember { mutableStateOf(currentMode) }
     var customBlockHeight by remember { mutableStateOf("") }
@@ -57,45 +60,53 @@ internal fun SyncOptionsDialog(
 
     AlertDialog(
         onDismissRequest = onDismiss,
-        title = { Text("Sync Options", fontWeight = FontWeight.Bold) },
+        title = { Text(title, fontWeight = FontWeight.Bold) },
         text = {
             Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
                 Text(
-                    text = "Choose how much transaction history to sync:",
+                    text = description,
                     style = MaterialTheme.typography.bodyMedium,
                     color = MaterialTheme.colorScheme.onSurfaceVariant
                 )
 
                 Spacer(Modifier.height(4.dp))
 
-                SyncOptionItem(
-                    title = "New Wallet",
-                    description = "No history \u2014 fastest startup",
-                    icon = Icons.Default.FiberNew,
-                    isSelected = selectedMode == SyncMode.NEW_WALLET,
-                    onClick = { selectedMode = SyncMode.NEW_WALLET; showCustomInput = false }
-                )
-                SyncOptionItem(
-                    title = "Recent (~30 days)",
-                    description = "Last ~200k blocks \u2014 recommended",
-                    icon = Icons.Default.Schedule,
-                    isSelected = selectedMode == SyncMode.RECENT,
-                    onClick = { selectedMode = SyncMode.RECENT; showCustomInput = false }
-                )
-                SyncOptionItem(
-                    title = "Full History",
-                    description = "From genesis \u2014 complete but slow",
-                    icon = Icons.Default.History,
-                    isSelected = selectedMode == SyncMode.FULL_HISTORY,
-                    onClick = { selectedMode = SyncMode.FULL_HISTORY; showCustomInput = false }
-                )
-                SyncOptionItem(
-                    title = "Custom Block Height",
-                    description = "Start from a specific block",
-                    icon = Icons.Default.Tune,
-                    isSelected = selectedMode == SyncMode.CUSTOM,
-                    onClick = { selectedMode = SyncMode.CUSTOM; showCustomInput = true }
-                )
+                if (SyncMode.NEW_WALLET in availableModes) {
+                    SyncOptionItem(
+                        title = "New Wallet",
+                        description = "No history \u2014 fastest startup",
+                        icon = Icons.Default.FiberNew,
+                        isSelected = selectedMode == SyncMode.NEW_WALLET,
+                        onClick = { selectedMode = SyncMode.NEW_WALLET; showCustomInput = false }
+                    )
+                }
+                if (SyncMode.RECENT in availableModes) {
+                    SyncOptionItem(
+                        title = "Recent (~30 days)",
+                        description = "Last ~200k blocks \u2014 recommended",
+                        icon = Icons.Default.Schedule,
+                        isSelected = selectedMode == SyncMode.RECENT,
+                        onClick = { selectedMode = SyncMode.RECENT; showCustomInput = false }
+                    )
+                }
+                if (SyncMode.FULL_HISTORY in availableModes) {
+                    SyncOptionItem(
+                        title = "Full History",
+                        description = "From genesis \u2014 complete but slow",
+                        icon = Icons.Default.History,
+                        isSelected = selectedMode == SyncMode.FULL_HISTORY,
+                        onClick = { selectedMode = SyncMode.FULL_HISTORY; showCustomInput = false }
+                    )
+                }
+                if (SyncMode.CUSTOM in availableModes) {
+                    SyncOptionItem(
+                        title = "Custom Block Height",
+                        description = "Start from a specific block",
+                        icon = Icons.Default.Tune,
+                        isSelected = selectedMode == SyncMode.CUSTOM,
+                        onClick = { selectedMode = SyncMode.CUSTOM; showCustomInput = true }
+                    )
+                }
 
                 if (showCustomInput) {
                     Spacer(Modifier.height(4.dp))
@@ -139,7 +150,7 @@ internal fun SyncOptionsDialog(
                     )
                 }
 
-                if (selectedMode == SyncMode.FULL_HISTORY) {
+                if (selectedMode == SyncMode.FULL_HISTORY && SyncMode.FULL_HISTORY in availableModes) {
                     Spacer(Modifier.height(4.dp))
                     Card(
                         colors = CardDefaults.cardColors(

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/home/HomeScreen.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/home/HomeScreen.kt
@@ -117,6 +117,23 @@ fun HomeScreen(
         )
     }
 
+    // Post-import sync mode dialog (mainnet only)
+    if (uiState.showPostImportSyncDialog) {
+        SyncOptionsDialog(
+            currentMode = SyncMode.RECENT,
+            title = "Choose Sync Start Point",
+            description = "Select how far back to sync your imported wallet's history. If your wallet is older than 30 days, choose Custom.",
+            availableModes = listOf(SyncMode.RECENT, SyncMode.CUSTOM),
+            onDismiss = { viewModel.hidePostImportSyncDialog() },
+            onSelectMode = { mode, customBlock ->
+                viewModel.hidePostImportSyncDialog()
+                if (mode != SyncMode.RECENT) {
+                    viewModel.changeSyncMode(mode, customBlock)
+                }
+            }
+        )
+    }
+
     // Network switch confirmation dialog
     val pendingSwitch = uiState.pendingNetworkSwitch
     if (uiState.showNetworkSwitchDialog && pendingSwitch != null) {
@@ -271,19 +288,6 @@ fun HomeScreen(
                             BackupReminderBanner(
                                 onDismiss = { viewModel.dismissBackupReminder() },
                                 onBackup = onNavigateToBackup
-                            )
-                        }
-                    }
-
-                    // Sync Mode Reminder for Imported Wallets
-                    if (uiState.showImportSyncReminder) {
-                        item {
-                            SyncModeReminderBanner(
-                                onDismiss = { viewModel.dismissSyncReminder() },
-                                onSettingsClick = {
-                                    viewModel.dismissSyncReminder()
-                                    viewModel.showSyncOptions()
-                                }
                             )
                         }
                     }
@@ -460,62 +464,6 @@ private fun ImportWalletDialog(
             }
         }
     )
-}
-
-@Composable
-private fun SyncModeReminderBanner(
-    onDismiss: () -> Unit,
-    onSettingsClick: () -> Unit
-) {
-    Card(
-        modifier = Modifier.fillMaxWidth(),
-        colors = CardDefaults.cardColors(
-            containerColor = MaterialTheme.colorScheme.secondaryContainer
-        ),
-        shape = RoundedCornerShape(12.dp)
-    ) {
-        Column(modifier = Modifier.padding(16.dp)) {
-            Row(verticalAlignment = Alignment.CenterVertically) {
-                Icon(
-                    imageVector = Icons.Default.History,
-                    contentDescription = null,
-                    tint = MaterialTheme.colorScheme.onSecondaryContainer
-                )
-                Spacer(modifier = Modifier.width(12.dp))
-                Text(
-                    text = "Sync Settings",
-                    style = MaterialTheme.typography.titleSmall,
-                    color = MaterialTheme.colorScheme.onSecondaryContainer,
-                    fontWeight = FontWeight.Bold
-                )
-                Spacer(modifier = Modifier.weight(1f))
-                IconButton(onClick = onDismiss, modifier = Modifier.size(24.dp)) {
-                    Icon(
-                        imageVector = Icons.Default.Close,
-                        contentDescription = "Dismiss",
-                        tint = MaterialTheme.colorScheme.onSecondaryContainer.copy(alpha = 0.6f)
-                    )
-                }
-            }
-            Spacer(modifier = Modifier.height(8.dp))
-            Text(
-                text = "Since you imported a wallet, you might want to set a custom sync start height to see your historical transactions faster.",
-                style = MaterialTheme.typography.bodyMedium,
-                color = MaterialTheme.colorScheme.onSecondaryContainer
-            )
-            Spacer(modifier = Modifier.height(12.dp))
-            Button(
-                onClick = onSettingsClick,
-                colors = ButtonDefaults.buttonColors(
-                    containerColor = MaterialTheme.colorScheme.secondary,
-                    contentColor = MaterialTheme.colorScheme.onSecondary
-                ),
-                modifier = Modifier.align(Alignment.End)
-            ) {
-                Text("Configure Sync")
-            }
-        }
-    }
 }
 
 @Composable

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/home/HomeViewModel.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/home/HomeViewModel.kt
@@ -387,11 +387,8 @@ class HomeViewModel @Inject constructor(
         _uiState.update { it.copy(showImportDialog = false) }
     }
 
-    /**
-     * Dismiss the sync reminder
-     */
-    fun dismissSyncReminder() {
-        _uiState.update { it.copy(showImportSyncReminder = false) }
+    fun hidePostImportSyncDialog() {
+        _uiState.update { it.copy(showPostImportSyncDialog = false) }
     }
 
     /**
@@ -405,9 +402,9 @@ class HomeViewModel @Inject constructor(
                 .onSuccess { info ->
                     Log.d(TAG, "Wallet imported successfully: ${info.testnetAddress}")
                     _uiState.update { it.copy(
-                        walletInfo = info, 
+                        walletInfo = info,
                         isLoading = false,
-                        showImportSyncReminder = true // Show reminder for imported wallet
+                        showPostImportSyncDialog = repository.currentNetwork == NetworkType.MAINNET
                     ) }
                     registerAndRefresh()
                 }
@@ -503,7 +500,7 @@ data class HomeUiState(
     val showBackupDialog: Boolean = false,
     val privateKeyHex: String? = null,
     val showImportDialog: Boolean = false,
-    val showImportSyncReminder: Boolean = false,
+    val showPostImportSyncDialog: Boolean = false,
     val showBackupReminder: Boolean = false,
     val walletType: String = KeyManager.WALLET_TYPE_RAW_KEY,
     val currentNetwork: NetworkType = NetworkType.MAINNET,


### PR DESCRIPTION
## Summary
- After importing a wallet (mnemonic or private key) on **mainnet**, a dialog now lets the user choose between **Recent (~30 days)** and **Custom block height** sync modes
- Extracted `SyncOptionsDialog` into a shared component (`ui/components/SyncOptionsDialog.kt`) with configurable title, description, and available modes
- Replaced the old `SyncModeReminderBanner` (dismissible text banner) with an actual sync mode selector dialog

## Changes
- **NEW** `SyncOptionsDialog.kt` — shared component with `availableModes` filter, custom block height input, and validation
- **HomeScreen.kt** — uses shared dialog for both settings sync options and post-import sync dialog; removed inline `SyncOptionsDialog`, `SyncOptionItem`, and `SyncModeReminderBanner` (~250 lines removed)
- **HomeViewModel.kt** — renamed `showImportSyncReminder` → `showPostImportSyncDialog`, only shows on mainnet
- **MnemonicImportScreen.kt** — shows sync dialog on mainnet after mnemonic or private key import; selection persisted via `resyncAccount()`

## Test plan
- [ ] Import mnemonic on mainnet → sync dialog appears with Recent + Custom options
- [ ] Import private key on mainnet → same dialog appears
- [ ] Select Custom → enter block → applies and navigates to Home
- [ ] Dismiss dialog → defaults to Recent, navigates to Home
- [ ] Import on testnet → no dialog shown
- [ ] Create new wallet → no dialog shown
- [ ] In-app import (HomeScreen) on mainnet → post-import sync dialog
- [ ] Settings sync options still works with all 4 modes

Closes #23

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added post-import sync mode selection dialog for mainnet wallet imports, allowing users to choose between recent or custom transaction history synchronization.
  * Enhanced sync configuration with network-aware options and improved user control over sync preferences during wallet import workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->