### PR TITLE
feat: copy private key option in backup screen

### DIFF
--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/home/Components.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/home/Components.kt
@@ -17,10 +17,9 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Visibility
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
@@ -42,6 +41,8 @@ import com.composables.icons.lucide.ArrowUpRight
 import com.composables.icons.lucide.CircleHelp
 import com.composables.icons.lucide.Copy
 import com.composables.icons.lucide.Download
+import com.composables.icons.lucide.Eye
+import com.composables.icons.lucide.EyeOff
 import com.composables.icons.lucide.Landmark
 import com.composables.icons.lucide.Lucide
 import com.composables.icons.lucide.Send
@@ -59,6 +60,8 @@ fun WalletBalanceCard(
     fiatBalance: String?,
     address: String,
     peerCount: Int,
+    isBalanceHidden: Boolean = false,
+    onToggleVisibility: () -> Unit = {},
     onCopyAddress: () -> Unit
 ) {
     Surface(
@@ -69,28 +72,35 @@ fun WalletBalanceCard(
         Column(modifier = Modifier.padding(20.dp)) {
             Row(
                 modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.SpaceBetween
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically
             ) {
                 Text(
                     "Wallet Balance",
                     style = MaterialTheme.typography.labelMedium,
                     color = MaterialTheme.colorScheme.onSurfaceVariant
                 )
-                Icon(
-                    Icons.Default.Visibility,
-                    contentDescription = null,
-                    tint = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.4f)
-                )
+                IconButton(
+                    onClick = onToggleVisibility,
+                    modifier = Modifier.size(24.dp)
+                ) {
+                    Icon(
+                        if (isBalanceHidden) Lucide.EyeOff else Lucide.Eye,
+                        contentDescription = if (isBalanceHidden) "Show balance" else "Hide balance",
+                        tint = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.4f),
+                        modifier = Modifier.size(20.dp)
+                    )
+                }
             }
             Spacer(modifier = Modifier.height(8.dp))
             Text(
-                text = String.format(Locale.US, "%,.2f CKB", balanceCkb),
+                text = if (isBalanceHidden) "••••••" else String.format(Locale.US, "%,.2f CKB", balanceCkb),
                 color = MaterialTheme.colorScheme.primary,
                 fontSize = 32.sp,
                 fontWeight = FontWeight.Bold
             )
             Text(
-                text = fiatBalance ?: "≈ — USD",
+                text = if (isBalanceHidden) "••••" else (fiatBalance ?: "≈ — USD"),
                 style = MaterialTheme.typography.bodyMedium,
                 color = MaterialTheme.colorScheme.onSurfaceVariant
             )

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/home/HomeScreen.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/home/HomeScreen.kt
@@ -293,6 +293,7 @@ fun HomeScreen(
                 onNavigateToSend = onNavigateToSend,
                 onNavigateToReceive = onNavigateToReceive,
                 dismissBackupReminder = { viewModel.dismissBackupReminder() },
+                onToggleBalanceVisibility = { viewModel.toggleBalanceVisibility() },
                 clipboardManager = clipboardManager,
                 snackbarHostState = snackbarHostState,
                 scope = scope,
@@ -311,6 +312,7 @@ fun HomeScreenUI(
     onNavigateToSend: () -> Unit,
     onNavigateToReceive: () -> Unit,
     dismissBackupReminder: () -> Unit,
+    onToggleBalanceVisibility: () -> Unit,
     clipboardManager: androidx.compose.ui.platform.ClipboardManager,
     snackbarHostState: SnackbarHostState,
     scope: CoroutineScope,
@@ -351,6 +353,8 @@ fun HomeScreenUI(
                     fiatBalance = uiState.fiatBalance,
                     address = uiState.address,
                     peerCount = uiState.peerCount,
+                    isBalanceHidden = uiState.isBalanceHidden,
+                    onToggleVisibility = onToggleBalanceVisibility,
                     onCopyAddress = {
                         clipboardManager.setText(AnnotatedString(uiState.address))
                         scope.launch {
@@ -984,6 +988,7 @@ private fun HomeScreenUIPreview() {
             onNavigateToSend = {},
             onNavigateToReceive = {},
             dismissBackupReminder = {},
+            onToggleBalanceVisibility = {},
             clipboardManager = androidx.compose.ui.platform.LocalClipboardManager.current,
             snackbarHostState = remember { SnackbarHostState() },
             scope = rememberCoroutineScope(),

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/home/HomeViewModel.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/home/HomeViewModel.kt
@@ -366,6 +366,10 @@ class HomeViewModel @Inject constructor(
         _uiState.update { it.copy(showBackupReminder = false) }
     }
 
+    fun toggleBalanceVisibility() {
+        _uiState.update { it.copy(isBalanceHidden = !it.isBalanceHidden) }
+    }
+
     fun isMnemonicWallet(): Boolean = _uiState.value.walletType == KeyManager.WALLET_TYPE_MNEMONIC
 
     /**
@@ -511,5 +515,6 @@ data class HomeUiState(
     val currentNetwork: NetworkType = NetworkType.MAINNET,
     val isSwitchingNetwork: Boolean = false,
     val showNetworkSwitchDialog: Boolean = false,
-    val pendingNetworkSwitch: NetworkType? = null
+    val pendingNetworkSwitch: NetworkType? = null,
+    val isBalanceHidden: Boolean = false
 )


### PR DESCRIPTION
## Summary
- Adds a "Copy Private Key" `OutlinedButton` (with key icon) to the mnemonic backup display step
- Private key is loaded from `KeyManager` via `GatewayRepository.getPrivateKey()` and converted to hex
- Button only appears when the private key is available; copies `0x`-prefixed hex to clipboard
- Shows snackbar confirmation after copy

## Test plan
- [ ] Create or restore a mnemonic wallet
- [ ] Navigate to Settings > Back Up Wallet
- [ ] Verify "Copy Private Key" button appears below the word grid
- [ ] Tap the button and verify snackbar says "Private key copied to clipboard"
- [ ] Paste elsewhere and verify the copied key starts with `0x` and is valid hex
- [ ] Import a raw_key wallet and verify the button still works (private key available)
- [ ] All 232 existing unit tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Copy private key to clipboard from the backup screen with a confirmation snackbar.
  * Toggle to hide/show wallet balance on the Home screen; numeric and fiat amounts are masked when hidden.
* **UI**
  * Balance visibility control added to the wallet card with accessible icons and preserved layout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->