### PR TITLE
perf: bundle of #83 sub-tasks (items 1, 4, 6, 8, 9)

### DIFF
--- a/android/app/src/main/java/com/rjnr/pocketnode/data/database/AppDatabase.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/database/AppDatabase.kt
@@ -24,7 +24,7 @@ import com.rjnr.pocketnode.data.database.entity.WalletEntity
         WalletEntity::class,
         KeyMaterialEntity::class
     ],
-    version = 5,
+    version = 6,
     exportSchema = false
 )
 abstract class AppDatabase : RoomDatabase() {

--- a/android/app/src/main/java/com/rjnr/pocketnode/data/database/DatabaseMaintenanceUtil.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/database/DatabaseMaintenanceUtil.kt
@@ -4,8 +4,26 @@ import android.database.Cursor
 
 object DatabaseMaintenanceUtil {
 
+    /** ~30 days, matches the periodic-VACUUM cadence we run from startup idle. */
+    const val VACUUM_INTERVAL_MS: Long = 30L * 24 * 60 * 60 * 1000
+
     fun vacuum(db: AppDatabase) {
         db.openHelper.writableDatabase.execSQL("VACUUM")
+    }
+
+    /**
+     * Run VACUUM only if the last run was longer than [intervalMs] ago.
+     * Returns true if VACUUM ran, false if the throttle window blocked it.
+     */
+    fun vacuumIfDue(
+        db: AppDatabase,
+        lastRunMs: Long,
+        nowMs: Long = System.currentTimeMillis(),
+        intervalMs: Long = VACUUM_INTERVAL_MS
+    ): Boolean {
+        if (nowMs - lastRunMs < intervalMs) return false
+        vacuum(db)
+        return true
     }
 
     fun getDatabaseSizeBytes(db: AppDatabase): Long {

--- a/android/app/src/main/java/com/rjnr/pocketnode/data/database/Migrations.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/database/Migrations.kt
@@ -170,3 +170,26 @@ val MIGRATION_4_5 = object : Migration(4, 5) {
         )
     }
 }
+
+/**
+ * v5 -> v6: Partial index on PENDING transactions to speed up the
+ * "pending-first" sort used by ActivityScreen paging
+ * (TransactionDao.getTransactionsPaged / getByWalletAndNetwork).
+ *
+ * The existing composite index covers (walletId, network, timestamp DESC) but
+ * the `CASE WHEN status = 'PENDING'` ORDER BY clause forces a full scan when
+ * pending rows are sparse; a partial index keyed only on PENDING rows lets
+ * SQLite jump straight to them.
+ *
+ * Defined in raw SQL because Room's `@Index` annotation does not support
+ * WHERE clauses. Room schema validation ignores indices it didn't create.
+ */
+val MIGRATION_5_6 = object : Migration(5, 6) {
+    override fun migrate(db: SupportSQLiteDatabase) {
+        db.execSQL(
+            "CREATE INDEX IF NOT EXISTS `idx_tx_pending` " +
+                "ON `transactions` (`walletId`, `network`, `timestamp` DESC) " +
+                "WHERE `status` = 'PENDING'"
+        )
+    }
+}

--- a/android/app/src/main/java/com/rjnr/pocketnode/data/gateway/GatewayRepository.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/gateway/GatewayRepository.kt
@@ -20,6 +20,9 @@ import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -1707,43 +1710,50 @@ class GatewayRepository @Inject constructor(
             tip.number.removePrefix("0x").toLong(16)
         } else 0L
 
-        val scriptStatuses = wallets.mapNotNull { wallet ->
-            val privateKey = keyManager.getPrivateKeyForWallet(wallet.walletId) ?: run {
-                Log.w(TAG, "No key for wallet ${wallet.walletId}, skipping script registration")
-                return@mapNotNull null
-            }
-            val publicKey = keyManager.derivePublicKey(privateKey)
-            val lockScript = keyManager.deriveLockScript(publicKey)
+        // Per-wallet derivation is independent CPU+IO work (Room read for the
+        // private key, blake2b hash for the lock script). Run them concurrently
+        // so a 5-wallet ALL_WALLETS sync doesn't pay the cost serially.
+        val scriptStatuses = coroutineScope {
+            wallets.map { wallet ->
+                async(Dispatchers.IO) {
+                    val privateKey = keyManager.getPrivateKeyForWallet(wallet.walletId) ?: run {
+                        Log.w(TAG, "No key for wallet ${wallet.walletId}, skipping script registration")
+                        return@async null
+                    }
+                    val publicKey = keyManager.derivePublicKey(privateKey)
+                    val lockScript = keyManager.deriveLockScript(publicKey)
 
-            // Resume from saved per-wallet progress, or calculate from sync mode if first sync
-            val savedBlock = walletPreferences.getLastSyncedBlock(walletId = wallet.walletId)
-            val blockNum: String
-            if (savedBlock > 0) {
-                blockNum = savedBlock.toString()
-            } else {
-                val syncMode = walletPreferences.getSyncMode(walletId = wallet.walletId)
-                val customHeight = walletPreferences.getCustomBlockHeight(walletId = wallet.walletId)
-                val calculated = syncMode.toFromBlock(
-                    if (syncMode == SyncMode.CUSTOM) customHeight else null,
-                    tipHeight,
-                    currentNetwork
-                )
-                val calculatedLong = calculated.toLongOrNull() ?: 0L
-                // Safety: don't start from block 0 — use checkpoint if available
-                val checkpoint = getCheckpoint(currentNetwork)
-                blockNum = if (calculatedLong == 0L && syncMode != SyncMode.FULL_HISTORY && checkpoint > 0) {
-                    checkpoint.toString()
-                } else {
-                    calculated
+                    // Resume from saved per-wallet progress, or calculate from sync mode if first sync
+                    val savedBlock = walletPreferences.getLastSyncedBlock(walletId = wallet.walletId)
+                    val blockNum: String
+                    if (savedBlock > 0) {
+                        blockNum = savedBlock.toString()
+                    } else {
+                        val syncMode = walletPreferences.getSyncMode(walletId = wallet.walletId)
+                        val customHeight = walletPreferences.getCustomBlockHeight(walletId = wallet.walletId)
+                        val calculated = syncMode.toFromBlock(
+                            if (syncMode == SyncMode.CUSTOM) customHeight else null,
+                            tipHeight,
+                            currentNetwork
+                        )
+                        val calculatedLong = calculated.toLongOrNull() ?: 0L
+                        // Safety: don't start from block 0 — use checkpoint if available
+                        val checkpoint = getCheckpoint(currentNetwork)
+                        blockNum = if (calculatedLong == 0L && syncMode != SyncMode.FULL_HISTORY && checkpoint > 0) {
+                            checkpoint.toString()
+                        } else {
+                            calculated
+                        }
+                    }
+                    val blockNumberHex = "0x${blockNum.toLongOrNull()?.toString(16) ?: "0"}"
+
+                    JniScriptStatus(
+                        script = lockScript,
+                        scriptType = "lock",
+                        blockNumber = blockNumberHex
+                    )
                 }
-            }
-            val blockNumberHex = "0x${blockNum.toLongOrNull()?.toString(16) ?: "0"}"
-
-            JniScriptStatus(
-                script = lockScript,
-                scriptType = "lock",
-                blockNumber = blockNumberHex
-            )
+            }.awaitAll().filterNotNull()
         }
 
         if (scriptStatuses.isEmpty()) {

--- a/android/app/src/main/java/com/rjnr/pocketnode/data/gateway/GatewayRepository.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/gateway/GatewayRepository.kt
@@ -2,6 +2,8 @@ package com.rjnr.pocketnode.data.gateway
 
 import android.content.Context
 import android.util.Log
+import com.rjnr.pocketnode.data.database.AppDatabase
+import com.rjnr.pocketnode.data.database.DatabaseMaintenanceUtil
 import com.rjnr.pocketnode.data.database.dao.WalletDao
 import com.rjnr.pocketnode.data.database.entity.WalletEntity
 import com.rjnr.pocketnode.data.gateway.models.*
@@ -52,7 +54,8 @@ class GatewayRepository @Inject constructor(
     private val cacheManager: CacheManager,
     private val daoSyncManager: DaoSyncManager,
     private val walletMigrationHelper: WalletMigrationHelper,
-    private val walletDao: WalletDao
+    private val walletDao: WalletDao,
+    private val appDatabase: AppDatabase
 ) {
     private val _walletInfo = MutableStateFlow<WalletInfo?>(null)
     val walletInfo: StateFlow<WalletInfo?> = _walletInfo.asStateFlow()
@@ -101,6 +104,16 @@ class GatewayRepository @Inject constructor(
                 // Delete ESP files after successful migration
                 keyManager.deleteEspFilesIfSafe()
                 activeWalletId = walletPreferences.getActiveWalletId() ?: ""
+
+                // Periodic VACUUM (~monthly) to reclaim fragmented space from
+                // tombstoned tx/cell rows. Throttled so it doesn't run on
+                // every cold start.
+                runCatching {
+                    if (DatabaseMaintenanceUtil.vacuumIfDue(appDatabase, walletPreferences.getLastVacuumAt())) {
+                        walletPreferences.setLastVacuumAt(System.currentTimeMillis())
+                        Log.d(TAG, "Periodic VACUUM completed")
+                    }
+                }.onFailure { Log.w(TAG, "Periodic VACUUM failed (non-fatal)", it) }
 
                 initializeNode(currentNetwork)
             } catch (e: Exception) {

--- a/android/app/src/main/java/com/rjnr/pocketnode/data/gateway/GatewayRepository.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/gateway/GatewayRepository.kt
@@ -4,7 +4,9 @@ import android.content.Context
 import android.util.Log
 import com.rjnr.pocketnode.data.database.AppDatabase
 import com.rjnr.pocketnode.data.database.DatabaseMaintenanceUtil
+import com.rjnr.pocketnode.data.database.dao.HeaderCacheDao
 import com.rjnr.pocketnode.data.database.dao.WalletDao
+import com.rjnr.pocketnode.data.database.entity.HeaderCacheEntity
 import com.rjnr.pocketnode.data.database.entity.WalletEntity
 import com.rjnr.pocketnode.data.gateway.models.*
 import com.rjnr.pocketnode.data.sync.SyncForegroundService
@@ -58,7 +60,8 @@ class GatewayRepository @Inject constructor(
     private val daoSyncManager: DaoSyncManager,
     private val walletMigrationHelper: WalletMigrationHelper,
     private val walletDao: WalletDao,
-    private val appDatabase: AppDatabase
+    private val appDatabase: AppDatabase,
+    private val headerCacheDao: HeaderCacheDao
 ) {
     private val _walletInfo = MutableStateFlow<WalletInfo?>(null)
     val walletInfo: StateFlow<WalletInfo?> = _walletInfo.asStateFlow()
@@ -988,26 +991,40 @@ class GatewayRepository @Inject constructor(
             val amount = if (netChangeShannons < 0) -netChangeShannons else netChangeShannons
 
             // Attempt to fetch block header to get real timestamp and block hash.
-            // nativeGetTransaction gives us the blockHash, then nativeGetHeader gives the header.
+            // For a 50-tx page this used to do 50 native_get_header round-trips
+            // even when the same headers had been resolved seconds earlier.
+            // header_cache (Room) is consulted first; JNI is only invoked on miss
+            // and the result is persisted so the next page-load is free.
             data class HeaderInfo(val timestampHex: String?, val hash: String?)
             val headerInfo: HeaderInfo = runCatching {
                 val txWithStatus = LightClientNative.nativeGetTransaction(txHash)
                     ?.let { json.decodeFromString<JniTransactionWithStatus>(it) }
                 val blockHashFromStatus = txWithStatus?.txStatus?.blockHash
                 if (blockHashFromStatus != null) {
-                    // Try local lookup first, then trigger a fetch if not cached
-                    val headerJson = LightClientNative.nativeGetHeader(blockHashFromStatus)
-                    val header = headerJson?.let { json.decodeFromString<JniHeaderView>(it) }
-                    if (header != null) {
-                        HeaderInfo(timestampHex = header.timestamp, hash = header.hash)
+                    val cached = headerCacheDao.getByBlockHash(blockHashFromStatus)
+                    if (cached != null) {
+                        HeaderInfo(timestampHex = cached.timestamp, hash = cached.blockHash)
                     } else {
-                        // Header not cached locally — ask light client to fetch it
-                        val fetchJson = LightClientNative.nativeFetchHeader(blockHashFromStatus)
-                        val fetchResult = fetchJson?.let { json.decodeFromString<JniFetchHeaderResponse>(it) }
-                        if (fetchResult?.status == "fetched" && fetchResult.data != null) {
-                            HeaderInfo(timestampHex = fetchResult.data.timestamp, hash = fetchResult.data.hash)
+                        // Try local JNI lookup first, then trigger a fetch if not cached
+                        val headerJson = LightClientNative.nativeGetHeader(blockHashFromStatus)
+                        val header = headerJson?.let { json.decodeFromString<JniHeaderView>(it) }
+                        if (header != null) {
+                            runCatching {
+                                headerCacheDao.upsert(HeaderCacheEntity.from(header, currentNetwork.name))
+                            }
+                            HeaderInfo(timestampHex = header.timestamp, hash = header.hash)
                         } else {
-                            HeaderInfo(null, null)
+                            // Header not cached locally — ask light client to fetch it
+                            val fetchJson = LightClientNative.nativeFetchHeader(blockHashFromStatus)
+                            val fetchResult = fetchJson?.let { json.decodeFromString<JniFetchHeaderResponse>(it) }
+                            if (fetchResult?.status == "fetched" && fetchResult.data != null) {
+                                runCatching {
+                                    headerCacheDao.upsert(HeaderCacheEntity.from(fetchResult.data, currentNetwork.name))
+                                }
+                                HeaderInfo(timestampHex = fetchResult.data.timestamp, hash = fetchResult.data.hash)
+                            } else {
+                                HeaderInfo(null, null)
+                            }
                         }
                     }
                 } else HeaderInfo(null, null)

--- a/android/app/src/main/java/com/rjnr/pocketnode/data/wallet/WalletPreferences.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/wallet/WalletPreferences.kt
@@ -163,6 +163,14 @@ class WalletPreferences @Inject constructor(
         prefs.edit().putBoolean(KEY_BACKGROUND_SYNC, enabled).commit()
     }
 
+    // --- Database maintenance ---
+
+    fun getLastVacuumAt(): Long = prefs.getLong(KEY_LAST_VACUUM_AT, 0L)
+
+    fun setLastVacuumAt(timestampMs: Long) {
+        prefs.edit().putLong(KEY_LAST_VACUUM_AT, timestampMs).apply()
+    }
+
     // --- Active wallet (M3 multi-wallet) ---
 
     fun getActiveWalletId(): String? = prefs.getString(KEY_ACTIVE_WALLET_ID, null)
@@ -251,5 +259,6 @@ class WalletPreferences @Inject constructor(
         private const val KEY_SYNC_STRATEGY = "sync_strategy"
         private const val KEY_THEME_MODE = "theme_mode"
         private const val KEY_BACKGROUND_SYNC = "background_sync_enabled"
+        private const val KEY_LAST_VACUUM_AT = "last_vacuum_at"
     }
 }

--- a/android/app/src/main/java/com/rjnr/pocketnode/di/AppModule.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/di/AppModule.kt
@@ -177,6 +177,7 @@ object AppModule {
         cacheManager: CacheManager,
         daoSyncManager: DaoSyncManager,
         walletMigrationHelper: WalletMigrationHelper,
-        walletDao: WalletDao
-    ): GatewayRepository = GatewayRepository(context, keyManager, walletPreferences, json, transactionBuilder, cacheManager, daoSyncManager, walletMigrationHelper, walletDao)
+        walletDao: WalletDao,
+        appDatabase: AppDatabase
+    ): GatewayRepository = GatewayRepository(context, keyManager, walletPreferences, json, transactionBuilder, cacheManager, daoSyncManager, walletMigrationHelper, walletDao, appDatabase)
 }

--- a/android/app/src/main/java/com/rjnr/pocketnode/di/AppModule.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/di/AppModule.kt
@@ -178,6 +178,7 @@ object AppModule {
         daoSyncManager: DaoSyncManager,
         walletMigrationHelper: WalletMigrationHelper,
         walletDao: WalletDao,
-        appDatabase: AppDatabase
-    ): GatewayRepository = GatewayRepository(context, keyManager, walletPreferences, json, transactionBuilder, cacheManager, daoSyncManager, walletMigrationHelper, walletDao, appDatabase)
+        appDatabase: AppDatabase,
+        headerCacheDao: HeaderCacheDao
+    ): GatewayRepository = GatewayRepository(context, keyManager, walletPreferences, json, transactionBuilder, cacheManager, daoSyncManager, walletMigrationHelper, walletDao, appDatabase, headerCacheDao)
 }

--- a/android/app/src/main/java/com/rjnr/pocketnode/di/AppModule.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/di/AppModule.kt
@@ -12,6 +12,7 @@ import com.rjnr.pocketnode.data.database.MIGRATION_1_2
 import com.rjnr.pocketnode.data.database.MIGRATION_2_3
 import com.rjnr.pocketnode.data.database.MIGRATION_3_4
 import com.rjnr.pocketnode.data.database.MIGRATION_4_5
+import com.rjnr.pocketnode.data.database.MIGRATION_5_6
 import com.rjnr.pocketnode.data.database.dao.BalanceCacheDao
 import com.rjnr.pocketnode.data.database.dao.DaoCellDao
 import com.rjnr.pocketnode.data.database.dao.HeaderCacheDao
@@ -112,7 +113,7 @@ object AppModule {
     fun provideAppDatabase(@ApplicationContext context: Context): AppDatabase =
         Room.databaseBuilder(context, AppDatabase::class.java, "pocket_node.db")
             .setJournalMode(RoomDatabase.JournalMode.WRITE_AHEAD_LOGGING)
-            .addMigrations(MIGRATION_1_2, MIGRATION_2_3, MIGRATION_3_4, MIGRATION_4_5)
+            .addMigrations(MIGRATION_1_2, MIGRATION_2_3, MIGRATION_3_4, MIGRATION_4_5, MIGRATION_5_6)
             .build()
 
     @Provides

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/home/HomeViewModel.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/home/HomeViewModel.kt
@@ -24,6 +24,7 @@ import com.rjnr.pocketnode.ui.components.WalletGroup
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.*
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.jsonArray
 import java.util.Locale
@@ -42,6 +43,12 @@ class HomeViewModel @Inject constructor(
     private val authManager: AuthManager,
     private val cacheManager: CacheManager
 ) : ViewModel() {
+
+    // Skip-overlapping guard for refreshTransactionsOnly. The fn is called from
+    // refresh(), the syncProgress observer (silent), and wallet switches; under
+    // load these can fire within milliseconds. tryLock means we never queue a
+    // duplicate JNI/Room round-trip — the second caller bails immediately.
+    private val txRefreshMutex = Mutex()
 
     private val _uiState = MutableStateFlow(HomeUiState())
     val uiState: StateFlow<HomeUiState> = _uiState.asStateFlow()
@@ -297,25 +304,33 @@ class HomeViewModel @Inject constructor(
     }
 
     private suspend fun refreshTransactionsOnly(silent: Boolean = false) {
-        Log.d(TAG, "Fetching transactions (limit=50)...")
-        repository.getTransactions(limit = 50)
-            .onSuccess { response ->
-                Log.d(TAG, "Fetched ${response.items.size} transactions")
-                response.items.forEachIndexed { index, tx ->
-                    Log.d(TAG, "  [$index] ${tx.txHash.take(16)}... dir=${tx.direction} amount=${tx.balanceChange} conf=${tx.confirmations}")
-                }
-                _uiState.update {
-                    it.copy(transactions = response.items)
-                }
-            }
-            .onFailure { error ->
-                Log.e(TAG, "Failed to fetch transactions", error)
-                if (!silent) {
+        if (!txRefreshMutex.tryLock()) {
+            Log.d(TAG, "refreshTransactionsOnly skipped — already in flight")
+            return
+        }
+        try {
+            Log.d(TAG, "Fetching transactions (limit=50)...")
+            repository.getTransactions(limit = 50)
+                .onSuccess { response ->
+                    Log.d(TAG, "Fetched ${response.items.size} transactions")
+                    response.items.forEachIndexed { index, tx ->
+                        Log.d(TAG, "  [$index] ${tx.txHash.take(16)}... dir=${tx.direction} amount=${tx.balanceChange} conf=${tx.confirmations}")
+                    }
                     _uiState.update {
-                        it.copy(error = "Failed to load transactions: ${error.message}")
+                        it.copy(transactions = response.items)
                     }
                 }
-            }
+                .onFailure { error ->
+                    Log.e(TAG, "Failed to fetch transactions", error)
+                    if (!silent) {
+                        _uiState.update {
+                            it.copy(error = "Failed to load transactions: ${error.message}")
+                        }
+                    }
+                }
+        } finally {
+            txRefreshMutex.unlock()
+        }
     }
 
     fun clearError() {


### PR DESCRIPTION
## Summary

Closes #83 (partial — 5 of 9 items shipped, 4 deferred to follow-ups #99–#102).

Each commit on this branch is one of the #83 sub-tasks; they are independent and can be reviewed in any order.

## Shipped

| Commit | Item | What |
|---|---|---|
| f5ef9e2 | #83.1 | Partial SQLite index on PENDING transactions to speed the pending-first sort |
| 9124e7d | #83.4 | Throttled (~monthly) VACUUM during startup idle |
| 1a73d2e | #83.8 | Mutex around \`refreshTransactionsOnly\` so overlapping calls bail instead of stacking JNI/Room work |
| 5258d1d | #83.6 | Per-wallet derivation in \`registerAllWalletScripts\` runs concurrently via async/awaitAll |
| d077fe6 | #83.9 | Tx-list block headers served from \`header_cache\` (Room) before falling back to \`nativeGetHeader\` / \`nativeFetchHeader\` |

## Deferred (follow-up issues opened)

| Item | Issue | Reason |
|---|---|---|
| #83.7 cache getAccountStatus | #99 | Only caller is the 5s/30s sync poll; 2-3s TTL window expires before next call |
| #83.3 transactionCount on WalletEntity | #100 | Zero current consumers; denormalised invariant ahead of demand |
| #83.5 lazy light-client init | #101 | Init already async; real refactor needs single-flight init guard + audit of \`nodeStatus\` observers |
| #83.2 balance @DatabaseView | #102 | \`balance_cache\` already plays this role; a cell-mirror view would create a second source of truth and drift bait |

## Test plan

- [x] \`./gradlew :app:compileDebugKotlin\` clean
- [x] \`./gradlew :app:testDebugUnitTest --rerun-tasks\` passes (459 tests)
- [ ] Manual: app installs on a v5 DB → migrates to v6, partial index appears, no schema warnings
- [ ] Manual: install fresh → DB built at v6 directly
- [ ] Manual: ALL_WALLETS strategy with 3+ wallets → registerAllWalletScripts completes faster vs main
- [ ] Manual: scroll Activity tab → second visit hits header_cache (no fresh \`native_get_header\` log lines)
- [ ] Manual: sync polling under load → no overlapping \`refreshTransactionsOnly\` log entries