### PR TITLE
chore: post-#105 cleanup — no-resync guard + rawPrefs encapsulation

### DIFF
--- a/android/app/src/main/java/com/rjnr/pocketnode/data/migration/WalletMigrationHelper.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/migration/WalletMigrationHelper.kt
@@ -100,8 +100,7 @@ class WalletMigrationHelper @Inject constructor(
      * the original start block was never recorded.
      */
     suspend fun migrateSyncProgressToRoomIfNeeded(): Boolean {
-        val rawPrefs = walletPreferences.rawPrefs
-        if (rawPrefs.getBoolean(KEY_SYNC_PROGRESS_MIGRATED, false)) return false
+        if (walletPreferences.isSyncProgressMigratedToRoom()) return false
 
         val now = System.currentTimeMillis()
         val wallets = walletDao.getAll()
@@ -110,11 +109,8 @@ class WalletMigrationHelper @Inject constructor(
         database.withTransaction {
             for (wallet in wallets) {
                 for (net in networks) {
-                    val key = "${wallet.walletId}_${net.name.lowercase()}_last_synced_block"
-                    if (!rawPrefs.contains(key)) continue
-                    val block = rawPrefs.getLong(key, 0L)
-                    if (block <= 0L) continue
-
+                    val block = walletPreferences.getLegacySyncedBlock(wallet.walletId, net)
+                        ?: continue
                     syncProgressDao.upsert(
                         SyncProgressEntity(
                             walletId = wallet.walletId,
@@ -128,21 +124,15 @@ class WalletMigrationHelper @Inject constructor(
             }
         }
 
-        // Always remove every legacy key (even those skipped above for block <= 0):
-        // the entire `*_last_synced_block` prefs namespace is being retired.
-        val editor = rawPrefs.edit()
-        for (wallet in wallets) {
-            for (net in networks) {
-                editor.remove("${wallet.walletId}_${net.name.lowercase()}_last_synced_block")
-            }
-        }
-        editor.putBoolean(KEY_SYNC_PROGRESS_MIGRATED, true).commit()
+        // Atomic: removes every legacy key + sets the guard flag in one commit.
+        // Runs AFTER the Room txn commits so a crash mid-write leaves the guard
+        // unset and the migration retries safely on next launch.
+        walletPreferences.clearLegacySyncedBlocksAndMarkMigrated(
+            wallets.map { it.walletId },
+            networks
+        )
 
         Log.d(TAG, "sync_progress migration complete: ${wallets.size} wallets x ${networks.size} networks")
         return true
-    }
-
-    companion object {
-        private const val KEY_SYNC_PROGRESS_MIGRATED = "sync_progress_migrated_to_room_v7"
     }
 }

--- a/android/app/src/main/java/com/rjnr/pocketnode/data/wallet/WalletPreferences.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/wallet/WalletPreferences.kt
@@ -28,13 +28,44 @@ class WalletPreferences @Inject constructor(
         Context.MODE_PRIVATE
     )
 
+    // --- sync_progress prefs → Room migration (#105 / #112) ---
+    // Self-contained API so SharedPreferences never escapes this class.
+    // Remove these three methods once the migration helper is retired.
+
+    /** True once `migrateSyncProgressToRoomIfNeeded` has run successfully. */
+    internal fun isSyncProgressMigratedToRoom(): Boolean =
+        prefs.getBoolean(KEY_SYNC_PROGRESS_MIGRATED, false)
+
     /**
-     * Internal raw SharedPreferences accessor — DO NOT USE outside the migration package.
-     * Exists only so WalletMigrationHelper can read/delete legacy un-typed keys
-     * during the SharedPrefs → Room sync_progress migration (v6→v7).
-     * Remove this accessor once no migration helper depends on it.
+     * Read a legacy `${walletId}_${network}_last_synced_block` value.
+     * Returns null when the key is absent OR the stored block is <= 0
+     * (placeholder values that should not be migrated).
      */
-    internal val rawPrefs: SharedPreferences get() = prefs
+    internal fun getLegacySyncedBlock(walletId: String, network: NetworkType): Long? {
+        val key = "${walletId}_${network.name.lowercase()}_last_synced_block"
+        if (!prefs.contains(key)) return null
+        val block = prefs.getLong(key, 0L)
+        return if (block > 0L) block else null
+    }
+
+    /**
+     * Atomically remove every legacy `*_last_synced_block` key for the supplied
+     * wallets/networks AND set the migration guard flag in a single commit.
+     * `commit()` (synchronous) so the guard is durable before this method returns —
+     * a crash mid-migration leaves the guard unset and the migration retries safely.
+     */
+    internal fun clearLegacySyncedBlocksAndMarkMigrated(
+        walletIds: List<String>,
+        networks: List<NetworkType>
+    ) {
+        val editor = prefs.edit()
+        for (walletId in walletIds) {
+            for (net in networks) {
+                editor.remove("${walletId}_${net.name.lowercase()}_last_synced_block")
+            }
+        }
+        editor.putBoolean(KEY_SYNC_PROGRESS_MIGRATED, true).commit()
+    }
 
     private val _themeMode = MutableStateFlow(readThemeMode())
     val themeModeFlow: StateFlow<ThemeMode> = _themeMode.asStateFlow()
@@ -244,5 +275,6 @@ class WalletPreferences @Inject constructor(
         private const val KEY_THEME_MODE = "theme_mode"
         private const val KEY_BACKGROUND_SYNC = "background_sync_enabled"
         private const val KEY_LAST_VACUUM_AT = "last_vacuum_at"
+        private const val KEY_SYNC_PROGRESS_MIGRATED = "sync_progress_migrated_to_room_v7"
     }
 }

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/home/HomeViewModel.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/home/HomeViewModel.kt
@@ -342,6 +342,14 @@ class HomeViewModel @Inject constructor(
      * This will re-register with the light client using the new sync settings.
      */
     fun changeSyncMode(syncMode: SyncMode, customBlockHeight: Long? = null) {
+        // No-op when the user re-selects the currently-active mode (no change to
+        // resync against). Without this guard, re-selecting RECENT after a full
+        // sync would wipe progress and re-sync the last 200k blocks. (#108)
+        val current = _uiState.value
+        if (syncMode == current.currentSyncMode && customBlockHeight == current.savedCustomBlockHeight) {
+            Log.d(TAG, "changeSyncMode: same mode + height already active — no-op")
+            return
+        }
         viewModelScope.launch {
             Log.d(TAG, "Changing sync mode to: $syncMode, customBlock: $customBlockHeight")
 

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/settings/SettingsViewModel.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/settings/SettingsViewModel.kt
@@ -116,6 +116,14 @@ class SettingsViewModel @Inject constructor(
 
     fun setSyncMode(mode: SyncMode, customBlockHeight: Long? = null) {
         val previousMode = _uiState.value.syncMode
+        val previousCustom = _uiState.value.savedCustomBlockHeight
+        // No-op when the user re-selects the currently-active mode (no change to
+        // resync against). Without this guard, re-selecting RECENT after a full
+        // sync would wipe progress and re-sync the last 200k blocks. (#108)
+        if (mode == previousMode && customBlockHeight == previousCustom) {
+            _uiState.update { it.copy(showSyncDialog = false) }
+            return
+        }
         _uiState.update { it.copy(syncMode = mode, showSyncDialog = false) }
         viewModelScope.launch {
             repository.resyncAccount(mode, customBlockHeight)

--- a/android/app/src/test/java/com/rjnr/pocketnode/data/migration/WalletMigrationHelperTest.kt
+++ b/android/app/src/test/java/com/rjnr/pocketnode/data/migration/WalletMigrationHelperTest.kt
@@ -33,6 +33,14 @@ class WalletMigrationHelperTest {
     private lateinit var walletPreferences: WalletPreferences
     private lateinit var helper: WalletMigrationHelper
 
+    /**
+     * Direct handle to the same SharedPreferences file WalletPreferences uses.
+     * Used only to seed legacy state (pre-v7 keys) and inspect post-migration
+     * state — production code goes through WalletPreferences' encapsulated API.
+     * Hardcoded name "ckb_wallet_prefs" matches PREFS_NAME in WalletPreferences.
+     */
+    private lateinit var legacyPrefs: android.content.SharedPreferences
+
     @Before
     fun setUp() {
         val context = ApplicationProvider.getApplicationContext<Context>()
@@ -46,6 +54,8 @@ class WalletMigrationHelperTest {
         val migrationPrefs = context.getSharedPreferences("test_wallet_mig", Context.MODE_PRIVATE)
         migrationPrefs.edit().clear().commit()
         keyManager.keyStoreMigrationHelper = KeyStoreMigrationHelper(db.keyMaterialDao(), encryptionManager, migrationPrefs)
+        legacyPrefs = context.getSharedPreferences("ckb_wallet_prefs", Context.MODE_PRIVATE)
+        legacyPrefs.edit().clear().commit()
         walletPreferences = WalletPreferences(context)
         helper = WalletMigrationHelper(walletDao, keyManager, walletPreferences, db, db.syncProgressDao())
     }
@@ -130,7 +140,7 @@ class WalletMigrationHelperTest {
             accountIndex = 0, mainnetAddress = "ckb1x", testnetAddress = "ckt1x",
             isActive = true, createdAt = 0L
         ))
-        walletPreferences.rawPrefs.edit()
+        legacyPrefs.edit()
             .putLong("${walletId}_mainnet_last_synced_block", 12345L)
             .putLong("${walletId}_testnet_last_synced_block", 678L)
             .commit()
@@ -148,15 +158,15 @@ class WalletMigrationHelperTest {
         assertEquals(678L, testnet.lightStartBlockNumber)
 
         // Prefs keys deleted
-        assertFalse(walletPreferences.rawPrefs.contains("${walletId}_mainnet_last_synced_block"))
-        assertFalse(walletPreferences.rawPrefs.contains("${walletId}_testnet_last_synced_block"))
+        assertFalse(legacyPrefs.contains("${walletId}_mainnet_last_synced_block"))
+        assertFalse(legacyPrefs.contains("${walletId}_testnet_last_synced_block"))
         // Guard flag set
-        assertTrue(walletPreferences.rawPrefs.getBoolean("sync_progress_migrated_to_room_v7", false))
+        assertTrue(legacyPrefs.getBoolean("sync_progress_migrated_to_room_v7", false))
     }
 
     @Test
     fun `migrateSyncProgressToRoomIfNeeded is no-op on second run`() = runTest {
-        walletPreferences.rawPrefs.edit()
+        legacyPrefs.edit()
             .putBoolean("sync_progress_migrated_to_room_v7", true)
             .commit()
 
@@ -191,7 +201,7 @@ class WalletMigrationHelperTest {
             accountIndex = 0, mainnetAddress = "ckb1z", testnetAddress = "ckt1z",
             isActive = true, createdAt = 0L
         ))
-        walletPreferences.rawPrefs.edit()
+        legacyPrefs.edit()
             .putLong("${walletId}_mainnet_last_synced_block", 0L)
             .commit()
 
@@ -204,6 +214,6 @@ class WalletMigrationHelperTest {
         // No wallets, no prefs
         val ran = helper.migrateSyncProgressToRoomIfNeeded()
         assertTrue(ran)
-        assertTrue(walletPreferences.rawPrefs.getBoolean("sync_progress_migrated_to_room_v7", false))
+        assertTrue(legacyPrefs.getBoolean("sync_progress_migrated_to_room_v7", false))
     }
 }


### PR DESCRIPTION
Bundled cleanup PR addressing two follow-up issues from the #105 review.

## #108 — No-resync when re-selecting current sync mode

Selecting the currently-active sync mode no longer triggers a full resync. Guard added in both `SettingsViewModel.setSyncMode` and `HomeViewModel.changeSyncMode`: if the requested `(mode, customBlockHeight)` matches current state, the call short-circuits.

Without this, re-tapping `RECENT` after a fully-synced wallet would wipe progress and re-sync the last 200k blocks. Surfaced during #105 manual smoke.

## #112 — `rawPrefs` encapsulation

`WalletPreferences` no longer exposes raw `SharedPreferences`. The `internal val rawPrefs` accessor (added in #105 for the prefs → Room sync_progress migration) had a misleading KDoc warning — Kotlin's `internal` is module-scoped, so any class in `:app` could reach in.

Replaced with three single-purpose methods that keep `SharedPreferences` inside `WalletPreferences`:
- `isSyncProgressMigratedToRoom(): Boolean`
- `getLegacySyncedBlock(walletId, network): Long?`
- `clearLegacySyncedBlocksAndMarkMigrated(walletIds, networks)`

`WalletMigrationHelper.migrateSyncProgressToRoomIfNeeded()` reads cleaner and the migration semantics are now self-documenting in the API names. All three methods can be removed together when the migration helper retires.

## Test changes

`WalletMigrationHelperTest` previously seeded prefs via `walletPreferences.rawPrefs.edit()`. Now opens the same `SharedPreferences` file directly via `Context.getSharedPreferences("ckb_wallet_prefs", ...)` — no test backdoor on production code. Hardcoded prefs name matches `WalletPreferences.PREFS_NAME`; commented in the test.

## Test plan

- [x] Full unit suite passes (482 tests)
- [x] Manual: re-selecting `RECENT` after full sync → no resync log, no DB row mutation (verified locally during #108 root-cause investigation)

## Out of scope

- #107 (CLAUDE.md line counts) — file is gitignored at the repo level, so updates can't ship via PR. Closing #107 separately with explanation.
- #109 (white screen on 3rd wallet add) — needs full crash logcat capture.
- #106 (split GatewayRepository.kt) — large refactor, deserves own session.