### PR TITLE
feat: per-wallet sync state to Room + BALANCED sync strategy (#105)

### DIFF
--- a/android/app/src/main/java/com/rjnr/pocketnode/data/database/AppDatabase.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/database/AppDatabase.kt
@@ -6,12 +6,14 @@ import com.rjnr.pocketnode.data.database.dao.BalanceCacheDao
 import com.rjnr.pocketnode.data.database.dao.DaoCellDao
 import com.rjnr.pocketnode.data.database.dao.HeaderCacheDao
 import com.rjnr.pocketnode.data.database.dao.KeyMaterialDao
+import com.rjnr.pocketnode.data.database.dao.SyncProgressDao
 import com.rjnr.pocketnode.data.database.dao.TransactionDao
 import com.rjnr.pocketnode.data.database.dao.WalletDao
 import com.rjnr.pocketnode.data.database.entity.BalanceCacheEntity
 import com.rjnr.pocketnode.data.database.entity.DaoCellEntity
 import com.rjnr.pocketnode.data.database.entity.HeaderCacheEntity
 import com.rjnr.pocketnode.data.database.entity.KeyMaterialEntity
+import com.rjnr.pocketnode.data.database.entity.SyncProgressEntity
 import com.rjnr.pocketnode.data.database.entity.TransactionEntity
 import com.rjnr.pocketnode.data.database.entity.WalletEntity
 
@@ -22,9 +24,10 @@ import com.rjnr.pocketnode.data.database.entity.WalletEntity
         HeaderCacheEntity::class,
         DaoCellEntity::class,
         WalletEntity::class,
-        KeyMaterialEntity::class
+        KeyMaterialEntity::class,
+        SyncProgressEntity::class
     ],
-    version = 6,
+    version = 7,
     exportSchema = false
 )
 abstract class AppDatabase : RoomDatabase() {
@@ -34,4 +37,5 @@ abstract class AppDatabase : RoomDatabase() {
     abstract fun daoCellDao(): DaoCellDao
     abstract fun walletDao(): WalletDao
     abstract fun keyMaterialDao(): KeyMaterialDao
+    abstract fun syncProgressDao(): SyncProgressDao
 }

--- a/android/app/src/main/java/com/rjnr/pocketnode/data/database/Migrations.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/database/Migrations.kt
@@ -193,3 +193,26 @@ val MIGRATION_5_6 = object : Migration(5, 6) {
         )
     }
 }
+
+/**
+ * v6 -> v7: Add sync_progress table for per-wallet sync block tracking (#105).
+ * Replaces SharedPreferences storage of lastSyncedBlock. The data copy from
+ * SharedPrefs to this table happens at app start via WalletMigrationHelper —
+ * this migration only creates the empty table.
+ */
+val MIGRATION_6_7 = object : Migration(6, 7) {
+    override fun migrate(db: SupportSQLiteDatabase) {
+        db.execSQL(
+            """
+            CREATE TABLE IF NOT EXISTS `sync_progress` (
+                `walletId` TEXT NOT NULL,
+                `network` TEXT NOT NULL,
+                `lightStartBlockNumber` INTEGER NOT NULL,
+                `localSavedBlockNumber` INTEGER NOT NULL,
+                `updatedAt` INTEGER NOT NULL,
+                PRIMARY KEY(`walletId`, `network`)
+            )
+            """.trimIndent()
+        )
+    }
+}

--- a/android/app/src/main/java/com/rjnr/pocketnode/data/database/dao/SyncProgressDao.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/database/dao/SyncProgressDao.kt
@@ -1,0 +1,26 @@
+package com.rjnr.pocketnode.data.database.dao
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import com.rjnr.pocketnode.data.database.entity.SyncProgressEntity
+
+@Dao
+interface SyncProgressDao {
+
+    @Query("SELECT * FROM sync_progress WHERE walletId = :walletId AND network = :network LIMIT 1")
+    suspend fun get(walletId: String, network: String): SyncProgressEntity?
+
+    @Query("SELECT * FROM sync_progress WHERE network = :network")
+    suspend fun getAllForNetwork(network: String): List<SyncProgressEntity>
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun upsert(entity: SyncProgressEntity)
+
+    @Query("UPDATE sync_progress SET localSavedBlockNumber = :block, updatedAt = :ts WHERE walletId = :walletId AND network = :network")
+    suspend fun updateLocalSaved(walletId: String, network: String, block: Long, ts: Long)
+
+    @Query("DELETE FROM sync_progress WHERE walletId = :walletId")
+    suspend fun deleteForWallet(walletId: String)
+}

--- a/android/app/src/main/java/com/rjnr/pocketnode/data/database/dao/SyncProgressDao.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/database/dao/SyncProgressDao.kt
@@ -18,8 +18,14 @@ interface SyncProgressDao {
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun upsert(entity: SyncProgressEntity)
 
+    /**
+     * Atomic update of progress only (preserves lightStartBlockNumber).
+     * Returns rows affected (0 = no row, caller falls back to upsert).
+     * Closes the get→upsert race window in setWalletSyncBlock vs concurrent
+     * inserts from setScriptsAndRecord during initial registration.
+     */
     @Query("UPDATE sync_progress SET localSavedBlockNumber = :block, updatedAt = :ts WHERE walletId = :walletId AND network = :network")
-    suspend fun updateLocalSaved(walletId: String, network: String, block: Long, ts: Long)
+    suspend fun updateLocalSaved(walletId: String, network: String, block: Long, ts: Long): Int
 
     /**
      * Atomic update of registration metadata only (preserves localSavedBlockNumber).

--- a/android/app/src/main/java/com/rjnr/pocketnode/data/database/dao/SyncProgressDao.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/database/dao/SyncProgressDao.kt
@@ -21,6 +21,15 @@ interface SyncProgressDao {
     @Query("UPDATE sync_progress SET localSavedBlockNumber = :block, updatedAt = :ts WHERE walletId = :walletId AND network = :network")
     suspend fun updateLocalSaved(walletId: String, network: String, block: Long, ts: Long)
 
+    /**
+     * Atomic update of registration metadata only (preserves localSavedBlockNumber).
+     * Returns rows affected (0 = no row, caller falls back to upsert).
+     * Closes the get→upsert race window in setScriptsAndRecord vs concurrent
+     * setWalletSyncBlock writes from the sync poll.
+     */
+    @Query("UPDATE sync_progress SET lightStartBlockNumber = :lightStart, updatedAt = :ts WHERE walletId = :walletId AND network = :network")
+    suspend fun updateLightStart(walletId: String, network: String, lightStart: Long, ts: Long): Int
+
     @Query("DELETE FROM sync_progress WHERE walletId = :walletId")
     suspend fun deleteForWallet(walletId: String)
 }

--- a/android/app/src/main/java/com/rjnr/pocketnode/data/database/entity/SyncProgressEntity.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/database/entity/SyncProgressEntity.kt
@@ -1,0 +1,15 @@
+package com.rjnr.pocketnode.data.database.entity
+
+import androidx.room.Entity
+
+@Entity(
+    tableName = "sync_progress",
+    primaryKeys = ["walletId", "network"]
+)
+data class SyncProgressEntity(
+    val walletId: String,
+    val network: String,                 // NetworkType.name (MAINNET / TESTNET)
+    val lightStartBlockNumber: Long,     // block we passed to nativeSetScripts
+    val localSavedBlockNumber: Long,     // last block fully processed
+    val updatedAt: Long                  // epoch ms
+)

--- a/android/app/src/main/java/com/rjnr/pocketnode/data/gateway/GatewayRepository.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/gateway/GatewayRepository.kt
@@ -51,6 +51,27 @@ data class SyncProgress(
     val justReachedTip: Boolean = false
 )
 
+/**
+ * Pure BALANCED filter algorithm — no I/O. Extracted from GatewayRepository
+ * so unit tests exercise the production implementation directly without
+ * having to construct a full GatewayRepository instance.
+ *
+ * Returns Pair(kept, dropped). Active wallet always lands in `kept`.
+ */
+internal fun balancedFilterAlgorithm(
+    wallets: List<WalletEntity>,
+    progressByWalletId: Map<String, Long>,
+    activeId: String,
+    threshold: Long
+): Pair<List<WalletEntity>, List<WalletEntity>> {
+    if (wallets.size <= 1) return wallets to emptyList()
+    val maxProgress = progressByWalletId.values.maxOrNull() ?: 0L
+    return wallets.partition { wallet ->
+        val lag = maxProgress - (progressByWalletId[wallet.walletId] ?: 0L)
+        wallet.walletId == activeId || lag <= threshold
+    }
+}
+
 @Singleton
 class GatewayRepository @Inject constructor(
     @ApplicationContext private val context: Context,
@@ -1771,16 +1792,23 @@ class GatewayRepository @Inject constructor(
         statuses.zip(walletIds).forEach { (status, walletId) ->
             if (walletId.isEmpty()) return@forEach
             val startBlock = status.blockNumber.removePrefix("0x").toLong(16)
-            val existing = syncProgressDao.get(walletId, currentNetwork.name)
-            syncProgressDao.upsert(
-                SyncProgressEntity(
-                    walletId = walletId,
-                    network = currentNetwork.name,
-                    lightStartBlockNumber = startBlock,
-                    localSavedBlockNumber = existing?.localSavedBlockNumber ?: startBlock,
-                    updatedAt = now
-                )
+            // Atomic UPDATE preserves localSavedBlockNumber under concurrent writes
+            // from the sync poll's setWalletSyncBlock. Falls through to upsert only
+            // when no row exists yet (no race possible — nothing to overwrite).
+            val rowsUpdated = syncProgressDao.updateLightStart(
+                walletId, currentNetwork.name, startBlock, now
             )
+            if (rowsUpdated == 0) {
+                syncProgressDao.upsert(
+                    SyncProgressEntity(
+                        walletId = walletId,
+                        network = currentNetwork.name,
+                        lightStartBlockNumber = startBlock,
+                        localSavedBlockNumber = startBlock,
+                        updatedAt = now
+                    )
+                )
+            }
         }
         return true
     }
@@ -1797,23 +1825,27 @@ class GatewayRepository @Inject constructor(
      *
      * MUST stay pure — no cache writes. The lastBalancedEligibleSet cache is owned
      * by registerAllWalletScripts (Task 14).
+     *
+     * I/O wrapper — bulk-reads progress rows, delegates the partition logic to
+     * the top-level pure `balancedFilterAlgorithm` so tests can exercise it
+     * without constructing a full GatewayRepository.
      */
     private suspend fun applyBalancedFilter(wallets: List<WalletEntity>): List<WalletEntity> {
         if (wallets.size <= 1) return wallets
 
+        // Bulk read: one round-trip instead of N gets.
+        val rows = syncProgressDao.getAllForNetwork(currentNetwork.name)
+            .associateBy { it.walletId }
         val progress = wallets.associate { wallet ->
-            wallet.walletId to (syncProgressDao.get(wallet.walletId, currentNetwork.name)
-                ?.localSavedBlockNumber ?: 0L)
+            wallet.walletId to (rows[wallet.walletId]?.localSavedBlockNumber ?: 0L)
         }
-        val maxProgress = progress.values.max()
-        val activeId = activeWalletId
 
-        val (kept, dropped) = wallets.partition { wallet ->
-            val lag = maxProgress - (progress[wallet.walletId] ?: 0L)
-            wallet.walletId == activeId || lag <= BALANCED_LAG_THRESHOLD
-        }
+        val (kept, dropped) = balancedFilterAlgorithm(
+            wallets, progress, activeWalletId, BALANCED_LAG_THRESHOLD
+        )
 
         if (dropped.isNotEmpty()) {
+            val maxProgress = progress.values.maxOrNull() ?: 0L
             Log.i(TAG, "BALANCED: dropped ${dropped.size} laggards: " +
                 dropped.map { "${it.walletId}(lag=${maxProgress - (progress[it.walletId] ?: 0L)})" })
         }

--- a/android/app/src/main/java/com/rjnr/pocketnode/data/gateway/GatewayRepository.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/gateway/GatewayRepository.kt
@@ -194,19 +194,14 @@ class GatewayRepository @Inject constructor(
         } else null
 
         when (walletPreferences.getSyncStrategy()) {
-            SyncStrategy.ALL_WALLETS -> registerAllWalletScripts()
+            // BALANCED reads per-wallet syncMode/customBlockHeight inside the loop
+            // (registerAllWalletScripts at L1749), so the locals above are unused here.
+            SyncStrategy.ALL_WALLETS, SyncStrategy.BALANCED -> registerAllWalletScripts()
             SyncStrategy.ACTIVE_ONLY -> registerAccount(
                 syncMode = walletSyncMode,
                 customBlockHeight = walletCustomHeight,
                 savePreference = false
             )
-            SyncStrategy.BALANCED -> {
-                registerAccount(
-                    syncMode = walletSyncMode,
-                    customBlockHeight = walletCustomHeight,
-                    savePreference = false
-                )
-            }
         }
 
         // Emit cached data immediately
@@ -543,7 +538,7 @@ class GatewayRepository @Inject constructor(
         savePreference: Boolean = true
     ): Result<Unit> = runCatching {
         when (walletPreferences.getSyncStrategy()) {
-            SyncStrategy.ALL_WALLETS -> {
+            SyncStrategy.ALL_WALLETS, SyncStrategy.BALANCED -> {
                 registerAllWalletScripts()
                 if (savePreference) {
                     val wId = activeWalletId.ifEmpty { null }
@@ -554,7 +549,7 @@ class GatewayRepository @Inject constructor(
                     walletPreferences.setInitialSyncCompleted(true, walletId = wId)
                 }
             }
-            else -> {
+            SyncStrategy.ACTIVE_ONLY -> {
                 registerAccount(syncMode, customBlockHeight, savePreference).getOrThrow()
             }
         }
@@ -1815,12 +1810,22 @@ class GatewayRepository @Inject constructor(
         }
 
         val allWallets = walletDao.getAll().sortedByDescending { it.lastActiveAt }
-        val wallets = allWallets.take(MAX_CONCURRENT_WALLET_SCRIPTS)
-        if (allWallets.size > wallets.size) {
-            val droppedIds = allWallets.drop(wallets.size).map { it.walletId }
+        val strategy = walletPreferences.getSyncStrategy()
+
+        // Step 1: BALANCED filter runs BEFORE the cap (Q2=A in design).
+        val candidateWallets = if (strategy == SyncStrategy.BALANCED) {
+            applyBalancedFilter(allWallets)
+        } else {
+            allWallets
+        }
+
+        // Step 2: Cap (unchanged behavior for ALL_WALLETS).
+        val wallets = candidateWallets.take(MAX_CONCURRENT_WALLET_SCRIPTS)
+        if (candidateWallets.size > wallets.size) {
+            val droppedIds = candidateWallets.drop(wallets.size).map { it.walletId }
             Log.i(
                 TAG,
-                "ALL_WALLETS: syncing top-${wallets.size} of ${allWallets.size} wallets " +
+                "${strategy.name}: syncing top-${wallets.size} of ${candidateWallets.size} wallets " +
                     "(dropped: $droppedIds)"
             )
         }

--- a/android/app/src/main/java/com/rjnr/pocketnode/data/gateway/GatewayRepository.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/gateway/GatewayRepository.kt
@@ -124,6 +124,21 @@ class GatewayRepository @Inject constructor(
     @Volatile
     private var lastBalancedEligibleSet: Set<String> = emptySet()
 
+    /**
+     * Reverse mapping: lock-script `args` → walletId, populated by setScriptsAndRecord.
+     *
+     * Lets the sync poll fan progress out to every registered wallet, not just the
+     * active one. Without this, non-active wallets' localSavedBlockNumber rows go
+     * stale under BALANCED — the filter then mis-classifies them as laggards based
+     * on stale data, drops them, and they actually fall behind.
+     *
+     * @Volatile because reads (sync poll) and writes (registration) happen on
+     * different coroutine dispatchers. Worst-case torn read = one poll cycle's
+     * progress for a newly-registered wallet is dropped — corrected on next poll.
+     */
+    @Volatile
+    private var scriptArgsToWalletId: Map<String, String> = emptyMap()
+
     // --- Sync progress tracking ---
     private val syncProgressTracker = SyncProgressTracker()
     private var syncPollingJob: Job? = null
@@ -185,10 +200,10 @@ class GatewayRepository @Inject constructor(
     suspend fun setWalletSyncBlock(walletId: String, block: Long, network: NetworkType = currentNetwork) {
         if (walletId.isEmpty()) return
         val now = System.currentTimeMillis()
-        val existing = syncProgressDao.get(walletId, network.name)
-        if (existing != null) {
-            syncProgressDao.updateLocalSaved(walletId, network.name, block, now)
-        } else {
+        // Atomic UPDATE first preserves any concurrently-written lightStartBlockNumber
+        // (e.g. setScriptsAndRecord landing between get and upsert).
+        val rowsUpdated = syncProgressDao.updateLocalSaved(walletId, network.name, block, now)
+        if (rowsUpdated == 0) {
             syncProgressDao.upsert(
                 SyncProgressEntity(
                     walletId = walletId,
@@ -841,36 +856,45 @@ class GatewayRepository @Inject constructor(
             0L
         }
 
-        // Fetch script status — match active wallet's script by lock args
+        // Fetch script status for ALL registered scripts.
         val scriptsJson = LightClientNative.nativeGetScripts()
-        val scriptBlockNumber = if (scriptsJson != null) {
-            val scripts = json.decodeFromString<List<JniScriptStatus>>(scriptsJson)
-            val activeArgs = _walletInfo.value?.script?.args
-            val match = if (activeArgs != null) {
-                scripts.find { it.script.args == activeArgs }
-            } else {
-                scripts.firstOrNull()
-            }
-            match?.blockNumber?.removePrefix("0x")?.toLong(16) ?: 0L
+        val scripts = if (scriptsJson != null) {
+            json.decodeFromString<List<JniScriptStatus>>(scriptsJson)
         } else {
-            0L
+            emptyList()
         }
 
-        // Save sync progress per-wallet if we've made progress.
-        // No fallback to a global key by design: post-multi-wallet migration
-        // (#105 Part B) every progress row is keyed (walletId, network).
-        // If wId is empty (rare cold-start race before activeWalletId is set),
-        // we drop this poll's write — next poll catches up.
-        val wId = activeWalletId
-        if (wId.isNotEmpty() && scriptBlockNumber > getWalletSyncBlock(wId)) {
-            setWalletSyncBlock(wId, scriptBlockNumber)
-            Log.d(TAG, "💾 Saved sync progress: block $scriptBlockNumber (wallet=$wId)")
-
-            // BALANCED: a previously-laggard wallet may now be within threshold.
-            // Re-evaluate eligible set cheaply; only re-register when it changed.
-            if (walletPreferences.getSyncStrategy() == SyncStrategy.BALANCED) {
-                maybeReregisterBalanced()
+        // Persist progress for EVERY registered wallet, not just the active one.
+        // Under BALANCED with 3 wallets registered, the light client advances all
+        // their scripts; if we only saved the active wallet's progress, the others'
+        // localSavedBlockNumber rows would go stale and applyBalancedFilter would
+        // mis-classify them as laggards based on stale data.
+        val mapping = scriptArgsToWalletId
+        var anyUpdated = false
+        scripts.forEach { script ->
+            val walletId = mapping[script.script.args] ?: return@forEach
+            val block = script.blockNumber.removePrefix("0x").toLong(16)
+            if (block > getWalletSyncBlock(walletId)) {
+                setWalletSyncBlock(walletId, block)
+                anyUpdated = true
+                if (walletId == activeWalletId) {
+                    Log.d(TAG, "💾 Saved sync progress: block $block (wallet=$walletId)")
+                }
             }
+        }
+
+        // BALANCED: re-evaluate eligible set once after all updates landed.
+        if (anyUpdated && walletPreferences.getSyncStrategy() == SyncStrategy.BALANCED) {
+            maybeReregisterBalanced()
+        }
+
+        // Active wallet's block for the sync-progress display below.
+        val activeArgs = _walletInfo.value?.script?.args
+        val scriptBlockNumber = if (activeArgs != null) {
+            scripts.find { it.script.args == activeArgs }
+                ?.blockNumber?.removePrefix("0x")?.toLong(16) ?: 0L
+        } else {
+            scripts.firstOrNull()?.blockNumber?.removePrefix("0x")?.toLong(16) ?: 0L
         }
 
         // Log sync progress for debugging
@@ -1789,8 +1813,10 @@ class GatewayRepository @Inject constructor(
         if (!ok) return false
 
         val now = System.currentTimeMillis()
+        val newMapping = mutableMapOf<String, String>()
         statuses.zip(walletIds).forEach { (status, walletId) ->
             if (walletId.isEmpty()) return@forEach
+            newMapping[status.script.args] = walletId
             val startBlock = status.blockNumber.removePrefix("0x").toLong(16)
             // Atomic UPDATE preserves localSavedBlockNumber under concurrent writes
             // from the sync poll's setWalletSyncBlock. Falls through to upsert only
@@ -1809,6 +1835,12 @@ class GatewayRepository @Inject constructor(
                     )
                 )
             }
+        }
+        // ALL replaces the entire registered set; PARTIAL adds to it.
+        scriptArgsToWalletId = if (cmd == LightClientNative.CMD_SET_SCRIPTS_ALL) {
+            newMapping
+        } else {
+            scriptArgsToWalletId + newMapping
         }
         return true
     }
@@ -1858,14 +1890,18 @@ class GatewayRepository @Inject constructor(
      * Caller must already be on a coroutine context.
      */
     private suspend fun maybeReregisterBalanced() {
-        val newSet = applyBalancedFilter(
-            walletDao.getAll().sortedByDescending { it.lastActiveAt }
-        ).map { it.walletId }.toSet()
+        val allWallets = walletDao.getAll().sortedByDescending { it.lastActiveAt }
+        val filtered = applyBalancedFilter(allWallets)
+        val newSet = filtered.map { it.walletId }.toSet()
 
         if (newSet == lastBalancedEligibleSet) return
 
         Log.i(TAG, "BALANCED set changed (was=$lastBalancedEligibleSet, now=$newSet): re-registering")
-        registerAllWalletScripts()  // refreshes lastBalancedEligibleSet via the filter step
+        // Pass through the snapshot we just computed so registerAllWalletScripts
+        // doesn't re-fetch + re-filter (avoids double I/O and a snapshot race
+        // where wallet add/delete between calls would update the cache against
+        // a different set than the comparison was made on).
+        registerAllWalletScripts(preFetchedWallets = allWallets, preFilteredCandidates = filtered)
     }
 
     /**
@@ -1874,22 +1910,29 @@ class GatewayRepository @Inject constructor(
      * across every wallet without requiring a wallet switch.
      *
      * Capped at the 3 most-recently-active wallets to bound resource usage.
+     *
+     * @param preFetchedWallets if non-null, skip the walletDao.getAll() round-trip.
+     * @param preFilteredCandidates if non-null, skip applyBalancedFilter and use this list as the post-filter candidate set.
      */
-    private suspend fun registerAllWalletScripts() {
+    private suspend fun registerAllWalletScripts(
+        preFetchedWallets: List<WalletEntity>? = null,
+        preFilteredCandidates: List<WalletEntity>? = null
+    ) {
         if (!awaitNodeReady()) {
             throw Exception("Node initialization failed")
         }
 
-        val allWallets = walletDao.getAll().sortedByDescending { it.lastActiveAt }
+        val allWallets = preFetchedWallets
+            ?: walletDao.getAll().sortedByDescending { it.lastActiveAt }
         val strategy = walletPreferences.getSyncStrategy()
 
         // Step 1: BALANCED filter runs BEFORE the cap (Q2=A in design).
-        val candidateWallets = if (strategy == SyncStrategy.BALANCED) {
-            val filtered = applyBalancedFilter(allWallets)
-            lastBalancedEligibleSet = filtered.map { it.walletId }.toSet()
-            filtered
-        } else {
-            allWallets
+        val candidateWallets = preFilteredCandidates ?: when (strategy) {
+            SyncStrategy.BALANCED -> applyBalancedFilter(allWallets)
+            else -> allWallets
+        }
+        if (strategy == SyncStrategy.BALANCED) {
+            lastBalancedEligibleSet = candidateWallets.map { it.walletId }.toSet()
         }
 
         // Step 2: Cap (unchanged behavior for ALL_WALLETS).

--- a/android/app/src/main/java/com/rjnr/pocketnode/data/gateway/GatewayRepository.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/gateway/GatewayRepository.kt
@@ -90,6 +90,19 @@ class GatewayRepository @Inject constructor(
     private var activeWalletId: String = walletPreferences.getActiveWalletId() ?: ""
     private var activeWalletType: String = KeyManager.WALLET_TYPE_MNEMONIC
 
+    /**
+     * Cache of the last BALANCED-eligible wallet ID set, so the periodic poll can
+     * cheaply detect whether the eligible set has changed and only re-issue
+     * nativeSetScripts when it actually has.
+     *
+     * @Volatile so concurrent reads (poll path) and writes (wallet switch) don't tear.
+     * Worst-case race = one extra nativeSetScripts call, which is benign.
+     *
+     * MUTATED ONLY BY registerAllWalletScripts. applyBalancedFilter stays pure.
+     */
+    @Volatile
+    private var lastBalancedEligibleSet: Set<String> = emptySet()
+
     // --- Sync progress tracking ---
     private val syncProgressTracker = SyncProgressTracker()
     private var syncPollingJob: Job? = null
@@ -827,6 +840,12 @@ class GatewayRepository @Inject constructor(
         if (wId.isNotEmpty() && scriptBlockNumber > getWalletSyncBlock(wId)) {
             setWalletSyncBlock(wId, scriptBlockNumber)
             Log.d(TAG, "💾 Saved sync progress: block $scriptBlockNumber (wallet=$wId)")
+
+            // BALANCED: a previously-laggard wallet may now be within threshold.
+            // Re-evaluate eligible set cheaply; only re-register when it changed.
+            if (walletPreferences.getSyncStrategy() == SyncStrategy.BALANCED) {
+                maybeReregisterBalanced()
+            }
         }
 
         // Log sync progress for debugging
@@ -1798,6 +1817,22 @@ class GatewayRepository @Inject constructor(
     }
 
     /**
+     * Cheap BALANCED re-evaluation: compute the eligible set, compare to the cached
+     * lastBalancedEligibleSet; only re-issue setScripts when the set changed.
+     * Caller must already be on a coroutine context.
+     */
+    private suspend fun maybeReregisterBalanced() {
+        val newSet = applyBalancedFilter(
+            walletDao.getAll().sortedByDescending { it.lastActiveAt }
+        ).map { it.walletId }.toSet()
+
+        if (newSet == lastBalancedEligibleSet) return
+
+        Log.i(TAG, "BALANCED set changed (was=$lastBalancedEligibleSet, now=$newSet): re-registering")
+        registerAllWalletScripts()  // refreshes lastBalancedEligibleSet via the filter step
+    }
+
+    /**
      * Register lock scripts for ALL wallets with the light client simultaneously.
      * Used when SyncStrategy is ALL_WALLETS — enables balance/transaction tracking
      * across every wallet without requiring a wallet switch.
@@ -1814,7 +1849,9 @@ class GatewayRepository @Inject constructor(
 
         // Step 1: BALANCED filter runs BEFORE the cap (Q2=A in design).
         val candidateWallets = if (strategy == SyncStrategy.BALANCED) {
-            applyBalancedFilter(allWallets)
+            val filtered = applyBalancedFilter(allWallets)
+            lastBalancedEligibleSet = filtered.map { it.walletId }.toSet()
+            filtered
         } else {
             allWallets
         }

--- a/android/app/src/main/java/com/rjnr/pocketnode/data/gateway/GatewayRepository.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/gateway/GatewayRepository.kt
@@ -835,7 +835,11 @@ class GatewayRepository @Inject constructor(
             0L
         }
 
-        // Save sync progress per-wallet if we've made progress
+        // Save sync progress per-wallet if we've made progress.
+        // No fallback to a global key by design: post-multi-wallet migration
+        // (#105 Part B) every progress row is keyed (walletId, network).
+        // If wId is empty (rare cold-start race before activeWalletId is set),
+        // we drop this poll's write — next poll catches up.
         val wId = activeWalletId
         if (wId.isNotEmpty() && scriptBlockNumber > getWalletSyncBlock(wId)) {
             setWalletSyncBlock(wId, scriptBlockNumber)

--- a/android/app/src/main/java/com/rjnr/pocketnode/data/gateway/GatewayRepository.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/gateway/GatewayRepository.kt
@@ -105,6 +105,8 @@ class GatewayRepository @Inject constructor(
             try {
                 // Migrate single-wallet to multi-wallet schema (idempotent, no-op if already done)
                 walletMigrationHelper.migrateIfNeeded()
+                // Copy per-wallet lastSyncedBlock from SharedPreferences to Room sync_progress (#105)
+                walletMigrationHelper.migrateSyncProgressToRoomIfNeeded()
                 // Migrate key material from ESP to Room (one-time, for upgrading users)
                 keyManager.migrateEspToRoomIfNeeded(walletDao)
                 // Delete ESP files after successful migration

--- a/android/app/src/main/java/com/rjnr/pocketnode/data/gateway/GatewayRepository.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/gateway/GatewayRepository.kt
@@ -582,7 +582,7 @@ class GatewayRepository @Inject constructor(
         } else 0L
 
         // Check for existing sync progress to resume from (per-wallet)
-        val savedBlock = walletPreferences.getLastSyncedBlock(walletId = activeWalletId.ifEmpty { null })
+        val savedBlock = getWalletSyncBlock(activeWalletId)
         val existingScriptBlock = getExistingScriptBlock()
 
         val blockNum: String = when {
@@ -624,10 +624,15 @@ class GatewayRepository @Inject constructor(
         Log.d(TAG, "🔄 Sync mode $syncMode: tip=$tipHeight, targetBlock=$finalBlockNum")
 
         val blockNumberHex = "0x${finalBlockNum.toLongOrNull()?.toString(16) ?: "0"}"
-        val jsonStr = buildScriptStatusList(info.script, blockNumberHex)
+        val scriptStatuses = listOf(
+            JniScriptStatus(
+                script = info.script,
+                scriptType = "lock",
+                blockNumber = blockNumberHex
+            )
+        )
 
-        Log.d(TAG, "📡 Calling nativeSetScripts with: $jsonStr")
-        val result = LightClientNative.nativeSetScripts(jsonStr, LightClientNative.CMD_SET_SCRIPTS_ALL)
+        val result = setScriptsAndRecord(scriptStatuses, listOf(activeWalletId), LightClientNative.CMD_SET_SCRIPTS_ALL)
         if (!result) throw Exception("Failed to set scripts")
 
         _isRegistered.value = true
@@ -647,7 +652,7 @@ class GatewayRepository @Inject constructor(
     ): Result<Unit> {
         _isRegistered.value = false
         // Clear saved sync progress when explicitly resyncing (per-wallet)
-        walletPreferences.setLastSyncedBlock(0L, walletId = activeWalletId.ifEmpty { null })
+        setWalletSyncBlock(activeWalletId, 0L)
         return registerAccount(syncMode, customBlockHeight, savePreference = true, forceResync = true)
     }
 
@@ -657,7 +662,7 @@ class GatewayRepository @Inject constructor(
         Log.w(TAG, "Forcing sync reset...")
         // Only clear sync-related preferences for the active wallet, not all preferences
         val wId = activeWalletId.ifEmpty { null }
-        walletPreferences.setLastSyncedBlock(0L, walletId = wId)
+        setWalletSyncBlock(activeWalletId, 0L)
         walletPreferences.setInitialSyncCompleted(false, walletId = wId)
         _isRegistered.value = false
         _balance.value = null
@@ -761,14 +766,15 @@ class GatewayRepository @Inject constructor(
                         Log.d(TAG, "🔄 Rescan from block $rescanFrom (earliest tx at $earliestBlock)")
 
                         val blockNumberHex = "0x${rescanFrom.toString(16)}"
-                        val lockStatus = JniScriptStatus(
-                            script = info.script,
-                            scriptType = "lock",
-                            blockNumber = blockNumberHex
+                        val scriptStatuses = listOf(
+                            JniScriptStatus(
+                                script = info.script,
+                                scriptType = "lock",
+                                blockNumber = blockNumberHex
+                            )
                         )
-                        val jsonStr = json.encodeToString(listOf(lockStatus))
-                        LightClientNative.nativeSetScripts(jsonStr, LightClientNative.CMD_SET_SCRIPTS_PARTIAL)
-                        walletPreferences.setLastSyncedBlock(rescanFrom, walletId = activeWalletId.ifEmpty { null })
+                        setScriptsAndRecord(scriptStatuses, listOf(activeWalletId), LightClientNative.CMD_SET_SCRIPTS_PARTIAL)
+                        setWalletSyncBlock(activeWalletId, rescanFrom)
                         Log.d(TAG, "✅ Rescan triggered (partial) - balance should update on next refresh")
                     }
                 }
@@ -825,10 +831,10 @@ class GatewayRepository @Inject constructor(
         }
 
         // Save sync progress per-wallet if we've made progress
-        val wId = activeWalletId.ifEmpty { null }
-        if (scriptBlockNumber > walletPreferences.getLastSyncedBlock(walletId = wId)) {
-            walletPreferences.setLastSyncedBlock(scriptBlockNumber, walletId = wId)
-            Log.d(TAG, "💾 Saved sync progress: block $scriptBlockNumber (wallet=${wId ?: "global"})")
+        val wId = activeWalletId
+        if (wId.isNotEmpty() && scriptBlockNumber > getWalletSyncBlock(wId)) {
+            setWalletSyncBlock(wId, scriptBlockNumber)
+            Log.d(TAG, "💾 Saved sync progress: block $scriptBlockNumber (wallet=$wId)")
         }
 
         // Log sync progress for debugging
@@ -952,6 +958,7 @@ class GatewayRepository @Inject constructor(
         // sender's wallet info up front — if the user switches wallets during the
         // 5s delay, we must still re-register the script that actually sent.
         val senderInfo = _walletInfo.value
+        val senderWalletId = activeWalletId
         scope.launch {
             try {
                 delay(5000) // Wait a bit for tx to propagate
@@ -964,13 +971,14 @@ class GatewayRepository @Inject constructor(
 
                     val blockNumberHex = "0x${rescanFrom.toString(16)}"
                     // Only register lock script (not DAO type) with PARTIAL mode
-                    val lockStatus = JniScriptStatus(
-                        script = senderInfo.script,
-                        scriptType = "lock",
-                        blockNumber = blockNumberHex
+                    val scriptStatuses = listOf(
+                        JniScriptStatus(
+                            script = senderInfo.script,
+                            scriptType = "lock",
+                            blockNumber = blockNumberHex
+                        )
                     )
-                    val jsonStr = json.encodeToString(listOf(lockStatus))
-                    LightClientNative.nativeSetScripts(jsonStr, LightClientNative.CMD_SET_SCRIPTS_PARTIAL)
+                    setScriptsAndRecord(scriptStatuses, listOf(senderWalletId), LightClientNative.CMD_SET_SCRIPTS_PARTIAL)
                 }
             } catch (e: Exception) {
                 Log.e(TAG, "Failed to re-register script after send: ${e.message}")
@@ -1808,7 +1816,7 @@ class GatewayRepository @Inject constructor(
         // Per-wallet derivation is independent CPU+IO work (Room read for the
         // private key, blake2b hash for the lock script). Run them concurrently
         // so a 5-wallet ALL_WALLETS sync doesn't pay the cost serially.
-        val scriptStatuses = coroutineScope {
+        val pairs = coroutineScope {
             wallets.map { wallet ->
                 async(Dispatchers.IO) {
                     val privateKey = keyManager.getPrivateKeyForWallet(wallet.walletId) ?: run {
@@ -1819,7 +1827,7 @@ class GatewayRepository @Inject constructor(
                     val lockScript = keyManager.deriveLockScript(publicKey)
 
                     // Resume from saved per-wallet progress, or calculate from sync mode if first sync
-                    val savedBlock = walletPreferences.getLastSyncedBlock(walletId = wallet.walletId)
+                    val savedBlock = getWalletSyncBlock(wallet.walletId)
                     val blockNum: String
                     if (savedBlock > 0) {
                         blockNum = savedBlock.toString()
@@ -1842,7 +1850,7 @@ class GatewayRepository @Inject constructor(
                     }
                     val blockNumberHex = "0x${blockNum.toLongOrNull()?.toString(16) ?: "0"}"
 
-                    JniScriptStatus(
+                    wallet.walletId to JniScriptStatus(
                         script = lockScript,
                         scriptType = "lock",
                         blockNumber = blockNumberHex
@@ -1851,14 +1859,15 @@ class GatewayRepository @Inject constructor(
             }.awaitAll().filterNotNull()
         }
 
-        if (scriptStatuses.isEmpty()) {
+        if (pairs.isEmpty()) {
             Log.w(TAG, "registerAllWalletScripts: no scripts to register")
             return
         }
 
-        val jsonStr = json.encodeToString(scriptStatuses)
+        val scriptStatuses = pairs.map { it.second }
+        val walletIds = pairs.map { it.first }
         Log.d(TAG, "Registering ${scriptStatuses.size} wallet scripts with light client")
-        val result = LightClientNative.nativeSetScripts(jsonStr, LightClientNative.CMD_SET_SCRIPTS_ALL)
+        val result = setScriptsAndRecord(scriptStatuses, walletIds, LightClientNative.CMD_SET_SCRIPTS_ALL)
         if (!result) throw Exception("Failed to set scripts for all wallets")
 
         _isRegistered.value = true

--- a/android/app/src/main/java/com/rjnr/pocketnode/data/gateway/GatewayRepository.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/gateway/GatewayRepository.kt
@@ -1739,6 +1739,44 @@ class GatewayRepository @Inject constructor(
     }
 
     /**
+     * Wraps every nativeSetScripts call so lightStartBlockNumber is recorded atomically
+     * with the registration. Preserves existing localSavedBlockNumber when the row exists
+     * (we're updating registration metadata, not progress).
+     *
+     * walletIds must be parallel to statuses — same length, same order. For single-wallet
+     * PARTIAL paths, pass listOf(activeWalletId).
+     */
+    private suspend fun setScriptsAndRecord(
+        statuses: List<JniScriptStatus>,
+        walletIds: List<String>,
+        cmd: Int
+    ): Boolean {
+        require(statuses.size == walletIds.size) {
+            "setScriptsAndRecord: statuses (${statuses.size}) and walletIds (${walletIds.size}) must be parallel"
+        }
+        val jsonStr = json.encodeToString(statuses)
+        val ok = LightClientNative.nativeSetScripts(jsonStr, cmd)
+        if (!ok) return false
+
+        val now = System.currentTimeMillis()
+        statuses.zip(walletIds).forEach { (status, walletId) ->
+            if (walletId.isEmpty()) return@forEach
+            val startBlock = status.blockNumber.removePrefix("0x").toLong(16)
+            val existing = syncProgressDao.get(walletId, currentNetwork.name)
+            syncProgressDao.upsert(
+                SyncProgressEntity(
+                    walletId = walletId,
+                    network = currentNetwork.name,
+                    lightStartBlockNumber = startBlock,
+                    localSavedBlockNumber = existing?.localSavedBlockNumber ?: startBlock,
+                    updatedAt = now
+                )
+            )
+        }
+        return true
+    }
+
+    /**
      * Register lock scripts for ALL wallets with the light client simultaneously.
      * Used when SyncStrategy is ALL_WALLETS — enables balance/transaction tracking
      * across every wallet without requiring a wallet switch.

--- a/android/app/src/main/java/com/rjnr/pocketnode/data/gateway/GatewayRepository.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/gateway/GatewayRepository.kt
@@ -137,7 +137,6 @@ class GatewayRepository @Inject constructor(
     /**
      * Read the last fully-processed block for a wallet on a given network.
      * Returns 0L when no sync_progress row exists (wallet never synced).
-     * Replaces WalletPreferences.getLastSyncedBlock.
      */
     suspend fun getWalletSyncBlock(walletId: String, network: NetworkType = currentNetwork): Long {
         if (walletId.isEmpty()) return 0L
@@ -148,7 +147,6 @@ class GatewayRepository @Inject constructor(
      * Persist the last fully-processed block for a wallet on a given network.
      * If no sync_progress row exists, creates one (lightStartBlockNumber seeded to `block`).
      * If a row exists, updates only `localSavedBlockNumber` and `updatedAt`.
-     * Replaces WalletPreferences.setLastSyncedBlock.
      */
     suspend fun setWalletSyncBlock(walletId: String, block: Long, network: NetworkType = currentNetwork) {
         if (walletId.isEmpty()) return
@@ -661,9 +659,8 @@ class GatewayRepository @Inject constructor(
     suspend fun forceResetSync(): Result<Unit> = runCatching {
         Log.w(TAG, "Forcing sync reset...")
         // Only clear sync-related preferences for the active wallet, not all preferences
-        val wId = activeWalletId.ifEmpty { null }
         setWalletSyncBlock(activeWalletId, 0L)
-        walletPreferences.setInitialSyncCompleted(false, walletId = wId)
+        walletPreferences.setInitialSyncCompleted(false, walletId = activeWalletId.ifEmpty { null })
         _isRegistered.value = false
         _balance.value = null
         registerAccount(SyncMode.RECENT)
@@ -1730,20 +1727,6 @@ class GatewayRepository @Inject constructor(
         val txHash = sendTransaction(tx).getOrThrow()
         Log.d(TAG, "DAO unlock (phase 2) sent: $txHash")
         txHash
-    }
-
-    /**
-     * Build the script status list for registration (lock script only).
-     * DAO cells are discovered via lock script query and filtered locally by type hash,
-     * following the same pattern as Neuron wallet.
-     */
-    private fun buildScriptStatusList(lockScript: Script, blockNumberHex: String): String {
-        val lockStatus = JniScriptStatus(
-            script = lockScript,
-            scriptType = "lock",
-            blockNumber = blockNumberHex
-        )
-        return json.encodeToString(listOf(lockStatus))
     }
 
     /**

--- a/android/app/src/main/java/com/rjnr/pocketnode/data/gateway/GatewayRepository.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/gateway/GatewayRepository.kt
@@ -1768,6 +1768,41 @@ class GatewayRepository @Inject constructor(
     }
 
     /**
+     * BALANCED strategy filter: drop wallets whose localSavedBlockNumber lags the
+     * max-progress wallet by more than BALANCED_LAG_THRESHOLD blocks. Active wallet
+     * always passes regardless of its own lag (otherwise the user's current view stalls).
+     *
+     * Reference = max localSavedBlockNumber across the candidate set, NOT the active
+     * wallet's progress (Q3=B in design): survives wallet-switch correctly.
+     *
+     * Returns input unchanged when wallets.size <= 1.
+     *
+     * MUST stay pure — no cache writes. The lastBalancedEligibleSet cache is owned
+     * by registerAllWalletScripts (Task 14).
+     */
+    private suspend fun applyBalancedFilter(wallets: List<WalletEntity>): List<WalletEntity> {
+        if (wallets.size <= 1) return wallets
+
+        val progress = wallets.associate { wallet ->
+            wallet.walletId to (syncProgressDao.get(wallet.walletId, currentNetwork.name)
+                ?.localSavedBlockNumber ?: 0L)
+        }
+        val maxProgress = progress.values.max()
+        val activeId = activeWalletId
+
+        val (kept, dropped) = wallets.partition { wallet ->
+            val lag = maxProgress - (progress[wallet.walletId] ?: 0L)
+            wallet.walletId == activeId || lag <= BALANCED_LAG_THRESHOLD
+        }
+
+        if (dropped.isNotEmpty()) {
+            Log.i(TAG, "BALANCED: dropped ${dropped.size} laggards: " +
+                dropped.map { "${it.walletId}(lag=${maxProgress - (progress[it.walletId] ?: 0L)})" })
+        }
+        return kept
+    }
+
+    /**
      * Register lock scripts for ALL wallets with the light client simultaneously.
      * Used when SyncStrategy is ALL_WALLETS — enables balance/transaction tracking
      * across every wallet without requiring a wallet switch.
@@ -1941,5 +1976,13 @@ class GatewayRepository @Inject constructor(
         // beyond this are dropped by lastActiveAt descending; the dropped ids are
         // logged so support can diagnose "why isn't wallet X syncing".
         private const val MAX_CONCURRENT_WALLET_SCRIPTS = 3
+
+        /**
+         * Source: Neuron's THRESHOLD_BLOCK_NUMBER_IN_DIFF_WALLET, validated in production for years.
+         * Wallets lagging the max-progress wallet by more than this are dropped from the registered
+         * script set (BALANCED strategy) until the leader's tail catches up.
+         * https://github.com/nervosnetwork/neuron/blob/develop/packages/neuron-wallet/src/block-sync-renderer/sync/light-synchronizer.ts#L22
+         */
+        const val BALANCED_LAG_THRESHOLD = 100_000L
     }
 }

--- a/android/app/src/main/java/com/rjnr/pocketnode/data/gateway/GatewayRepository.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/gateway/GatewayRepository.kt
@@ -5,8 +5,10 @@ import android.util.Log
 import com.rjnr.pocketnode.data.database.AppDatabase
 import com.rjnr.pocketnode.data.database.DatabaseMaintenanceUtil
 import com.rjnr.pocketnode.data.database.dao.HeaderCacheDao
+import com.rjnr.pocketnode.data.database.dao.SyncProgressDao
 import com.rjnr.pocketnode.data.database.dao.WalletDao
 import com.rjnr.pocketnode.data.database.entity.HeaderCacheEntity
+import com.rjnr.pocketnode.data.database.entity.SyncProgressEntity
 import com.rjnr.pocketnode.data.database.entity.WalletEntity
 import com.rjnr.pocketnode.data.gateway.models.*
 import com.rjnr.pocketnode.data.sync.SyncForegroundService
@@ -61,7 +63,8 @@ class GatewayRepository @Inject constructor(
     private val walletMigrationHelper: WalletMigrationHelper,
     private val walletDao: WalletDao,
     private val appDatabase: AppDatabase,
-    private val headerCacheDao: HeaderCacheDao
+    private val headerCacheDao: HeaderCacheDao,
+    private val syncProgressDao: SyncProgressDao
 ) {
     private val _walletInfo = MutableStateFlow<WalletInfo?>(null)
     val walletInfo: StateFlow<WalletInfo?> = _walletInfo.asStateFlow()
@@ -128,6 +131,41 @@ class GatewayRepository @Inject constructor(
                 Log.e(TAG, "Startup sequence failed before node init", e)
                 _nodeReady.value = false
             }
+        }
+    }
+
+    /**
+     * Read the last fully-processed block for a wallet on a given network.
+     * Returns 0L when no sync_progress row exists (wallet never synced).
+     * Replaces WalletPreferences.getLastSyncedBlock.
+     */
+    suspend fun getWalletSyncBlock(walletId: String, network: NetworkType = currentNetwork): Long {
+        if (walletId.isEmpty()) return 0L
+        return syncProgressDao.get(walletId, network.name)?.localSavedBlockNumber ?: 0L
+    }
+
+    /**
+     * Persist the last fully-processed block for a wallet on a given network.
+     * If no sync_progress row exists, creates one (lightStartBlockNumber seeded to `block`).
+     * If a row exists, updates only `localSavedBlockNumber` and `updatedAt`.
+     * Replaces WalletPreferences.setLastSyncedBlock.
+     */
+    suspend fun setWalletSyncBlock(walletId: String, block: Long, network: NetworkType = currentNetwork) {
+        if (walletId.isEmpty()) return
+        val now = System.currentTimeMillis()
+        val existing = syncProgressDao.get(walletId, network.name)
+        if (existing != null) {
+            syncProgressDao.updateLocalSaved(walletId, network.name, block, now)
+        } else {
+            syncProgressDao.upsert(
+                SyncProgressEntity(
+                    walletId = walletId,
+                    network = network.name,
+                    lightStartBlockNumber = block,
+                    localSavedBlockNumber = block,
+                    updatedAt = now
+                )
+            )
         }
     }
 

--- a/android/app/src/main/java/com/rjnr/pocketnode/data/migration/WalletMigrationHelper.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/migration/WalletMigrationHelper.kt
@@ -1,9 +1,13 @@
 package com.rjnr.pocketnode.data.migration
 
 import android.util.Log
+import androidx.room.withTransaction
 import com.rjnr.pocketnode.data.database.AppDatabase
+import com.rjnr.pocketnode.data.database.dao.SyncProgressDao
 import com.rjnr.pocketnode.data.database.dao.WalletDao
+import com.rjnr.pocketnode.data.database.entity.SyncProgressEntity
 import com.rjnr.pocketnode.data.database.entity.WalletEntity
+import com.rjnr.pocketnode.data.gateway.models.NetworkType
 import com.rjnr.pocketnode.data.wallet.KeyManager
 import com.rjnr.pocketnode.data.wallet.WalletPreferences
 import java.util.UUID
@@ -25,7 +29,8 @@ class WalletMigrationHelper @Inject constructor(
     private val walletDao: WalletDao,
     private val keyManager: KeyManager,
     private val walletPreferences: WalletPreferences,
-    private val database: AppDatabase
+    private val database: AppDatabase,
+    private val syncProgressDao: SyncProgressDao
 ) {
     /**
      * Migrate the legacy single-wallet to the multi-wallet Room table.
@@ -80,5 +85,62 @@ class WalletMigrationHelper @Inject constructor(
         } catch (e: Exception) {
             Log.e(TAG, "Migration failed — legacy wallet intact, will retry next launch", e)
         }
+    }
+
+    /**
+     * Idempotent migration: copy per-wallet `lastSyncedBlock` from SharedPreferences
+     * to the v7 `sync_progress` Room table, then delete the prefs keys.
+     * Returns true if the migration ran (regardless of whether rows were written),
+     * false if the guard flag was already set.
+     *
+     * Key format read from SharedPrefs: "${walletId}_${network.lowercase()}_last_synced_block"
+     * (matches WalletPreferences.walletNetworkKey at WalletPreferences.kt:78-79, 144).
+     *
+     * Migrated rows seed `lightStartBlockNumber = localSavedBlockNumber` because
+     * the original start block was never recorded.
+     */
+    suspend fun migrateSyncProgressToRoomIfNeeded(): Boolean {
+        val rawPrefs = walletPreferences.rawPrefs
+        if (rawPrefs.getBoolean(KEY_SYNC_PROGRESS_MIGRATED, false)) return false
+
+        val now = System.currentTimeMillis()
+        val wallets = walletDao.getAll()
+        val networks = listOf(NetworkType.MAINNET, NetworkType.TESTNET)
+
+        database.withTransaction {
+            for (wallet in wallets) {
+                for (net in networks) {
+                    val key = "${wallet.walletId}_${net.name.lowercase()}_last_synced_block"
+                    if (!rawPrefs.contains(key)) continue
+                    val block = rawPrefs.getLong(key, 0L)
+                    if (block <= 0L) continue
+
+                    syncProgressDao.upsert(
+                        SyncProgressEntity(
+                            walletId = wallet.walletId,
+                            network = net.name,
+                            lightStartBlockNumber = block,
+                            localSavedBlockNumber = block,
+                            updatedAt = now
+                        )
+                    )
+                }
+            }
+        }
+
+        val editor = rawPrefs.edit()
+        for (wallet in wallets) {
+            for (net in networks) {
+                editor.remove("${wallet.walletId}_${net.name.lowercase()}_last_synced_block")
+            }
+        }
+        editor.putBoolean(KEY_SYNC_PROGRESS_MIGRATED, true).commit()
+
+        Log.d(TAG, "sync_progress migration complete: ${wallets.size} wallets x ${networks.size} networks")
+        return true
+    }
+
+    companion object {
+        private const val KEY_SYNC_PROGRESS_MIGRATED = "sync_progress_migrated_to_room_v7"
     }
 }

--- a/android/app/src/main/java/com/rjnr/pocketnode/data/migration/WalletMigrationHelper.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/migration/WalletMigrationHelper.kt
@@ -128,6 +128,8 @@ class WalletMigrationHelper @Inject constructor(
             }
         }
 
+        // Always remove every legacy key (even those skipped above for block <= 0):
+        // the entire `*_last_synced_block` prefs namespace is being retired.
         val editor = rawPrefs.edit()
         for (wallet in wallets) {
             for (net in networks) {

--- a/android/app/src/main/java/com/rjnr/pocketnode/data/wallet/WalletPreferences.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/wallet/WalletPreferences.kt
@@ -28,6 +28,14 @@ class WalletPreferences @Inject constructor(
         Context.MODE_PRIVATE
     )
 
+    /**
+     * Internal raw SharedPreferences accessor — DO NOT USE outside the migration package.
+     * Exists only so WalletMigrationHelper can read/delete legacy un-typed keys
+     * during the SharedPrefs → Room sync_progress migration (v6→v7).
+     * Remove this accessor once no migration helper depends on it.
+     */
+    internal val rawPrefs: SharedPreferences get() = prefs
+
     private val _themeMode = MutableStateFlow(readThemeMode())
     val themeModeFlow: StateFlow<ThemeMode> = _themeMode.asStateFlow()
 

--- a/android/app/src/main/java/com/rjnr/pocketnode/data/wallet/WalletPreferences.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/wallet/WalletPreferences.kt
@@ -145,22 +145,6 @@ class WalletPreferences @Inject constructor(
         prefs.edit().putBoolean(key, completed).apply()
     }
 
-    // --- Last synced block ---
-
-    fun getLastSyncedBlock(network: NetworkType? = null, walletId: String? = null): Long {
-        val net = network ?: getSelectedNetwork()
-        val key = if (walletId != null) walletNetworkKey(walletId, net.name, KEY_LAST_SYNCED_BLOCK)
-                  else networkKey(KEY_LAST_SYNCED_BLOCK, net)
-        return prefs.getLong(key, 0L)
-    }
-
-    fun setLastSyncedBlock(blockNumber: Long, network: NetworkType? = null, walletId: String? = null) {
-        val net = network ?: getSelectedNetwork()
-        val key = if (walletId != null) walletNetworkKey(walletId, net.name, KEY_LAST_SYNCED_BLOCK)
-                  else networkKey(KEY_LAST_SYNCED_BLOCK, net)
-        prefs.edit().putLong(key, blockNumber).apply()
-    }
-
     // --- Background sync (global, not per-network) ---
 
     fun isBackgroundSyncEnabled(): Boolean {
@@ -243,13 +227,6 @@ class WalletPreferences @Inject constructor(
             editor.remove(KEY_INITIAL_SYNC_COMPLETED)
         }
 
-        // Migrate last_synced_block
-        if (prefs.contains(KEY_LAST_SYNCED_BLOCK)) {
-            val oldValue = prefs.getLong(KEY_LAST_SYNCED_BLOCK, 0L)
-            editor.putLong("${mainnetPrefix}$KEY_LAST_SYNCED_BLOCK", oldValue)
-            editor.remove(KEY_LAST_SYNCED_BLOCK)
-        }
-
         // Set default network (always, even if no old keys existed)
         editor.putString(KEY_SELECTED_NETWORK, NetworkType.MAINNET.name)
         editor.commit() // Synchronous to ensure migration guard persists before process death
@@ -262,7 +239,6 @@ class WalletPreferences @Inject constructor(
         private const val KEY_SYNC_MODE = "sync_mode"
         private const val KEY_CUSTOM_BLOCK_HEIGHT = "custom_block_height"
         private const val KEY_INITIAL_SYNC_COMPLETED = "initial_sync_completed"
-        private const val KEY_LAST_SYNCED_BLOCK = "last_synced_block"
         private const val KEY_ACTIVE_WALLET_ID = "active_wallet_id"
         private const val KEY_SYNC_STRATEGY = "sync_strategy"
         private const val KEY_THEME_MODE = "theme_mode"

--- a/android/app/src/main/java/com/rjnr/pocketnode/di/AppModule.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/di/AppModule.kt
@@ -137,7 +137,6 @@ object AppModule {
     fun provideKeyMaterialDao(db: AppDatabase): KeyMaterialDao = db.keyMaterialDao()
 
     @Provides
-    @Singleton
     fun provideSyncProgressDao(db: AppDatabase): SyncProgressDao = db.syncProgressDao()
 
     @Provides

--- a/android/app/src/main/java/com/rjnr/pocketnode/di/AppModule.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/di/AppModule.kt
@@ -184,6 +184,7 @@ object AppModule {
         walletMigrationHelper: WalletMigrationHelper,
         walletDao: WalletDao,
         appDatabase: AppDatabase,
-        headerCacheDao: HeaderCacheDao
-    ): GatewayRepository = GatewayRepository(context, keyManager, walletPreferences, json, transactionBuilder, cacheManager, daoSyncManager, walletMigrationHelper, walletDao, appDatabase, headerCacheDao)
+        headerCacheDao: HeaderCacheDao,
+        syncProgressDao: SyncProgressDao
+    ): GatewayRepository = GatewayRepository(context, keyManager, walletPreferences, json, transactionBuilder, cacheManager, daoSyncManager, walletMigrationHelper, walletDao, appDatabase, headerCacheDao, syncProgressDao)
 }

--- a/android/app/src/main/java/com/rjnr/pocketnode/di/AppModule.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/di/AppModule.kt
@@ -13,10 +13,12 @@ import com.rjnr.pocketnode.data.database.MIGRATION_2_3
 import com.rjnr.pocketnode.data.database.MIGRATION_3_4
 import com.rjnr.pocketnode.data.database.MIGRATION_4_5
 import com.rjnr.pocketnode.data.database.MIGRATION_5_6
+import com.rjnr.pocketnode.data.database.MIGRATION_6_7
 import com.rjnr.pocketnode.data.database.dao.BalanceCacheDao
 import com.rjnr.pocketnode.data.database.dao.DaoCellDao
 import com.rjnr.pocketnode.data.database.dao.HeaderCacheDao
 import com.rjnr.pocketnode.data.database.dao.KeyMaterialDao
+import com.rjnr.pocketnode.data.database.dao.SyncProgressDao
 import com.rjnr.pocketnode.data.database.dao.TransactionDao
 import com.rjnr.pocketnode.data.database.dao.WalletDao
 import com.rjnr.pocketnode.data.migration.WalletMigrationHelper
@@ -113,7 +115,7 @@ object AppModule {
     fun provideAppDatabase(@ApplicationContext context: Context): AppDatabase =
         Room.databaseBuilder(context, AppDatabase::class.java, "pocket_node.db")
             .setJournalMode(RoomDatabase.JournalMode.WRITE_AHEAD_LOGGING)
-            .addMigrations(MIGRATION_1_2, MIGRATION_2_3, MIGRATION_3_4, MIGRATION_4_5, MIGRATION_5_6)
+            .addMigrations(MIGRATION_1_2, MIGRATION_2_3, MIGRATION_3_4, MIGRATION_4_5, MIGRATION_5_6, MIGRATION_6_7)
             .build()
 
     @Provides
@@ -133,6 +135,10 @@ object AppModule {
 
     @Provides
     fun provideKeyMaterialDao(db: AppDatabase): KeyMaterialDao = db.keyMaterialDao()
+
+    @Provides
+    @Singleton
+    fun provideSyncProgressDao(db: AppDatabase): SyncProgressDao = db.syncProgressDao()
 
     @Provides
     @Singleton

--- a/android/app/src/test/java/com/rjnr/pocketnode/data/database/MigrationTest.kt
+++ b/android/app/src/test/java/com/rjnr/pocketnode/data/database/MigrationTest.kt
@@ -31,7 +31,7 @@ class MigrationTest {
     fun setup() {
         val context = ApplicationProvider.getApplicationContext<Context>()
         db = Room.inMemoryDatabaseBuilder(context, AppDatabase::class.java)
-            .addMigrations(MIGRATION_1_2, MIGRATION_2_3, MIGRATION_3_4, MIGRATION_4_5)
+            .addMigrations(MIGRATION_1_2, MIGRATION_2_3, MIGRATION_3_4, MIGRATION_4_5, MIGRATION_5_6, MIGRATION_6_7)
             .allowMainThreadQueries()
             .build()
     }
@@ -177,5 +177,22 @@ class MigrationTest {
 
         db.keyMaterialDao().delete("to-delete")
         assertEquals(0, db.keyMaterialDao().count())
+    }
+
+    @Test
+    fun `v7 sync_progress table is accessible and round-trips`() = runTest {
+        val entity = com.rjnr.pocketnode.data.database.entity.SyncProgressEntity(
+            walletId = "w-mig",
+            network = "MAINNET",
+            lightStartBlockNumber = 1000L,
+            localSavedBlockNumber = 1500L,
+            updatedAt = System.currentTimeMillis()
+        )
+        db.syncProgressDao().upsert(entity)
+
+        val r = db.syncProgressDao().get("w-mig", "MAINNET")
+        assertNotNull(r)
+        assertEquals(1500L, r!!.localSavedBlockNumber)
+        assertEquals(1000L, r.lightStartBlockNumber)
     }
 }

--- a/android/app/src/test/java/com/rjnr/pocketnode/data/database/dao/SyncProgressDaoTest.kt
+++ b/android/app/src/test/java/com/rjnr/pocketnode/data/database/dao/SyncProgressDaoTest.kt
@@ -83,11 +83,18 @@ class SyncProgressDaoTest {
     @Test
     fun `updateLocalSaved updates only that field`() = runTest {
         dao.upsert(row(light = 100L, local = 100L, ts = 1L))
-        dao.updateLocalSaved("w-1", "MAINNET", 999L, 5L)
+        val rows = dao.updateLocalSaved("w-1", "MAINNET", 999L, 5L)
+        assertEquals(1, rows)
         val r = dao.get("w-1", "MAINNET")!!
         assertEquals(100L, r.lightStartBlockNumber)        // unchanged
         assertEquals(999L, r.localSavedBlockNumber)
         assertEquals(5L, r.updatedAt)
+    }
+
+    @Test
+    fun `updateLocalSaved returns 0 when row absent`() = runTest {
+        val rows = dao.updateLocalSaved("missing", "MAINNET", 999L, 1L)
+        assertEquals(0, rows)
     }
 
     @Test

--- a/android/app/src/test/java/com/rjnr/pocketnode/data/database/dao/SyncProgressDaoTest.kt
+++ b/android/app/src/test/java/com/rjnr/pocketnode/data/database/dao/SyncProgressDaoTest.kt
@@ -1,0 +1,105 @@
+package com.rjnr.pocketnode.data.database.dao
+
+import android.content.Context
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import com.rjnr.pocketnode.data.database.AppDatabase
+import com.rjnr.pocketnode.data.database.entity.SyncProgressEntity
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Assert.*
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class SyncProgressDaoTest {
+
+    private lateinit var db: AppDatabase
+    private lateinit var dao: SyncProgressDao
+
+    @Before
+    fun setUp() {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        db = Room.inMemoryDatabaseBuilder(context, AppDatabase::class.java)
+            .allowMainThreadQueries()
+            .build()
+        dao = db.syncProgressDao()
+    }
+
+    @After
+    fun tearDown() { db.close() }
+
+    private fun row(
+        walletId: String = "w-1",
+        network: String = "MAINNET",
+        light: Long = 100L,
+        local: Long = 100L,
+        ts: Long = 1_000L
+    ) = SyncProgressEntity(walletId, network, light, local, ts)
+
+    @Test
+    fun `upsert then get returns the row`() = runTest {
+        dao.upsert(row(local = 500L))
+        val r = dao.get("w-1", "MAINNET")
+        assertNotNull(r)
+        assertEquals(500L, r!!.localSavedBlockNumber)
+    }
+
+    @Test
+    fun `get returns null when row absent`() = runTest {
+        assertNull(dao.get("nonexistent", "MAINNET"))
+    }
+
+    @Test
+    fun `upsert replaces on conflict (same PK)`() = runTest {
+        dao.upsert(row(local = 100L, ts = 1L))
+        dao.upsert(row(local = 200L, ts = 2L))
+        val r = dao.get("w-1", "MAINNET")!!
+        assertEquals(200L, r.localSavedBlockNumber)
+        assertEquals(2L, r.updatedAt)
+    }
+
+    @Test
+    fun `same walletId different network are distinct rows`() = runTest {
+        dao.upsert(row(network = "MAINNET", local = 100L))
+        dao.upsert(row(network = "TESTNET", local = 200L))
+        assertEquals(100L, dao.get("w-1", "MAINNET")!!.localSavedBlockNumber)
+        assertEquals(200L, dao.get("w-1", "TESTNET")!!.localSavedBlockNumber)
+    }
+
+    @Test
+    fun `getAllForNetwork returns only rows for that network`() = runTest {
+        dao.upsert(row(walletId = "w-1", network = "MAINNET"))
+        dao.upsert(row(walletId = "w-2", network = "MAINNET"))
+        dao.upsert(row(walletId = "w-3", network = "TESTNET"))
+
+        val mainnet = dao.getAllForNetwork("MAINNET")
+        assertEquals(2, mainnet.size)
+        assertTrue(mainnet.all { it.network == "MAINNET" })
+    }
+
+    @Test
+    fun `updateLocalSaved updates only that field`() = runTest {
+        dao.upsert(row(light = 100L, local = 100L, ts = 1L))
+        dao.updateLocalSaved("w-1", "MAINNET", 999L, 5L)
+        val r = dao.get("w-1", "MAINNET")!!
+        assertEquals(100L, r.lightStartBlockNumber)        // unchanged
+        assertEquals(999L, r.localSavedBlockNumber)
+        assertEquals(5L, r.updatedAt)
+    }
+
+    @Test
+    fun `deleteForWallet removes all networks for that walletId`() = runTest {
+        dao.upsert(row(network = "MAINNET"))
+        dao.upsert(row(network = "TESTNET"))
+        dao.upsert(row(walletId = "w-2", network = "MAINNET"))
+
+        dao.deleteForWallet("w-1")
+
+        assertNull(dao.get("w-1", "MAINNET"))
+        assertNull(dao.get("w-1", "TESTNET"))
+        assertNotNull(dao.get("w-2", "MAINNET"))
+    }
+}

--- a/android/app/src/test/java/com/rjnr/pocketnode/data/database/dao/SyncProgressDaoTest.kt
+++ b/android/app/src/test/java/com/rjnr/pocketnode/data/database/dao/SyncProgressDaoTest.kt
@@ -91,6 +91,25 @@ class SyncProgressDaoTest {
     }
 
     @Test
+    fun `updateLightStart returns 0 when row absent`() = runTest {
+        val rows = dao.updateLightStart("missing", "MAINNET", 999L, 1L)
+        assertEquals(0, rows)
+    }
+
+    @Test
+    fun `updateLightStart updates only lightStartBlockNumber preserving localSavedBlockNumber`() = runTest {
+        dao.upsert(row(light = 100L, local = 500L, ts = 1L))
+
+        val rows = dao.updateLightStart("w-1", "MAINNET", 999L, 5L)
+        assertEquals(1, rows)
+
+        val r = dao.get("w-1", "MAINNET")!!
+        assertEquals(999L, r.lightStartBlockNumber)
+        assertEquals(500L, r.localSavedBlockNumber)   // preserved (closes the race)
+        assertEquals(5L, r.updatedAt)
+    }
+
+    @Test
     fun `deleteForWallet removes all networks for that walletId`() = runTest {
         dao.upsert(row(network = "MAINNET"))
         dao.upsert(row(network = "TESTNET"))

--- a/android/app/src/test/java/com/rjnr/pocketnode/data/gateway/GatewayRepositoryBalancedTest.kt
+++ b/android/app/src/test/java/com/rjnr/pocketnode/data/gateway/GatewayRepositoryBalancedTest.kt
@@ -134,4 +134,16 @@ class GatewayRepositoryBalancedTest {
         val r = filter(listOf(wallet("a"), wallet("b")), activeId = "a")
         assertEquals(listOf("a"), r.map { it.walletId })
     }
+
+    @Test
+    fun `filter helper is deterministic - calling twice with same state returns same set`() = runTest {
+        seedProgress("a", "MAINNET", 1_000_000L)
+        seedProgress("b", "MAINNET", 950_000L)
+        val wallets = listOf(wallet("a"), wallet("b"))
+
+        val first = filter(wallets, activeId = "a")
+        val second = filter(wallets, activeId = "a")
+
+        assertEquals(first.map { it.walletId }, second.map { it.walletId })
+    }
 }

--- a/android/app/src/test/java/com/rjnr/pocketnode/data/gateway/GatewayRepositoryBalancedTest.kt
+++ b/android/app/src/test/java/com/rjnr/pocketnode/data/gateway/GatewayRepositoryBalancedTest.kt
@@ -1,0 +1,137 @@
+package com.rjnr.pocketnode.data.gateway
+
+import android.content.Context
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import com.rjnr.pocketnode.data.database.AppDatabase
+import com.rjnr.pocketnode.data.database.dao.SyncProgressDao
+import com.rjnr.pocketnode.data.database.entity.SyncProgressEntity
+import com.rjnr.pocketnode.data.database.entity.WalletEntity
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Assert.*
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+/**
+ * Unit tests for GatewayRepository.applyBalancedFilter — the function is private,
+ * so we test the algorithm via a thin test-only wrapper that mirrors production logic.
+ *
+ * Tests only the algorithm against the DAO. Production wires this to the
+ * GatewayRepository's `currentNetwork` and `activeWalletId` fields; this helper
+ * substitutes them via parameters. The integration is exercised by manual smoke
+ * (Task 15), which is the cheapest way to cover it — full integration would
+ * require constructing a fake GatewayRepository with stubbed JNI calls.
+ */
+@RunWith(RobolectricTestRunner::class)
+class GatewayRepositoryBalancedTest {
+
+    private lateinit var db: AppDatabase
+    private lateinit var dao: SyncProgressDao
+
+    @Before
+    fun setUp() {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        db = Room.inMemoryDatabaseBuilder(context, AppDatabase::class.java)
+            .allowMainThreadQueries().build()
+        dao = db.syncProgressDao()
+    }
+
+    @After
+    fun tearDown() { db.close() }
+
+    private fun wallet(id: String, lastActiveAt: Long = 0L) = WalletEntity(
+        walletId = id, name = id, type = "mnemonic",
+        derivationPath = "m/44'/309'/0'/0/0", parentWalletId = null,
+        accountIndex = 0, mainnetAddress = "ckb1$id", testnetAddress = "ckt1$id",
+        isActive = false, createdAt = 0L, lastActiveAt = lastActiveAt
+    )
+
+    private suspend fun seedProgress(walletId: String, network: String, block: Long) {
+        dao.upsert(SyncProgressEntity(walletId, network, block, block, 0L))
+    }
+
+    /**
+     * Helper duplicating GatewayRepository.applyBalancedFilter logic for unit testing.
+     * MUST stay byte-equivalent to the production implementation.
+     */
+    private suspend fun filter(
+        wallets: List<WalletEntity>,
+        activeId: String,
+        network: String = "MAINNET",
+        threshold: Long = 100_000L
+    ): List<WalletEntity> {
+        if (wallets.size <= 1) return wallets
+        val progress = wallets.associate { it.walletId to (dao.get(it.walletId, network)?.localSavedBlockNumber ?: 0L) }
+        val maxProgress = progress.values.max()
+        return wallets.filter { wallet ->
+            val lag = maxProgress - (progress[wallet.walletId] ?: 0L)
+            wallet.walletId == activeId || lag <= threshold
+        }
+    }
+
+    @Test
+    fun `single wallet returns input unchanged`() = runTest {
+        val w = listOf(wallet("a"))
+        assertEquals(w, filter(w, activeId = "a"))
+    }
+
+    @Test
+    fun `all wallets within threshold all kept`() = runTest {
+        seedProgress("a", "MAINNET", 1_000_000L)
+        seedProgress("b", "MAINNET", 950_000L)
+        seedProgress("c", "MAINNET", 900_001L)
+        val r = filter(listOf(wallet("a"), wallet("b"), wallet("c")), activeId = "a")
+        assertEquals(3, r.size)
+    }
+
+    @Test
+    fun `laggard dropped when active is leader`() = runTest {
+        seedProgress("a", "MAINNET", 1_000_000L)
+        seedProgress("b", "MAINNET", 500_000L)   // 500k behind
+        val r = filter(listOf(wallet("a"), wallet("b")), activeId = "a")
+        assertEquals(listOf("a"), r.map { it.walletId })
+    }
+
+    @Test
+    fun `active wallet kept even when itself is the laggard`() = runTest {
+        seedProgress("a", "MAINNET", 1_000_000L)
+        seedProgress("b", "MAINNET", 500_000L)
+        val r = filter(listOf(wallet("a"), wallet("b")), activeId = "b")
+        assertEquals(setOf("a", "b"), r.map { it.walletId }.toSet())
+    }
+
+    @Test
+    fun `multiple laggards dropped active kept`() = runTest {
+        seedProgress("a", "MAINNET", 1_000_000L)
+        seedProgress("b", "MAINNET", 500_000L)
+        seedProgress("c", "MAINNET", 400_000L)
+        val r = filter(listOf(wallet("a"), wallet("b"), wallet("c")), activeId = "a")
+        assertEquals(listOf("a"), r.map { it.walletId })
+    }
+
+    @Test
+    fun `no progress rows present all wallets pass`() = runTest {
+        // No upserts to dao
+        val r = filter(listOf(wallet("a"), wallet("b"), wallet("c")), activeId = "a")
+        assertEquals(3, r.size)
+    }
+
+    @Test
+    fun `boundary lag equals threshold kept`() = runTest {
+        seedProgress("a", "MAINNET", 200_000L)
+        seedProgress("b", "MAINNET", 100_000L)   // exactly 100k behind
+        val r = filter(listOf(wallet("a"), wallet("b")), activeId = "a")
+        assertEquals(2, r.size)
+    }
+
+    @Test
+    fun `boundary lag exceeds threshold by one dropped`() = runTest {
+        seedProgress("a", "MAINNET", 200_000L)
+        seedProgress("b", "MAINNET", 99_999L)    // 100_001 behind
+        val r = filter(listOf(wallet("a"), wallet("b")), activeId = "a")
+        assertEquals(listOf("a"), r.map { it.walletId })
+    }
+}

--- a/android/app/src/test/java/com/rjnr/pocketnode/data/gateway/GatewayRepositoryBalancedTest.kt
+++ b/android/app/src/test/java/com/rjnr/pocketnode/data/gateway/GatewayRepositoryBalancedTest.kt
@@ -1,149 +1,130 @@
 package com.rjnr.pocketnode.data.gateway
 
-import android.content.Context
-import androidx.room.Room
-import androidx.test.core.app.ApplicationProvider
-import com.rjnr.pocketnode.data.database.AppDatabase
-import com.rjnr.pocketnode.data.database.dao.SyncProgressDao
-import com.rjnr.pocketnode.data.database.entity.SyncProgressEntity
 import com.rjnr.pocketnode.data.database.entity.WalletEntity
-import kotlinx.coroutines.test.runTest
-import org.junit.After
 import org.junit.Assert.*
-import org.junit.Before
 import org.junit.Test
-import org.junit.runner.RunWith
-import org.robolectric.RobolectricTestRunner
 
 /**
- * Unit tests for GatewayRepository.applyBalancedFilter — the function is private,
- * so we test the algorithm via a thin test-only wrapper that mirrors production logic.
+ * Unit tests for the production BALANCED filter algorithm.
  *
- * Tests only the algorithm against the DAO. Production wires this to the
- * GatewayRepository's `currentNetwork` and `activeWalletId` fields; this helper
- * substitutes them via parameters. The integration is exercised by manual smoke
- * (Task 15), which is the cheapest way to cover it — full integration would
- * require constructing a fake GatewayRepository with stubbed JNI calls.
+ * Calls the top-level `balancedFilterAlgorithm` directly — exercises
+ * production code, not a duplicate. The DAO read + logging wrapper
+ * (GatewayRepository.applyBalancedFilter) is covered by manual smoke
+ * since it requires a full GatewayRepository to construct.
  */
-@RunWith(RobolectricTestRunner::class)
 class GatewayRepositoryBalancedTest {
 
-    private lateinit var db: AppDatabase
-    private lateinit var dao: SyncProgressDao
-
-    @Before
-    fun setUp() {
-        val context = ApplicationProvider.getApplicationContext<Context>()
-        db = Room.inMemoryDatabaseBuilder(context, AppDatabase::class.java)
-            .allowMainThreadQueries().build()
-        dao = db.syncProgressDao()
-    }
-
-    @After
-    fun tearDown() { db.close() }
-
-    private fun wallet(id: String, lastActiveAt: Long = 0L) = WalletEntity(
+    private fun wallet(id: String) = WalletEntity(
         walletId = id, name = id, type = "mnemonic",
         derivationPath = "m/44'/309'/0'/0/0", parentWalletId = null,
         accountIndex = 0, mainnetAddress = "ckb1$id", testnetAddress = "ckt1$id",
-        isActive = false, createdAt = 0L, lastActiveAt = lastActiveAt
+        isActive = false, createdAt = 0L, lastActiveAt = 0L
     )
 
-    private suspend fun seedProgress(walletId: String, network: String, block: Long) {
-        dao.upsert(SyncProgressEntity(walletId, network, block, block, 0L))
-    }
-
-    /**
-     * Helper duplicating GatewayRepository.applyBalancedFilter logic for unit testing.
-     * MUST stay byte-equivalent to the production implementation.
-     */
-    private suspend fun filter(
+    private fun filterKept(
         wallets: List<WalletEntity>,
+        progress: Map<String, Long>,
         activeId: String,
-        network: String = "MAINNET",
         threshold: Long = 100_000L
-    ): List<WalletEntity> {
-        if (wallets.size <= 1) return wallets
-        val progress = wallets.associate { it.walletId to (dao.get(it.walletId, network)?.localSavedBlockNumber ?: 0L) }
-        val maxProgress = progress.values.max()
-        return wallets.filter { wallet ->
-            val lag = maxProgress - (progress[wallet.walletId] ?: 0L)
-            wallet.walletId == activeId || lag <= threshold
-        }
-    }
+    ): List<WalletEntity> = balancedFilterAlgorithm(wallets, progress, activeId, threshold).first
 
     @Test
-    fun `single wallet returns input unchanged`() = runTest {
+    fun `single wallet returns input unchanged`() {
         val w = listOf(wallet("a"))
-        assertEquals(w, filter(w, activeId = "a"))
+        assertEquals(w, filterKept(w, emptyMap(), activeId = "a"))
     }
 
     @Test
-    fun `all wallets within threshold all kept`() = runTest {
-        seedProgress("a", "MAINNET", 1_000_000L)
-        seedProgress("b", "MAINNET", 950_000L)
-        seedProgress("c", "MAINNET", 900_001L)
-        val r = filter(listOf(wallet("a"), wallet("b"), wallet("c")), activeId = "a")
+    fun `all wallets within threshold all kept`() {
+        val r = filterKept(
+            listOf(wallet("a"), wallet("b"), wallet("c")),
+            mapOf("a" to 1_000_000L, "b" to 950_000L, "c" to 900_001L),
+            activeId = "a"
+        )
         assertEquals(3, r.size)
     }
 
     @Test
-    fun `laggard dropped when active is leader`() = runTest {
-        seedProgress("a", "MAINNET", 1_000_000L)
-        seedProgress("b", "MAINNET", 500_000L)   // 500k behind
-        val r = filter(listOf(wallet("a"), wallet("b")), activeId = "a")
+    fun `laggard dropped when active is leader`() {
+        val r = filterKept(
+            listOf(wallet("a"), wallet("b")),
+            mapOf("a" to 1_000_000L, "b" to 500_000L),  // 500k behind
+            activeId = "a"
+        )
         assertEquals(listOf("a"), r.map { it.walletId })
     }
 
     @Test
-    fun `active wallet kept even when itself is the laggard`() = runTest {
-        seedProgress("a", "MAINNET", 1_000_000L)
-        seedProgress("b", "MAINNET", 500_000L)
-        val r = filter(listOf(wallet("a"), wallet("b")), activeId = "b")
+    fun `active wallet kept even when itself is the laggard`() {
+        val r = filterKept(
+            listOf(wallet("a"), wallet("b")),
+            mapOf("a" to 1_000_000L, "b" to 500_000L),
+            activeId = "b"
+        )
         assertEquals(setOf("a", "b"), r.map { it.walletId }.toSet())
     }
 
     @Test
-    fun `multiple laggards dropped active kept`() = runTest {
-        seedProgress("a", "MAINNET", 1_000_000L)
-        seedProgress("b", "MAINNET", 500_000L)
-        seedProgress("c", "MAINNET", 400_000L)
-        val r = filter(listOf(wallet("a"), wallet("b"), wallet("c")), activeId = "a")
+    fun `multiple laggards dropped active kept`() {
+        val r = filterKept(
+            listOf(wallet("a"), wallet("b"), wallet("c")),
+            mapOf("a" to 1_000_000L, "b" to 500_000L, "c" to 400_000L),
+            activeId = "a"
+        )
         assertEquals(listOf("a"), r.map { it.walletId })
     }
 
     @Test
-    fun `no progress rows present all wallets pass`() = runTest {
-        // No upserts to dao
-        val r = filter(listOf(wallet("a"), wallet("b"), wallet("c")), activeId = "a")
+    fun `no progress rows present all wallets pass`() {
+        // Empty progress map → maxProgress=0, every lag=0 → all pass
+        val r = filterKept(
+            listOf(wallet("a"), wallet("b"), wallet("c")),
+            emptyMap(),
+            activeId = "a"
+        )
         assertEquals(3, r.size)
     }
 
     @Test
-    fun `boundary lag equals threshold kept`() = runTest {
-        seedProgress("a", "MAINNET", 200_000L)
-        seedProgress("b", "MAINNET", 100_000L)   // exactly 100k behind
-        val r = filter(listOf(wallet("a"), wallet("b")), activeId = "a")
+    fun `boundary lag equals threshold kept`() {
+        val r = filterKept(
+            listOf(wallet("a"), wallet("b")),
+            mapOf("a" to 200_000L, "b" to 100_000L),  // exactly 100k behind
+            activeId = "a"
+        )
         assertEquals(2, r.size)
     }
 
     @Test
-    fun `boundary lag exceeds threshold by one dropped`() = runTest {
-        seedProgress("a", "MAINNET", 200_000L)
-        seedProgress("b", "MAINNET", 99_999L)    // 100_001 behind
-        val r = filter(listOf(wallet("a"), wallet("b")), activeId = "a")
+    fun `boundary lag exceeds threshold by one dropped`() {
+        val r = filterKept(
+            listOf(wallet("a"), wallet("b")),
+            mapOf("a" to 200_000L, "b" to 99_999L),   // 100_001 behind
+            activeId = "a"
+        )
         assertEquals(listOf("a"), r.map { it.walletId })
     }
 
     @Test
-    fun `filter helper is deterministic - calling twice with same state returns same set`() = runTest {
-        seedProgress("a", "MAINNET", 1_000_000L)
-        seedProgress("b", "MAINNET", 950_000L)
+    fun `algorithm is pure - calling twice with same state returns same set`() {
         val wallets = listOf(wallet("a"), wallet("b"))
+        val progress = mapOf("a" to 1_000_000L, "b" to 950_000L)
 
-        val first = filter(wallets, activeId = "a")
-        val second = filter(wallets, activeId = "a")
+        val first = filterKept(wallets, progress, activeId = "a")
+        val second = filterKept(wallets, progress, activeId = "a")
 
         assertEquals(first.map { it.walletId }, second.map { it.walletId })
+    }
+
+    @Test
+    fun `dropped list contains laggards in original order`() {
+        val (kept, dropped) = balancedFilterAlgorithm(
+            wallets = listOf(wallet("a"), wallet("b"), wallet("c")),
+            progressByWalletId = mapOf("a" to 1_000_000L, "b" to 500_000L, "c" to 600_000L),
+            activeId = "a",
+            threshold = 100_000L
+        )
+        assertEquals(listOf("a"), kept.map { it.walletId })
+        assertEquals(listOf("b", "c"), dropped.map { it.walletId })
     }
 }

--- a/android/app/src/test/java/com/rjnr/pocketnode/data/migration/WalletMigrationHelperTest.kt
+++ b/android/app/src/test/java/com/rjnr/pocketnode/data/migration/WalletMigrationHelperTest.kt
@@ -9,7 +9,10 @@ import com.rjnr.pocketnode.data.database.MIGRATION_1_2
 import com.rjnr.pocketnode.data.database.MIGRATION_2_3
 import com.rjnr.pocketnode.data.database.MIGRATION_3_4
 import com.rjnr.pocketnode.data.database.MIGRATION_4_5
+import com.rjnr.pocketnode.data.database.MIGRATION_5_6
+import com.rjnr.pocketnode.data.database.MIGRATION_6_7
 import com.rjnr.pocketnode.data.database.dao.WalletDao
+import com.rjnr.pocketnode.data.database.entity.WalletEntity
 import com.rjnr.pocketnode.data.wallet.KeyManager
 import com.rjnr.pocketnode.data.wallet.MnemonicManager
 import com.rjnr.pocketnode.data.wallet.WalletPreferences
@@ -34,7 +37,7 @@ class WalletMigrationHelperTest {
     fun setUp() {
         val context = ApplicationProvider.getApplicationContext<Context>()
         db = Room.inMemoryDatabaseBuilder(context, AppDatabase::class.java)
-            .addMigrations(MIGRATION_1_2, MIGRATION_2_3, MIGRATION_3_4, MIGRATION_4_5)
+            .addMigrations(MIGRATION_1_2, MIGRATION_2_3, MIGRATION_3_4, MIGRATION_4_5, MIGRATION_5_6, MIGRATION_6_7)
             .allowMainThreadQueries()
             .build()
         walletDao = db.walletDao()
@@ -44,7 +47,7 @@ class WalletMigrationHelperTest {
         migrationPrefs.edit().clear().commit()
         keyManager.keyStoreMigrationHelper = KeyStoreMigrationHelper(db.keyMaterialDao(), encryptionManager, migrationPrefs)
         walletPreferences = WalletPreferences(context)
-        helper = WalletMigrationHelper(walletDao, keyManager, walletPreferences, db)
+        helper = WalletMigrationHelper(walletDao, keyManager, walletPreferences, db, db.syncProgressDao())
     }
 
     @After
@@ -115,5 +118,92 @@ class WalletMigrationHelperTest {
         val mnemonic = keyManager.getMnemonicForWallet(activeWalletId)
         assertNotNull(mnemonic)
         assertTrue(mnemonic!!.size >= 12)
+    }
+
+    @Test
+    fun `migrateSyncProgressToRoomIfNeeded copies prefs values to Room and deletes prefs keys`() = runTest {
+        // Seed: one wallet, two networks, both with progress in SharedPrefs
+        val walletId = "wallet-mig-1"
+        walletDao.insert(WalletEntity(
+            walletId = walletId, name = "X", type = "mnemonic",
+            derivationPath = "m/44'/309'/0'/0/0", parentWalletId = null,
+            accountIndex = 0, mainnetAddress = "ckb1x", testnetAddress = "ckt1x",
+            isActive = true, createdAt = 0L
+        ))
+        walletPreferences.rawPrefs.edit()
+            .putLong("${walletId}_mainnet_last_synced_block", 12345L)
+            .putLong("${walletId}_testnet_last_synced_block", 678L)
+            .commit()
+
+        // Run migration
+        val ran = helper.migrateSyncProgressToRoomIfNeeded()
+
+        // Assert
+        assertTrue(ran)
+        val mainnet = db.syncProgressDao().get(walletId, "MAINNET")
+        val testnet = db.syncProgressDao().get(walletId, "TESTNET")
+        assertEquals(12345L, mainnet!!.localSavedBlockNumber)
+        assertEquals(12345L, mainnet.lightStartBlockNumber)   // seed = local per Q4=i
+        assertEquals(678L, testnet!!.localSavedBlockNumber)
+        assertEquals(678L, testnet.lightStartBlockNumber)
+
+        // Prefs keys deleted
+        assertFalse(walletPreferences.rawPrefs.contains("${walletId}_mainnet_last_synced_block"))
+        assertFalse(walletPreferences.rawPrefs.contains("${walletId}_testnet_last_synced_block"))
+        // Guard flag set
+        assertTrue(walletPreferences.rawPrefs.getBoolean("sync_progress_migrated_to_room_v7", false))
+    }
+
+    @Test
+    fun `migrateSyncProgressToRoomIfNeeded is no-op on second run`() = runTest {
+        walletPreferences.rawPrefs.edit()
+            .putBoolean("sync_progress_migrated_to_room_v7", true)
+            .commit()
+
+        val ran = helper.migrateSyncProgressToRoomIfNeeded()
+        assertFalse(ran)
+    }
+
+    @Test
+    fun `migrateSyncProgressToRoomIfNeeded skips wallets with no prefs entry`() = runTest {
+        val walletId = "wallet-mig-2"
+        walletDao.insert(WalletEntity(
+            walletId = walletId, name = "Y", type = "mnemonic",
+            derivationPath = "m/44'/309'/0'/0/0", parentWalletId = null,
+            accountIndex = 0, mainnetAddress = "ckb1y", testnetAddress = "ckt1y",
+            isActive = true, createdAt = 0L
+        ))
+        // No prefs seeded
+
+        val ran = helper.migrateSyncProgressToRoomIfNeeded()
+        assertTrue(ran)  // ran (set guard flag), but no rows written
+
+        assertNull(db.syncProgressDao().get(walletId, "MAINNET"))
+        assertNull(db.syncProgressDao().get(walletId, "TESTNET"))
+    }
+
+    @Test
+    fun `migrateSyncProgressToRoomIfNeeded skips entries with non-positive block`() = runTest {
+        val walletId = "wallet-mig-3"
+        walletDao.insert(WalletEntity(
+            walletId = walletId, name = "Z", type = "mnemonic",
+            derivationPath = "m/44'/309'/0'/0/0", parentWalletId = null,
+            accountIndex = 0, mainnetAddress = "ckb1z", testnetAddress = "ckt1z",
+            isActive = true, createdAt = 0L
+        ))
+        walletPreferences.rawPrefs.edit()
+            .putLong("${walletId}_mainnet_last_synced_block", 0L)
+            .commit()
+
+        helper.migrateSyncProgressToRoomIfNeeded()
+        assertNull(db.syncProgressDao().get(walletId, "MAINNET"))
+    }
+
+    @Test
+    fun `migrateSyncProgressToRoomIfNeeded fresh install is no-op`() = runTest {
+        // No wallets, no prefs
+        val ran = helper.migrateSyncProgressToRoomIfNeeded()
+        assertTrue(ran)
+        assertTrue(walletPreferences.rawPrefs.getBoolean("sync_progress_migrated_to_room_v7", false))
     }
 }

--- a/android/app/src/test/java/com/rjnr/pocketnode/data/wallet/WalletPreferencesTest.kt
+++ b/android/app/src/test/java/com/rjnr/pocketnode/data/wallet/WalletPreferencesTest.kt
@@ -103,18 +103,6 @@ class WalletPreferencesTest {
         assertFalse(prefs.hasCompletedInitialSync(NetworkType.TESTNET))
     }
 
-    // --- Per-network isolation: last synced block ---
-
-    @Test
-    fun `last synced block is independent between networks`() {
-        val prefs = newPrefs()
-        prefs.setLastSyncedBlock(18_300_000L, NetworkType.MAINNET)
-        prefs.setLastSyncedBlock(50_000L, NetworkType.TESTNET)
-
-        assertEquals(18_300_000L, prefs.getLastSyncedBlock(NetworkType.MAINNET))
-        assertEquals(50_000L, prefs.getLastSyncedBlock(NetworkType.TESTNET))
-    }
-
     // --- Migration: pre-testnet upgrade path ---
 
     @Test
@@ -151,18 +139,6 @@ class WalletPreferencesTest {
 
         assertTrue(prefs.hasCompletedInitialSync(NetworkType.MAINNET))
         assertFalse(rawPrefs().contains("initial_sync_completed"))
-    }
-
-    @Test
-    fun `migration moves old last_synced_block to mainnet namespace`() {
-        rawPrefs().edit()
-            .putLong("last_synced_block", 18_000_000L)
-            .commit()
-
-        val prefs = newPrefs()
-
-        assertEquals(18_000_000L, prefs.getLastSyncedBlock(NetworkType.MAINNET))
-        assertFalse(rawPrefs().contains("last_synced_block"))
     }
 
     @Test


### PR DESCRIPTION
Closes #105.

Both parts of #105 land together on a single branch (16 commits).

## Summary

**Part B — Migrate per-wallet sync state from SharedPrefs to Room:**
- New `sync_progress` Room table (PK = `walletId, network`) replacing SharedPreferences `<walletId>_<network>_last_synced_block` keys.
- Schema migration v6 → v7 (`MIGRATION_6_7` — `CREATE TABLE` only).
- `WalletMigrationHelper.migrateSyncProgressToRoomIfNeeded()` runs once at app start (called from `GatewayRepository.init { scope.launch }` after the existing legacy migrations), copies prefs values to Room, deletes prefs keys, sets a guard flag. Idempotent under crash retry.
- Migrated rows seed `lightStartBlockNumber = localSavedBlockNumber` (original start block was never recorded — see design Q4=i).
- New `GatewayRepository` facade: `getWalletSyncBlock` / `setWalletSyncBlock`.
- New `setScriptsAndRecord` helper wraps every `nativeSetScripts` call so `lightStartBlockNumber` is recorded atomically with registration. The JNI primitive now has exactly one call site — future authors physically cannot register scripts without recording the start block.
- All 9 prior call sites (4 `nativeSetScripts` + 5 `getLastSyncedBlock`/`setLastSyncedBlock`) rewired.
- Deprecated `WalletPreferences.{get,set}LastSyncedBlock`, `KEY_LAST_SYNCED_BLOCK`, and the dead `migrateIfNeeded()` block removed.

**Part A — Implement BALANCED sync strategy:**
- `SyncStrategy.BALANCED` is no longer a phantom (was falling through to ACTIVE_ONLY).
- `BALANCED_LAG_THRESHOLD = 100_000L` constant — sourced from Neuron's [`THRESHOLD_BLOCK_NUMBER_IN_DIFF_WALLET`](https://github.com/nervosnetwork/neuron/blob/develop/packages/neuron-wallet/src/block-sync-renderer/sync/light-synchronizer.ts#L22), validated in production for years.
- `applyBalancedFilter` (pure): drops wallets whose `localSavedBlockNumber` lags the max-progress wallet by more than 100k blocks. Active wallet always passes. Reference = max progress across all wallets, NOT active wallet's progress (survives wallet-switch correctly per design Q3=B).
- Filter runs BEFORE the existing `MAX_CONCURRENT_WALLET_SCRIPTS=3` cap (design Q2=A).
- `@Volatile lastBalancedEligibleSet: Set<String>` cache (mutated only inside `registerAllWalletScripts`).
- `maybeReregisterBalanced` helper called from sync poll write site — re-evaluates eligibility cheaply; only re-issues `nativeSetScripts` when the eligible set actually changes.

## Test plan

**Unit:**
- [x] `SyncProgressDaoTest` (7) — CRUD, network isolation, PK conflict, partial update
- [x] `MigrationTest` — v7 schema accessible round-trip
- [x] `WalletMigrationHelperTest` (5 new) — fresh, populated, idempotent, skip-empty, skip-zero
- [x] `GatewayRepositoryBalancedTest` (9) — single-wallet, all-pass, single laggard, active-is-laggard, multi-laggard, no-progress-rows, boundary lag == 100k, lag > 100k, determinism
- [x] Full suite: 479 tests pass

**Manual smoke (device, MAINNET):**
- [x] Scenario 1 — Fresh install: migration runs (`0 wallets x 2 networks`), `sync_progress` row appears with `lightStartBlockNumber=19173290`, `localSavedBlockNumber` advancing live in DB Inspector.
- [x] Multi-wallet ALL_WALLETS regression: 3 wallets, all 3 `sync_progress` rows updating, `Registering 3 wallet scripts with light client` log.
- [x] BALANCED filter: `BALANCED: dropped 1 laggards: [410287bf...(lag=193946)]` log observed; subsequent `Registering 2 wallet scripts` confirms filter-then-cap.
- [x] BALANCED active-wallet-pass + cache short-circuit confirmed via additional logs.

## Behavior changes worth flagging for review

1. **Sync poll empty-walletId early-return** (`GatewayRepository.kt` ~L840): pre-branch behavior fell through to a network-namespaced global key when `activeWalletId` was empty; post-branch early-returns. Documented inline. Multi-wallet world has no global key by design.
2. **`setSyncMode` UX bug surfaced (NOT introduced)**: selecting the currently-active sync mode triggers a full resync. Filed as [#108](https://github.com/RaheemJnr/pocket-node/issues/108) for a follow-up 1-line fix.
3. **3rd-wallet white-screen flicker**: filed as [#109](https://github.com/RaheemJnr/pocket-node/issues/109) — needs full crash log capture to diagnose. Pre-existing.

## Out of scope (follow-ups)

- [#106](https://github.com/RaheemJnr/pocket-node/issues/106) — Split `GatewayRepository.kt` (now ~2030 lines) into `SyncCoordinator` + `DaoOperations`.
- [#107](https://github.com/RaheemJnr/pocket-node/issues/107) — Refresh `CLAUDE.md` "Key Files" line counts (drifted significantly).
- Part C of original #105 spec (multi-wallet progress UI + `syncedBlockNumber` column for stuck-detection) → spinning out as a new issue for M4 in a follow-up comment.

## Documentation

Spec + plan saved locally to `docs/superpowers/specs/2026-04-26-sync-progress-room-and-balanced-design.md` and `docs/superpowers/plans/2026-04-26-sync-progress-room-and-balanced.md` (the `docs/` dir is gitignored per repo policy).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-wallet sync progress is now persisted in the app database and sync logic updated to use it; balanced sync strategy refined to filter low-progress wallets while preserving the active wallet.

* **Database Updates**
  * Schema version upgraded (v6 → v7) with an automatic migration to create the new sync-progress table and migrate legacy values.

* **Tests**
  * Added comprehensive tests for migration, DAO operations, and balanced filtering logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->