### PR TITLE
feat: pull-to-refresh on activity screen (#92)

### DIFF
--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/activity/ActivityScreen.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/activity/ActivityScreen.kt
@@ -32,6 +32,7 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.pulltorefresh.PullToRefreshBox
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
@@ -126,12 +127,6 @@ fun ActivityScreen(
                             contentDescription = "Export CSV"
                         )
                     }
-                    IconButton(onClick = { viewModel.refreshCache() }) {
-                        Icon(
-                            imageVector = Lucide.RefreshCw,
-                            contentDescription = "Refresh"
-                        )
-                    }
                 },
                 colors = TopAppBarDefaults.topAppBarColors(
                     containerColor = MaterialTheme.colorScheme.surface
@@ -150,8 +145,18 @@ fun ActivityScreen(
                 onFilterSelected = { viewModel.setFilter(it) }
             )
 
+            // Initial empty load → fullscreen spinner. Subsequent refreshes are
+            // surfaced through the PullToRefreshBox indicator instead.
+            val isInitialLoading = pagingItems.itemCount == 0 &&
+                (pagingItems.loadState.refresh is LoadState.Loading || uiState.isLoading)
+
+            PullToRefreshBox(
+                isRefreshing = uiState.isLoading && pagingItems.itemCount > 0,
+                onRefresh = { viewModel.refreshCache() },
+                modifier = Modifier.fillMaxSize()
+            ) {
             when {
-                pagingItems.loadState.refresh is LoadState.Loading || uiState.isLoading -> {
+                isInitialLoading -> {
                     Box(
                         modifier = Modifier.fillMaxSize(),
                         contentAlignment = Alignment.Center
@@ -218,6 +223,7 @@ fun ActivityScreen(
                         }
                     }
                 }
+            }
             }
 
             selectedTransaction?.let { tx ->


### PR DESCRIPTION
## Summary

- Closes #92
- Replaces the Refresh icon button in the Activity TopAppBar with Material 3 `PullToRefreshBox` over the transaction list
- Standard mobile gesture; loading state co-located with the content being refreshed; one less affordance in the app bar

## Behaviour

- Initial empty load → fullscreen `CircularProgressIndicator` (PullToRefreshBox needs scrollable content for the gesture to be reachable)
- List populated → pull-down triggers `viewModel.refreshCache()`, indicator drives off `uiState.isLoading`
- Export icon retained
- Error / empty states unchanged

## Test plan

- [x] `./gradlew :app:compileDebugKotlin` clean
- [x] `./gradlew :app:testDebugUnitTest` passes (one transient MockK flake, fixed by #95)
- [ ] Manual: pull down on populated activity screen → refresh fires, indicator dismisses on completion
- [ ] Manual: empty state still shows fullscreen spinner on initial load
- [ ] Manual: refresh icon no longer in TopAppBar