### PR TITLE
feat: BIP39 word suggestions on manage-wallet mnemonic import (#93)

### DIFF
--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/components/MnemonicWordInput.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/components/MnemonicWordInput.kt
@@ -1,0 +1,69 @@
+package com.rjnr.pocketnode.ui.components
+
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ExposedDropdownMenuBox
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.MenuAnchorType
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import com.rjnr.pocketnode.ui.util.Bip39WordList
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun MnemonicWordInput(
+    index: Int,
+    value: String,
+    suggestions: List<String>,
+    isError: Boolean,
+    onValueChange: (String) -> Unit,
+    onSuggestionSelected: (String) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    var expanded by remember { mutableStateOf(false) }
+
+    LaunchedEffect(suggestions, value) {
+        expanded = suggestions.isNotEmpty() && !Bip39WordList.isValidWord(value)
+    }
+
+    ExposedDropdownMenuBox(
+        expanded = expanded,
+        onExpandedChange = { },
+        modifier = modifier
+    ) {
+        OutlinedTextField(
+            value = value,
+            onValueChange = onValueChange,
+            label = { Text("#${index + 1}") },
+            modifier = Modifier
+                .fillMaxWidth()
+                .menuAnchor(MenuAnchorType.PrimaryEditable),
+            singleLine = true,
+            isError = isError,
+            textStyle = MaterialTheme.typography.bodyMedium
+        )
+
+        ExposedDropdownMenu(
+            expanded = expanded,
+            onDismissRequest = { expanded = false }
+        ) {
+            suggestions.forEach { word ->
+                DropdownMenuItem(
+                    text = { Text(word) },
+                    onClick = {
+                        onSuggestionSelected(word)
+                        expanded = false
+                    }
+                )
+            }
+        }
+    }
+}

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/onboarding/MnemonicImportScreen.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/onboarding/MnemonicImportScreen.kt
@@ -21,6 +21,7 @@ import com.rjnr.pocketnode.data.gateway.models.NetworkType
 import com.rjnr.pocketnode.data.gateway.models.SyncMode
 import com.rjnr.pocketnode.data.wallet.MnemonicManager
 import com.rjnr.pocketnode.data.wallet.WalletRepository
+import com.rjnr.pocketnode.ui.components.MnemonicWordInput
 import com.rjnr.pocketnode.ui.components.SyncOptionsDialog
 import com.rjnr.pocketnode.ui.util.Bip39WordList
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -285,7 +286,7 @@ fun MnemonicImportScreen(
                 verticalArrangement = Arrangement.spacedBy(8.dp)
             ) {
                 items(12) { index ->
-                    WordInputField(
+                    MnemonicWordInput(
                         index = index,
                         value = uiState.words[index],
                         suggestions = uiState.suggestions[index] ?: emptyList(),
@@ -319,56 +320,6 @@ fun MnemonicImportScreen(
                     Spacer(Modifier.width(8.dp))
                 }
                 Text("Import Wallet")
-            }
-        }
-    }
-}
-
-@OptIn(ExperimentalMaterial3Api::class)
-@Composable
-private fun WordInputField(
-    index: Int,
-    value: String,
-    suggestions: List<String>,
-    isError: Boolean,
-    onValueChange: (String) -> Unit,
-    onSuggestionSelected: (String) -> Unit
-) {
-    var expanded by remember { mutableStateOf(false) }
-
-    // Show dropdown when there are suggestions and value doesn't exactly match a suggestion
-    LaunchedEffect(suggestions, value) {
-        expanded = suggestions.isNotEmpty() && !Bip39WordList.isValidWord(value)
-    }
-
-    ExposedDropdownMenuBox(
-        expanded = expanded,
-        onExpandedChange = { }
-    ) {
-        OutlinedTextField(
-            value = value,
-            onValueChange = onValueChange,
-            label = { Text("#${index + 1}") },
-            modifier = Modifier
-                .fillMaxWidth()
-                .menuAnchor(MenuAnchorType.PrimaryEditable),
-            singleLine = true,
-            isError = isError,
-            textStyle = MaterialTheme.typography.bodyMedium
-        )
-
-        ExposedDropdownMenu(
-            expanded = expanded,
-            onDismissRequest = { expanded = false }
-        ) {
-            suggestions.forEach { word ->
-                DropdownMenuItem(
-                    text = { Text(word) },
-                    onClick = {
-                        onSuggestionSelected(word)
-                        expanded = false
-                    }
-                )
             }
         }
     }

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/wallet/AddWalletScreen.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/wallet/AddWalletScreen.kt
@@ -1,15 +1,20 @@
 package com.rjnr.pocketnode.ui.screens.wallet
 
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.foundation.lazy.grid.items
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
@@ -28,6 +33,7 @@ import androidx.compose.material3.MenuAnchorType
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
@@ -42,14 +48,17 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalClipboardManager
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.composables.icons.lucide.ArrowLeft
+import com.composables.icons.lucide.ClipboardPaste
 import com.composables.icons.lucide.Key
 import com.composables.icons.lucide.Lucide
 import com.composables.icons.lucide.Plus
 import com.composables.icons.lucide.Users
 import com.composables.icons.lucide.Wallet
+import com.rjnr.pocketnode.ui.components.MnemonicWordInput
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -199,6 +208,8 @@ private fun NewWalletForm(uiState: AddWalletUiState, viewModel: AddWalletViewMod
 
 @Composable
 private fun ImportMnemonicForm(uiState: AddWalletUiState, viewModel: AddWalletViewModel) {
+    val clipboardManager = LocalClipboardManager.current
+
     OutlinedTextField(
         value = uiState.name,
         onValueChange = { viewModel.updateName(it) },
@@ -206,20 +217,44 @@ private fun ImportMnemonicForm(uiState: AddWalletUiState, viewModel: AddWalletVi
         modifier = Modifier.fillMaxWidth(),
         singleLine = true
     )
-    Spacer(Modifier.height(8.dp))
-    OutlinedTextField(
-        value = uiState.importMnemonic,
-        onValueChange = { viewModel.updateImportMnemonic(it) },
-        label = { Text("Seed Phrase") },
-        modifier = Modifier.fillMaxWidth(),
-        minLines = 3,
-        placeholder = { Text("Enter your 12 or 24 word seed phrase") }
-    )
+    Spacer(Modifier.height(12.dp))
+
+    OutlinedButton(
+        onClick = {
+            clipboardManager.getText()?.text?.let { viewModel.pasteImportMnemonic(it) }
+        },
+        modifier = Modifier.fillMaxWidth()
+    ) {
+        Icon(Lucide.ClipboardPaste, contentDescription = null, modifier = Modifier.size(18.dp))
+        Spacer(Modifier.width(8.dp))
+        Text("Paste from Clipboard")
+    }
+    Spacer(Modifier.height(12.dp))
+
+    LazyVerticalGrid(
+        columns = GridCells.Fixed(2),
+        modifier = Modifier
+            .fillMaxWidth()
+            .heightIn(max = 480.dp),
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+        verticalArrangement = Arrangement.spacedBy(8.dp)
+    ) {
+        items(12) { index ->
+            MnemonicWordInput(
+                index = index,
+                value = uiState.importWords[index],
+                suggestions = uiState.importSuggestions[index] ?: emptyList(),
+                isError = uiState.importWordErrors.contains(index),
+                onValueChange = { viewModel.updateImportWord(index, it) },
+                onSuggestionSelected = { viewModel.selectImportSuggestion(index, it) }
+            )
+        }
+    }
     Spacer(Modifier.height(16.dp))
     Button(
         onClick = { viewModel.importMnemonic() },
         modifier = Modifier.fillMaxWidth(),
-        enabled = !uiState.isLoading
+        enabled = !uiState.isLoading && uiState.importWords.all { it.isNotBlank() }
     ) {
         if (uiState.isLoading) {
             CircularProgressIndicator(modifier = Modifier.size(20.dp), strokeWidth = 2.dp)

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/wallet/AddWalletViewModel.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/wallet/AddWalletViewModel.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.rjnr.pocketnode.data.database.entity.WalletEntity
 import com.rjnr.pocketnode.data.gateway.GatewayRepository
+import com.rjnr.pocketnode.data.wallet.MnemonicManager
 import com.rjnr.pocketnode.data.wallet.WalletRepository
 import com.rjnr.pocketnode.ui.util.Bip39WordList
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -32,7 +33,8 @@ data class AddWalletUiState(
 @HiltViewModel
 class AddWalletViewModel @Inject constructor(
     private val walletRepository: WalletRepository,
-    private val gatewayRepository: GatewayRepository
+    private val gatewayRepository: GatewayRepository,
+    private val mnemonicManager: MnemonicManager
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow(AddWalletUiState())
@@ -182,6 +184,10 @@ class AddWalletViewModel @Inject constructor(
         }
         if (words.any { !Bip39WordList.isValidWord(it) }) {
             _uiState.update { it.copy(error = "One or more words are not in the BIP39 wordlist") }
+            return
+        }
+        if (!mnemonicManager.validateMnemonic(words)) {
+            _uiState.update { it.copy(error = "Invalid mnemonic. Please check your words and try again.") }
             return
         }
 

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/wallet/AddWalletViewModel.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/wallet/AddWalletViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.viewModelScope
 import com.rjnr.pocketnode.data.database.entity.WalletEntity
 import com.rjnr.pocketnode.data.gateway.GatewayRepository
 import com.rjnr.pocketnode.data.wallet.WalletRepository
+import com.rjnr.pocketnode.ui.util.Bip39WordList
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -16,7 +17,9 @@ import javax.inject.Inject
 data class AddWalletUiState(
     val isLoading: Boolean = false,
     val name: String = "",
-    val importMnemonic: String = "",
+    val importWords: List<String> = List(12) { "" },
+    val importSuggestions: Map<Int, List<String>> = emptyMap(),
+    val importWordErrors: Set<Int> = emptySet(),
     val importPrivateKey: String = "",
     val createdWallet: WalletEntity? = null,
     val isNewlyGenerated: Boolean = false,
@@ -78,8 +81,59 @@ class AddWalletViewModel @Inject constructor(
         _uiState.update { it.copy(name = name) }
     }
 
-    fun updateImportMnemonic(mnemonic: String) {
-        _uiState.update { it.copy(importMnemonic = mnemonic) }
+    fun updateImportWord(index: Int, text: String) {
+        val trimmed = text.trim().lowercase()
+        val newWords = _uiState.value.importWords.toMutableList().apply { set(index, trimmed) }
+        val newSuggestions = _uiState.value.importSuggestions.toMutableMap()
+        val newErrors = _uiState.value.importWordErrors.toMutableSet()
+
+        if (trimmed.length >= 2) {
+            newSuggestions[index] = Bip39WordList.getSuggestions(trimmed)
+        } else {
+            newSuggestions.remove(index)
+        }
+
+        if (trimmed.isNotEmpty() && !Bip39WordList.isValidWord(trimmed)) {
+            newErrors.add(index)
+        } else {
+            newErrors.remove(index)
+        }
+
+        _uiState.update {
+            it.copy(
+                importWords = newWords,
+                importSuggestions = newSuggestions,
+                importWordErrors = newErrors
+            )
+        }
+    }
+
+    fun selectImportSuggestion(index: Int, word: String) {
+        val newWords = _uiState.value.importWords.toMutableList().apply { set(index, word) }
+        val newSuggestions = _uiState.value.importSuggestions.toMutableMap().apply { remove(index) }
+        val newErrors = _uiState.value.importWordErrors.toMutableSet().apply { remove(index) }
+        _uiState.update {
+            it.copy(
+                importWords = newWords,
+                importSuggestions = newSuggestions,
+                importWordErrors = newErrors
+            )
+        }
+    }
+
+    fun pasteImportMnemonic(text: String) {
+        val parts = text.trim().lowercase().split("\\s+".toRegex()).take(12)
+        val newWords = List(12) { i -> parts.getOrElse(i) { "" } }
+        val newErrors = newWords.mapIndexedNotNull { i, w ->
+            if (w.isNotEmpty() && !Bip39WordList.isValidWord(w)) i else null
+        }.toSet()
+        _uiState.update {
+            it.copy(
+                importWords = newWords,
+                importSuggestions = emptyMap(),
+                importWordErrors = newErrors
+            )
+        }
     }
 
     fun updateImportPrivateKey(key: String) {
@@ -116,14 +170,18 @@ class AddWalletViewModel @Inject constructor(
     fun importMnemonic() {
         if (_uiState.value.isLoading) return // prevent double-tap
         val name = _uiState.value.name.trim()
-        val words = _uiState.value.importMnemonic.trim().split("\\s+".toRegex())
+        val words = _uiState.value.importWords.map { it.trim().lowercase() }
 
         if (name.isBlank()) {
             _uiState.update { it.copy(error = "Please enter a wallet name") }
             return
         }
-        if (words.size !in listOf(12, 15, 18, 21, 24)) {
-            _uiState.update { it.copy(error = "Mnemonic must be 12, 15, 18, 21, or 24 words") }
+        if (words.any { it.isEmpty() }) {
+            _uiState.update { it.copy(error = "Please fill in all 12 words") }
+            return
+        }
+        if (words.any { !Bip39WordList.isValidWord(it) }) {
+            _uiState.update { it.copy(error = "One or more words are not in the BIP39 wordlist") }
             return
         }
 


### PR DESCRIPTION
## Summary

- Closes #93
- Replaces the single multi-line seed phrase field on **Manage Wallet → Add Wallet → Import** with the same 12-cell grid + autocomplete + paste UX used in onboarding
- Extracts `WordInputField` from `MnemonicImportScreen` into a shared `ui/components/MnemonicWordInput.kt` so both flows render the exact same control

## Behaviour

- Per-word `OutlinedTextField` with `ExposedDropdownMenu` autocomplete after 2 chars
- Inline error styling for words not in the BIP39 wordlist
- "Paste from Clipboard" button populates all 12 cells in one step
- Import button disabled until every cell is non-blank
- `importMnemonic()` now validates "all 12 filled" + "all in BIP39 wordlist" before calling `WalletRepository.importWallet`

## Test plan

- [x] `./gradlew :app:compileDebugKotlin` clean
- [x] `./gradlew :app:testDebugUnitTest` passes (transient MockK flake fixed by #95)
- [ ] Manual: open Manage Wallet → Add Wallet → Import via mnemonic
- [ ] Manual: type 2+ chars in a cell — autocomplete dropdown appears with BIP39 suggestions
- [ ] Manual: tap suggestion — cell populates and dropdown dismisses
- [ ] Manual: type a non-BIP39 word — cell shows error styling
- [ ] Manual: paste full mnemonic — all 12 cells populate
- [ ] Manual: onboarding import flow still works identically (same shared component)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Implemented structured 12-word mnemonic import with real-time BIP39 word suggestions as you type
  * Added clipboard paste support for streamlined mnemonic import

* **Refactor**
  * Redesigned mnemonic import interface from free-form text field to guided grid-based word-by-word entry with validation feedback
  * Standardized to 12-word mnemonic format

<!-- end of auto-generated comment: release notes by coderabbit.ai -->