### PR TITLE
fix: validate custom sync block height against tip (#81)

### DIFF
--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/components/SyncOptionsDialog.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/components/SyncOptionsDialog.kt
@@ -45,7 +45,8 @@ internal fun SyncOptionsDialog(
     title: String = "Sync Options",
     description: String = "Choose how much transaction history to sync:",
     availableModes: List<SyncMode> = SyncMode.entries.toList(),
-    savedCustomBlockHeight: Long? = null
+    savedCustomBlockHeight: Long? = null,
+    tipBlockNumber: Long = 0L
 ) {
     // If the parent hides currentMode from availableModes, fall back to the first
     // shown option so the dialog never opens with an invisible selection.
@@ -135,6 +136,8 @@ internal fun SyncOptionsDialog(
                     }
                     Spacer(Modifier.height(8.dp))
                     val parsedHeight = customBlockHeight.toLongOrNull()
+                    val exceedsTip = parsedHeight != null && tipBlockNumber > 0 && parsedHeight > tipBlockNumber
+                    val invalidNumber = customBlockHeight.isNotBlank() && parsedHeight == null
                     OutlinedTextField(
                         value = customBlockHeight,
                         onValueChange = { customBlockHeight = it.filter { c -> c.isDigit() } },
@@ -143,10 +146,14 @@ internal fun SyncOptionsDialog(
                         keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
                         modifier = Modifier.fillMaxWidth(),
                         singleLine = true,
-                        isError = customBlockHeight.isNotBlank() && parsedHeight == null,
-                        supportingText = if (customBlockHeight.isNotBlank() && parsedHeight == null) {
-                            { Text("Invalid block height") }
-                        } else null
+                        isError = invalidNumber || exceedsTip,
+                        supportingText = when {
+                            invalidNumber -> { { Text("Invalid block height") } }
+                            exceedsTip -> { {
+                                Text("Exceeds current tip ($tipBlockNumber). Enter a lower value.")
+                            } }
+                            else -> null
+                        }
                     )
                 }
 
@@ -180,12 +187,15 @@ internal fun SyncOptionsDialog(
         },
         confirmButton = {
             val confirmParsedHeight = customBlockHeight.toLongOrNull()
+            val withinTip = tipBlockNumber <= 0L || confirmParsedHeight == null ||
+                confirmParsedHeight <= tipBlockNumber
             Button(
                 onClick = {
                     val custom = if (selectedMode == SyncMode.CUSTOM) confirmParsedHeight else null
                     onSelectMode(selectedMode, custom)
                 },
-                enabled = selectedMode != SyncMode.CUSTOM || (confirmParsedHeight != null && confirmParsedHeight > 0)
+                enabled = selectedMode != SyncMode.CUSTOM ||
+                    (confirmParsedHeight != null && confirmParsedHeight > 0 && withinTip)
             ) {
                 Text("Apply")
             }

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/home/HomeScreen.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/home/HomeScreen.kt
@@ -128,6 +128,8 @@ fun HomeScreen(
         onDispose { lifecycleOwner.lifecycle.removeObserver(observer) }
     }
 
+    val tipBlockNumberLong = uiState.tipBlockNumber.toLongOrNull() ?: 0L
+
     // Sync options dialog (settings path)
     if (uiState.showSyncOptionsDialog) {
         SyncOptionsDialog(
@@ -137,7 +139,8 @@ fun HomeScreen(
                 viewModel.hideSyncOptions()
                 viewModel.changeSyncMode(mode, customBlock)
             },
-            savedCustomBlockHeight = uiState.savedCustomBlockHeight
+            savedCustomBlockHeight = uiState.savedCustomBlockHeight,
+            tipBlockNumber = tipBlockNumberLong
         )
     }
 
@@ -154,7 +157,8 @@ fun HomeScreen(
                 if (mode != SyncMode.RECENT) {
                     viewModel.changeSyncMode(mode, customBlock)
                 }
-            }
+            },
+            tipBlockNumber = tipBlockNumberLong
         )
     }
 

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/onboarding/MnemonicImportScreen.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/onboarding/MnemonicImportScreen.kt
@@ -41,6 +41,7 @@ data class MnemonicImportUiState(
     val importSuccess: Boolean = false,
     val showPrivateKeyDialog: Boolean = false,
     val showSyncModeDialog: Boolean = false,
+    val tipBlockNumber: Long = 0L,
     val error: String? = null
 )
 
@@ -55,6 +56,14 @@ class MnemonicImportViewModel @Inject constructor(
 
     private val _uiState = MutableStateFlow(MnemonicImportUiState())
     val uiState: StateFlow<MnemonicImportUiState> = _uiState.asStateFlow()
+
+    init {
+        viewModelScope.launch {
+            repository.syncProgress.collect { progress ->
+                _uiState.update { it.copy(tipBlockNumber = progress.tipBlockNumber) }
+            }
+        }
+    }
 
     fun updateWord(index: Int, text: String) {
         val trimmed = text.trim().lowercase()
@@ -229,7 +238,8 @@ fun MnemonicImportScreen(
             description = "Select how far back to sync your wallet history. If your wallet is older than 30 days, choose Custom to enter a specific block height.",
             availableModes = listOf(SyncMode.RECENT, SyncMode.CUSTOM),
             onDismiss = { viewModel.skipSyncSelection() },
-            onSelectMode = { mode, height -> viewModel.onSyncModeSelected(mode, height) }
+            onSelectMode = { mode, height -> viewModel.onSyncModeSelected(mode, height) },
+            tipBlockNumber = uiState.tipBlockNumber
         )
     }
 

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/settings/SettingsScreen.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/settings/SettingsScreen.kt
@@ -145,7 +145,8 @@ fun SettingsScreen(
             currentMode = uiState.syncMode,
             onDismiss = { viewModel.hideSyncDialog() },
             onSelectMode = { mode, customBlock -> viewModel.setSyncMode(mode, customBlock) },
-            savedCustomBlockHeight = uiState.savedCustomBlockHeight
+            savedCustomBlockHeight = uiState.savedCustomBlockHeight,
+            tipBlockNumber = uiState.tipBlockNumber
         )
     }
 

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/settings/SettingsViewModel.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/settings/SettingsViewModel.kt
@@ -39,6 +39,7 @@ class SettingsViewModel @Inject constructor(
         val showNetworkSwitchDialog: Boolean = false,
         val showThemeDialog: Boolean = false,
         val pendingNetworkSwitch: NetworkType? = null,
+        val tipBlockNumber: Long = 0L,
         val error: String? = null
     )
 
@@ -52,6 +53,13 @@ class SettingsViewModel @Inject constructor(
         viewModelScope.launch {
             repository.network.collect { network ->
                 _uiState.update { it.copy(currentNetwork = network) }
+            }
+        }
+
+        // Track tip block number so the sync options dialog can validate custom heights
+        viewModelScope.launch {
+            repository.syncProgress.collect { progress ->
+                _uiState.update { it.copy(tipBlockNumber = progress.tipBlockNumber) }
             }
         }
 


### PR DESCRIPTION
## Summary

- Closes #81
- Adds inline validation to `SyncOptionsDialog`: when the user enters a custom block height above the current chain tip, the field shows an error ("Exceeds current tip (N). Enter a lower value.") and the Apply button is disabled
- Plumbs the live tip from `GatewayRepository.syncProgress` through `SettingsViewModel`, `MnemonicImportViewModel`, and the existing `HomeViewModel` exposure into all four dialog call sites

## Why

Previously the dialog accepted any positive number. The repo then silently reset future-block input to `tip - 200_000` (RECENT) and synced from there, leaving the user thinking their entered height had been honoured. Now they get immediate feedback.

## Out of scope

The issue also mentions a Snackbar fallback for the race where the tip advances between user input and submission. Skipped: the backend reroute is already safe (just falls back to RECENT), the UI validation removes the common case, and the cross-layer event plumbing isn't warranted for a low-priority UX fix. Easy follow-up if needed.

## Test plan

- [x] `./gradlew :app:compileDebugKotlin` clean
- [x] `./gradlew :app:testDebugUnitTest` passes (one transient MockK ByteBuddy flake on first run, fixed by #95 / unaffected by these changes)
- [ ] Manual: open Sync Options from Settings, enter value above tip — error shows, Apply disabled
- [ ] Manual: enter value below tip — no error, Apply enabled
- [ ] Manual: same on post-import dialog (mainnet) and mnemonic import flow