### PR TITLE
chore: Google Play Store listing content

### DIFF
--- a/android/app/src/main/play/STORE_LISTING_CHECKLIST.md
+++ b/android/app/src/main/play/STORE_LISTING_CHECKLIST.md
@@ -1,0 +1,55 @@
+# Google Play Store Listing Checklist
+
+## Text Content (ready)
+
+- [x] App title: `title.txt`
+- [x] Short description (76 chars): `listings/en-US/short-description.txt`
+- [x] Full description: `listings/en-US/full-description.txt`
+
+## Graphics (TODO)
+
+- [ ] App icon — replace placeholder with final Pocket Node icon
+  - Adaptive icon: `mipmap-anydpi-v26/ic_launcher.xml`
+  - Foreground: 108x108dp (432x432px xxxhdpi)
+  - Background: solid color or image layer
+  - Also provide 512x512 PNG for Play Store
+
+- [ ] Phone screenshots — at least 2, recommended 8
+  - Min 320px, max 3840px on any side
+  - Capture in both **light** and **dark** mode
+  - Suggested screens:
+    1. Home (balance + actions)
+    2. Send CKB
+    3. Receive (QR code)
+    4. Transaction history (Activity tab)
+    5. Onboarding (create wallet)
+    6. Mnemonic backup (word grid)
+    7. Node status dashboard
+    8. Settings
+
+- [ ] Feature graphic: 1024x500 PNG or JPG
+  - Shown at top of Play Store listing
+  - Include app name, tagline, and key visual
+
+## Play Console Setup (TODO)
+
+- [ ] Privacy policy — host publicly and provide URL
+  - Must cover: data collected (none), key storage, permissions used
+  - Suggested host: GitHub Pages or project website
+
+- [ ] Content rating questionnaire
+  - App category: Finance
+  - No violence, no user-generated content
+  - Cryptocurrency wallet functionality
+
+- [ ] Target audience declaration
+  - Target age: 18+ (financial app)
+  - Not designed for children
+
+- [ ] App category: Finance
+- [ ] Contact email for store listing
+- [ ] Data safety section
+  - No data collected or shared
+  - Data encrypted in transit (P2P connections)
+  - Data encrypted at rest (TEE/StrongBox)
+  - Users can request data deletion (wipe wallet)

--- a/android/app/src/main/play/listings/en-US/full-description.txt
+++ b/android/app/src/main/play/listings/en-US/full-description.txt
@@ -1,0 +1,43 @@
+Pocket Node is the first mobile CKB wallet that runs a real light client directly on your phone. No remote servers, no middlemen — just you, your keys, and the Nervos blockchain.
+
+Unlike browser-extension wallets or custodial apps, Pocket Node embeds a Rust-based CKB light client via JNI. Every balance check, every transaction, every block header is verified locally on your device.
+
+KEY FEATURES
+
+Embedded Light Client
+Run a real CKB light node on your Android device. Verify transactions and balances without trusting any third-party server. Your phone connects directly to the Nervos peer-to-peer network.
+
+BIP39 Seed Phrase
+Generate a standard 12-word recovery phrase backed by BIP39/BIP44 key derivation (path m/44'/309'/0'/0/0). Your seed phrase is encrypted with Android's Trusted Execution Environment (TEE) or StrongBox hardware security module.
+
+Biometric & PIN Security
+Protect your wallet with fingerprint, face recognition, or a 6-digit PIN. Authentication is required every time you open the app or send a transaction.
+
+Send & Receive CKB
+Send CKB to any address with real-time fee estimation and burn warnings. Scan QR codes to fill addresses instantly. View your full transaction history with confirmations.
+
+Mainnet & Testnet
+Switch between CKB mainnet and Pudge testnet at any time. Perfect for developers and users who want to experiment before moving real funds.
+
+Node Status Dashboard
+Monitor your light client in real time — see tip block height, connected peers, sync progress, and live logs straight from the embedded node.
+
+PRIVACY & SECURITY
+
+- Keys never leave your device
+- Seed phrase encrypted with TEE/StrongBox (AES-256-GCM)
+- No analytics, no tracking, no remote servers
+- PIN hashed with Blake2b and per-device salt
+- Lockout protection after failed auth attempts
+- Open source: audit the code yourself
+
+TECHNICAL DETAILS
+
+- CKB Light Client: Embedded Rust library via JNI
+- Key Derivation: BIP39 + BIP44 (m/44'/309'/0'/0/0)
+- Lock Script: secp256k1-blake160
+- Sync Modes: New Wallet, Recent (~30 days), Full History, Custom Block
+- Storage: ~5 MB on mainnet
+- Min Android: 8.0 (API 26)
+
+Pocket Node is funded by a Nervos Community DAO grant and is fully open source on GitHub.

--- a/android/app/src/main/play/listings/en-US/short-description.txt
+++ b/android/app/src/main/play/listings/en-US/short-description.txt
@@ -1,0 +1,1 @@
+Self-custody CKB wallet with an embedded light client. Your keys, your node.

--- a/android/app/src/main/play/listings/en-US/title.txt
+++ b/android/app/src/main/play/listings/en-US/title.txt
@@ -1,0 +1,1 @@
+Pocket Node — CKB Light Wallet


### PR DESCRIPTION
## Summary
- Add Play Store text content: app title, short description (76 chars), and full description with feature list
- Add store listing checklist tracking remaining manual items (screenshots, feature graphic, privacy policy, Play Console setup)
- Text files follow Gradle Play Publisher directory convention (`app/src/main/play/listings/en-US/`)

## Remaining manual tasks (tracked in checklist)
- [ ] Replace app icon with final Pocket Node icon
- [ ] Take phone screenshots (light + dark mode)
- [ ] Create feature graphic (1024x500)
- [ ] Host privacy policy and provide URL
- [ ] Complete content rating questionnaire on Play Console
- [ ] Complete target audience declaration on Play Console

## Test plan
- [ ] Verify short description is under 80 chars
- [ ] Verify full description reads well and covers key features
- [ ] Review checklist for completeness

Closes #9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Google Play Store listing materials including app title, descriptions, and comprehensive feature details.
  * Added checklist for pending Play Store configuration and asset requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->