### PR TITLE
fix(sync): skip poll iteration when wallet not loaded (silence log spam)

### DIFF
--- a/android/app/src/main/java/com/rjnr/pocketnode/data/gateway/GatewayRepository.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/gateway/GatewayRepository.kt
@@ -2026,6 +2026,17 @@ class GatewayRepository @Inject constructor(
         syncPollingJob = scope.launch {
             Log.d(TAG, "Starting centralized sync polling")
             while (true) {
+                // Skip the iteration when no wallet is loaded into repo state.
+                // Happens during normal lifecycle windows: lock screen (PIN not
+                // entered), brief startup race before wallet decryption, after
+                // session clear on background. Without this guard, getAccountStatus
+                // throws "No wallet" on every poll and floods logcat with stack
+                // traces that look like real errors.
+                if (_walletInfo.value == null) {
+                    delay(5_000L)
+                    continue
+                }
+
                 getAccountStatus()
                     .onSuccess { status ->
                         val syncedBlock = status.syncedToBlock.toLongOrNull() ?: 0L


### PR DESCRIPTION
## Problem

Centralized sync poll spams logcat with `Sync polling: failed to get account status / java.lang.Exception: No wallet` and a full stack trace whenever the wallet isn't loaded into repo state. Happens during normal lifecycle windows:

- **Lock screen** — app foregrounded, PIN/biometric not yet entered, wallet not decrypted into memory
- **Cold-start race** — node starts before wallet load completes
- **Background → foreground** — `clearSession()` wipes `_walletInfo` for security; poll keeps running

The exception is caught by `runCatching` so it's functionally harmless — sync resumes once the wallet loads. But the stack trace looks like a real error and clutters logcat for anyone debugging.

Example from a recent lock-screen session:
```
04-26 22:46:03.082 D GatewayRepository: Starting centralized sync polling
04-26 22:46:03.084 E GatewayRepository: Sync polling: failed to get account status
04-26 22:46:03.084 E GatewayRepository: java.lang.Exception: No wallet
04-26 22:46:03.084 E GatewayRepository:     at com.rjnr.pocketnode.data.gateway.GatewayRepository.getAccountStatus-IoAF18A(GatewayRepository.kt:848)
04-26 22:46:03.084 E GatewayRepository:     at com.rjnr.pocketnode.data.gateway.GatewayRepository$startSyncPolling$1.invokeSuspend(GatewayRepository.kt:2029)
... [10+ frames of coroutine machinery]
```

Repeats every 5s while the wallet is unloaded.

## Fix

Short-circuit the poll body when `_walletInfo.value == null`:

```kotlin
if (_walletInfo.value == null) {
    delay(5_000L)
    continue
}
```

Poll keeps running on its normal cadence; picks back up automatically once the wallet loads. No restart needed, no lifecycle plumbing.

## Test plan

- [x] Full unit suite passes
- [x] Manual: lock device, watch logcat, no more "No wallet" stack traces. Unlock, sync resumes within 5s.

## Out of scope

- Stopping/restarting the polling job around lock/unlock would be cleaner architecturally but invasive (lifecycle wiring across MainActivity + repo). The 5s idle-poll cost is negligible vs the engineering cost; revisit if it shows up in battery profiling.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced unnecessary error messages during app initialization when wallet configuration is pending, ensuring a smoother startup experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->