### PR TITLE
feat: send reliability Phase A — broadcast state machine + cell reservation + watchdog (#115)

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -132,6 +132,7 @@ dependencies {
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.lifecycle.runtime.ktx)
     implementation(libs.androidx.lifecycle.viewmodel.compose)
+    implementation(libs.androidx.lifecycle.process)
     implementation(libs.androidx.activity.compose)
 
     // Compose

--- a/android/app/src/main/java/com/rjnr/pocketnode/CkbWalletApp.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/CkbWalletApp.kt
@@ -1,7 +1,16 @@
 package com.rjnr.pocketnode
 
 import android.app.Application
+import com.rjnr.pocketnode.data.sync.BroadcastWatchdog
 import dagger.hilt.android.HiltAndroidApp
+import javax.inject.Inject
 
 @HiltAndroidApp
-class CkbWalletApp : Application()
+class CkbWalletApp : Application() {
+    @Inject lateinit var broadcastWatchdog: BroadcastWatchdog
+
+    override fun onCreate() {
+        super.onCreate()
+        broadcastWatchdog.start()
+    }
+}

--- a/android/app/src/main/java/com/rjnr/pocketnode/data/database/AppDatabase.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/database/AppDatabase.kt
@@ -6,6 +6,7 @@ import com.rjnr.pocketnode.data.database.dao.BalanceCacheDao
 import com.rjnr.pocketnode.data.database.dao.DaoCellDao
 import com.rjnr.pocketnode.data.database.dao.HeaderCacheDao
 import com.rjnr.pocketnode.data.database.dao.KeyMaterialDao
+import com.rjnr.pocketnode.data.database.dao.PendingBroadcastDao
 import com.rjnr.pocketnode.data.database.dao.SyncProgressDao
 import com.rjnr.pocketnode.data.database.dao.TransactionDao
 import com.rjnr.pocketnode.data.database.dao.WalletDao
@@ -13,6 +14,7 @@ import com.rjnr.pocketnode.data.database.entity.BalanceCacheEntity
 import com.rjnr.pocketnode.data.database.entity.DaoCellEntity
 import com.rjnr.pocketnode.data.database.entity.HeaderCacheEntity
 import com.rjnr.pocketnode.data.database.entity.KeyMaterialEntity
+import com.rjnr.pocketnode.data.database.entity.PendingBroadcastEntity
 import com.rjnr.pocketnode.data.database.entity.SyncProgressEntity
 import com.rjnr.pocketnode.data.database.entity.TransactionEntity
 import com.rjnr.pocketnode.data.database.entity.WalletEntity
@@ -25,9 +27,10 @@ import com.rjnr.pocketnode.data.database.entity.WalletEntity
         DaoCellEntity::class,
         WalletEntity::class,
         KeyMaterialEntity::class,
-        SyncProgressEntity::class
+        SyncProgressEntity::class,
+        PendingBroadcastEntity::class
     ],
-    version = 7,
+    version = 8,
     exportSchema = false
 )
 abstract class AppDatabase : RoomDatabase() {
@@ -38,4 +41,5 @@ abstract class AppDatabase : RoomDatabase() {
     abstract fun walletDao(): WalletDao
     abstract fun keyMaterialDao(): KeyMaterialDao
     abstract fun syncProgressDao(): SyncProgressDao
+    abstract fun pendingBroadcastDao(): PendingBroadcastDao
 }

--- a/android/app/src/main/java/com/rjnr/pocketnode/data/database/Migrations.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/database/Migrations.kt
@@ -216,3 +216,35 @@ val MIGRATION_6_7 = object : Migration(6, 7) {
         )
     }
 }
+
+/**
+ * v7 -> v8: Add pending_broadcasts table for the broadcast state machine (#115).
+ *
+ * Broadcast-state side of the send-reliability fix; the `transactions`
+ * table continues to be the user-facing ledger.
+ */
+val MIGRATION_7_8 = object : Migration(7, 8) {
+    override fun migrate(db: SupportSQLiteDatabase) {
+        db.execSQL(
+            """
+            CREATE TABLE IF NOT EXISTS `pending_broadcasts` (
+                `txHash` TEXT NOT NULL,
+                `walletId` TEXT NOT NULL,
+                `network` TEXT NOT NULL,
+                `signedTxJson` TEXT NOT NULL,
+                `reservedInputs` TEXT NOT NULL,
+                `state` TEXT NOT NULL,
+                `submittedAtTipBlock` INTEGER NOT NULL,
+                `nullCount` INTEGER NOT NULL,
+                `createdAt` INTEGER NOT NULL,
+                `lastCheckedAt` INTEGER NOT NULL,
+                PRIMARY KEY(`txHash`)
+            )
+            """.trimIndent()
+        )
+        db.execSQL(
+            "CREATE INDEX IF NOT EXISTS `idx_pb_wallet_net_state` " +
+                "ON `pending_broadcasts` (`walletId`, `network`, `state`)"
+        )
+    }
+}

--- a/android/app/src/main/java/com/rjnr/pocketnode/data/database/dao/PendingBroadcastDao.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/database/dao/PendingBroadcastDao.kt
@@ -1,0 +1,65 @@
+package com.rjnr.pocketnode.data.database.dao
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import com.rjnr.pocketnode.data.database.entity.PendingBroadcastEntity
+import kotlinx.coroutines.flow.Flow
+
+@Dao
+interface PendingBroadcastDao {
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insert(row: PendingBroadcastEntity)
+
+    /**
+     * CAS update — only writes if current state matches [expected].
+     * Returns rows-affected. Watchdog must check `== 1` before treating
+     * the transition as committed; concurrent tip-event + fallback-timer
+     * checks would otherwise race.
+     */
+    @Query(
+        "UPDATE pending_broadcasts SET state = :next, lastCheckedAt = :now " +
+            "WHERE txHash = :hash AND state = :expected"
+    )
+    suspend fun compareAndUpdateState(
+        hash: String,
+        expected: String,
+        next: String,
+        now: Long
+    ): Int
+
+    @Query(
+        "UPDATE pending_broadcasts SET nullCount = :count, lastCheckedAt = :now WHERE txHash = :hash"
+    )
+    suspend fun updateNullCount(hash: String, count: Int, now: Long)
+
+    @Query("DELETE FROM pending_broadcasts WHERE txHash = :hash")
+    suspend fun delete(hash: String)
+
+    /** Snapshot — for cell-reservation reads inside a mutex-guarded section. */
+    @Query(
+        "SELECT * FROM pending_broadcasts " +
+            "WHERE walletId = :walletId AND network = :network " +
+            "AND state IN ('BROADCASTING','BROADCAST')"
+    )
+    suspend fun getActive(walletId: String, network: String): List<PendingBroadcastEntity>
+
+    /** Flow — UI observation only. */
+    @Query(
+        "SELECT * FROM pending_broadcasts " +
+            "WHERE walletId = :walletId AND network = :network " +
+            "AND state IN ('BROADCASTING','BROADCAST')"
+    )
+    fun observeActive(walletId: String, network: String): Flow<List<PendingBroadcastEntity>>
+
+    @Query(
+        "SELECT * FROM pending_broadcasts " +
+            "WHERE walletId = :walletId AND network = :network AND state = 'FAILED'"
+    )
+    fun observeFailed(walletId: String, network: String): Flow<List<PendingBroadcastEntity>>
+
+    @Query("SELECT * FROM pending_broadcasts WHERE txHash = :hash AND state = 'FAILED'")
+    suspend fun getFailedRow(hash: String): PendingBroadcastEntity?
+}

--- a/android/app/src/main/java/com/rjnr/pocketnode/data/database/dao/TransactionDao.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/database/dao/TransactionDao.kt
@@ -25,6 +25,10 @@ interface TransactionDao {
     @Query("UPDATE transactions SET status = :status, confirmations = :confirmations, blockNumber = :blockNumber, blockHash = :blockHash, isLocal = 0, cachedAt = :cachedAt WHERE txHash = :txHash")
     suspend fun updateStatus(txHash: String, status: String, confirmations: Int, blockNumber: String, blockHash: String, cachedAt: Long = System.currentTimeMillis())
 
+    /** Status-only update used by BroadcastWatchdog (no on-chain fields known yet). */
+    @Query("UPDATE transactions SET status = :status WHERE txHash = :hash")
+    suspend fun updateStatusOnly(hash: String, status: String)
+
     @Query("DELETE FROM transactions WHERE network = :network")
     suspend fun deleteByNetwork(network: String)
 

--- a/android/app/src/main/java/com/rjnr/pocketnode/data/database/dao/TransactionDao.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/database/dao/TransactionDao.kt
@@ -57,6 +57,19 @@ interface TransactionDao {
     @Query("SELECT * FROM transactions WHERE walletId = :walletId AND network = :network AND status IN ('PENDING', 'FAILED')")
     suspend fun getNonConfirmedByWallet(walletId: String, network: String): List<TransactionEntity>
 
+    /**
+     * Legacy PENDING `transactions` rows that have no matching `pending_broadcasts`
+     * entry — i.e. they predate the broadcast state machine (#115). Used at init
+     * to reconcile against the live chain so the user doesn't see stuck-pending
+     * rows from before the fix landed.
+     */
+    @Query(
+        "SELECT txHash FROM transactions " +
+            "WHERE walletId = :walletId AND network = :network AND status = 'PENDING' " +
+            "AND txHash NOT IN (SELECT txHash FROM pending_broadcasts)"
+    )
+    suspend fun getOrphanPendingHashes(walletId: String, network: String): List<String>
+
     @Query("DELETE FROM transactions WHERE walletId = :walletId AND network = :network")
     suspend fun deleteByWalletAndNetwork(walletId: String, network: String)
 

--- a/android/app/src/main/java/com/rjnr/pocketnode/data/database/dao/TransactionDao.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/database/dao/TransactionDao.kt
@@ -28,6 +28,9 @@ interface TransactionDao {
     @Query("DELETE FROM transactions WHERE network = :network")
     suspend fun deleteByNetwork(network: String)
 
+    @Query("DELETE FROM transactions WHERE txHash = :hash")
+    suspend fun deleteByHash(hash: String)
+
     @Query("DELETE FROM transactions")
     suspend fun deleteAll()
 

--- a/android/app/src/main/java/com/rjnr/pocketnode/data/database/dao/TransactionDao.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/database/dao/TransactionDao.kt
@@ -49,6 +49,14 @@ interface TransactionDao {
     @Query("SELECT * FROM transactions WHERE walletId = :walletId AND network = :network AND status = 'PENDING'")
     suspend fun getPendingByWallet(walletId: String, network: String): List<TransactionEntity>
 
+    /**
+     * Pending + Failed local rows. Used to surface non-confirmed activity in
+     * the home list — the JNI feed only carries on-chain (confirmed) txs, so
+     * pending/failed rows must be merged in from cache.
+     */
+    @Query("SELECT * FROM transactions WHERE walletId = :walletId AND network = :network AND status IN ('PENDING', 'FAILED')")
+    suspend fun getNonConfirmedByWallet(walletId: String, network: String): List<TransactionEntity>
+
     @Query("DELETE FROM transactions WHERE walletId = :walletId AND network = :network")
     suspend fun deleteByWalletAndNetwork(walletId: String, network: String)
 

--- a/android/app/src/main/java/com/rjnr/pocketnode/data/database/dao/TransactionDao.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/database/dao/TransactionDao.kt
@@ -25,9 +25,13 @@ interface TransactionDao {
     @Query("UPDATE transactions SET status = :status, confirmations = :confirmations, blockNumber = :blockNumber, blockHash = :blockHash, isLocal = 0, cachedAt = :cachedAt WHERE txHash = :txHash")
     suspend fun updateStatus(txHash: String, status: String, confirmations: Int, blockNumber: String, blockHash: String, cachedAt: Long = System.currentTimeMillis())
 
-    /** Status-only update used by BroadcastWatchdog (no on-chain fields known yet). */
-    @Query("UPDATE transactions SET status = :status WHERE txHash = :hash")
-    suspend fun updateStatusOnly(hash: String, status: String)
+    /**
+     * Status-only update used by BroadcastWatchdog (no on-chain fields known yet).
+     * Bumps `cachedAt` so any TTL/staleness logic treats the transition as fresh —
+     * matches the convention of [updateStatus] above.
+     */
+    @Query("UPDATE transactions SET status = :status, cachedAt = :cachedAt WHERE txHash = :hash")
+    suspend fun updateStatusOnly(hash: String, status: String, cachedAt: Long = System.currentTimeMillis())
 
     @Query("DELETE FROM transactions WHERE network = :network")
     suspend fun deleteByNetwork(network: String)

--- a/android/app/src/main/java/com/rjnr/pocketnode/data/database/entity/PendingBroadcastEntity.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/database/entity/PendingBroadcastEntity.kt
@@ -1,0 +1,39 @@
+package com.rjnr.pocketnode.data.database.entity
+
+import androidx.room.Entity
+import androidx.room.Index
+import androidx.room.PrimaryKey
+
+/**
+ * Broadcast-state row for an in-flight or recently-failed transaction.
+ *
+ * Distinct from `transactions`: that table is the user-facing ledger
+ * record (kept forever); this table is the ephemeral broadcast state
+ * machine (deleted on terminal resolution, except FAILED which is kept
+ * until user dismisses the retry CTA).
+ *
+ * State transitions (CAS in PendingBroadcastDao.compareAndUpdateState):
+ *   BROADCASTING -> BROADCAST     (JNI returned the hash)
+ *   BROADCASTING -> CONFIRMED     (watchdog saw on-chain)
+ *   BROADCASTING -> FAILED        (JNI null/exception; or watchdog null x 3 + tip past +25)
+ *   BROADCAST    -> CONFIRMED     (watchdog saw on-chain)
+ *   BROADCAST    -> FAILED        (watchdog null x 3 + tip past +25)
+ */
+@Entity(
+    tableName = "pending_broadcasts",
+    indices = [
+        Index(value = ["walletId", "network", "state"], name = "idx_pb_wallet_net_state")
+    ]
+)
+data class PendingBroadcastEntity(
+    @PrimaryKey val txHash: String,
+    val walletId: String,
+    val network: String,
+    val signedTxJson: String,
+    val reservedInputs: String,         // JSON-encoded List<OutPoint>
+    val state: String,                  // BROADCASTING | BROADCAST | CONFIRMED | FAILED
+    val submittedAtTipBlock: Long,
+    val nullCount: Int,
+    val createdAt: Long,
+    val lastCheckedAt: Long
+)

--- a/android/app/src/main/java/com/rjnr/pocketnode/data/database/entity/TransactionEntity.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/database/entity/TransactionEntity.kt
@@ -41,7 +41,8 @@ data class TransactionEntity(
         fee = fee,
         confirmations = confirmations,
         blockTimestampHex = blockTimestampHex,
-        isDaoRelated = direction.startsWith("dao_")
+        isDaoRelated = direction.startsWith("dao_"),
+        status = status
     )
 
     companion object {

--- a/android/app/src/main/java/com/rjnr/pocketnode/data/gateway/BroadcastClient.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/gateway/BroadcastClient.kt
@@ -1,0 +1,17 @@
+package com.rjnr.pocketnode.data.gateway
+
+import com.nervosnetwork.ckblightclient.LightClientNative
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/** Indirection over the static JNI bridge so tests can fake it. */
+fun interface BroadcastClient {
+    /** Returns the JNI-returned tx hash JSON string, or null on failure. */
+    suspend fun sendRaw(txJson: String): String?
+}
+
+@Singleton
+class LightClientBroadcastClient @Inject constructor() : BroadcastClient {
+    override suspend fun sendRaw(txJson: String): String? =
+        LightClientNative.nativeSendTransaction(txJson)
+}

--- a/android/app/src/main/java/com/rjnr/pocketnode/data/gateway/CacheManager.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/gateway/CacheManager.kt
@@ -119,6 +119,10 @@ class CacheManager @Inject constructor(
         }
     }
 
+    /** Legacy PENDING `transactions` rows with no `pending_broadcasts` entry (#115). */
+    suspend fun getOrphanPendingHashes(walletId: String, network: String): List<String> =
+        transactionDao.getOrphanPendingHashes(walletId, network)
+
     suspend fun deleteTransaction(txHash: String) {
         try {
             transactionDao.deleteByHash(txHash)

--- a/android/app/src/main/java/com/rjnr/pocketnode/data/gateway/CacheManager.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/gateway/CacheManager.kt
@@ -129,9 +129,15 @@ class CacheManager @Inject constructor(
         }
     }
 
+    /**
+     * Returns local PENDING + FAILED rows not present in [excludeHashes]. Used
+     * by `GatewayRepository.getTransactions` to merge non-confirmed activity
+     * into the JNI-derived (confirmed-only) feed. FAILED rows are written by
+     * `BroadcastWatchdog` after the timeout ladder fires.
+     */
     suspend fun getPendingNotIn(network: String, excludeHashes: Set<String>, walletId: String = ""): List<TransactionRecord> {
         return try {
-            transactionDao.getPendingByWallet(walletId, network)
+            transactionDao.getNonConfirmedByWallet(walletId, network)
                 .filter { it.isLocal && it.txHash !in excludeHashes }
                 .map { it.toTransactionRecord() }
         } catch (e: CancellationException) {

--- a/android/app/src/main/java/com/rjnr/pocketnode/data/gateway/CacheManager.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/gateway/CacheManager.kt
@@ -66,7 +66,14 @@ class CacheManager @Inject constructor(
         }
     }
 
-    suspend fun insertPendingTransaction(txHash: String, network: String, walletId: String = "") {
+    suspend fun insertPendingTransaction(
+        txHash: String,
+        network: String,
+        walletId: String = "",
+        balanceChange: String = "0x0",
+        direction: String = "out",
+        fee: String = "0x0"
+    ) {
         try {
             transactionDao.insert(
                 TransactionEntity(
@@ -74,9 +81,9 @@ class CacheManager @Inject constructor(
                     blockNumber = "",
                     blockHash = "",
                     timestamp = System.currentTimeMillis(),
-                    balanceChange = "0x0",
-                    direction = "out",
-                    fee = "0x186a0",
+                    balanceChange = balanceChange,
+                    direction = direction,
+                    fee = fee,
                     confirmations = 0,
                     blockTimestampHex = null,
                     network = network,
@@ -91,6 +98,16 @@ class CacheManager @Inject constructor(
             throw e
         } catch (e: Exception) {
             Log.w(TAG, "Failed to cache pending tx", e)
+        }
+    }
+
+    suspend fun deleteTransaction(txHash: String) {
+        try {
+            transactionDao.deleteByHash(txHash)
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            Log.w(TAG, "Failed to delete transaction $txHash", e)
         }
     }
 

--- a/android/app/src/main/java/com/rjnr/pocketnode/data/gateway/CacheManager.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/gateway/CacheManager.kt
@@ -110,13 +110,10 @@ class CacheManager @Inject constructor(
     }
 
     override suspend fun updateTransactionStatus(hash: String, status: String) {
-        try {
-            transactionDao.updateStatusOnly(hash, status)
-        } catch (e: CancellationException) {
-            throw e
-        } catch (e: Exception) {
-            Log.w(TAG, "Failed to update tx status for $hash", e)
-        }
+        // Propagate failures — BroadcastWatchdog runs this BEFORE the terminal
+        // CAS specifically so a DB hiccup leaves the pending row recoverable.
+        // Swallowing here would silently break that contract.
+        transactionDao.updateStatusOnly(hash, status)
     }
 
     /** Legacy PENDING `transactions` rows with no `pending_broadcasts` entry (#115). */

--- a/android/app/src/main/java/com/rjnr/pocketnode/data/gateway/CacheManager.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/gateway/CacheManager.kt
@@ -11,11 +11,19 @@ import kotlinx.coroutines.CancellationException
 import javax.inject.Inject
 import javax.inject.Singleton
 
+/**
+ * Narrow surface used by BroadcastWatchdog. Lets tests fake without
+ * mocking the full CacheManager.
+ */
+interface TransactionStatusUpdater {
+    suspend fun updateTransactionStatus(hash: String, status: String)
+}
+
 @Singleton
 class CacheManager @Inject constructor(
     private val transactionDao: TransactionDao,
     private val balanceCacheDao: BalanceCacheDao
-) {
+) : TransactionStatusUpdater {
     // --- Balance cache ---
 
     suspend fun getCachedBalance(network: String, walletId: String = ""): BalanceResponse? {
@@ -98,6 +106,16 @@ class CacheManager @Inject constructor(
             throw e
         } catch (e: Exception) {
             Log.w(TAG, "Failed to cache pending tx", e)
+        }
+    }
+
+    override suspend fun updateTransactionStatus(hash: String, status: String) {
+        try {
+            transactionDao.updateStatusOnly(hash, status)
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            Log.w(TAG, "Failed to update tx status for $hash", e)
         }
     }
 

--- a/android/app/src/main/java/com/rjnr/pocketnode/data/gateway/GatewayRepository.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/gateway/GatewayRepository.kt
@@ -456,6 +456,34 @@ class GatewayRepository @Inject constructor(
                         }
                     }
 
+                    // Legacy reconciliation: PENDING `transactions` rows that predate
+                    // pending_broadcasts have no broadcast row, so the watchdog can't
+                    // see them. Query the light client directly: on chain → CONFIRMED,
+                    // not found → FAILED, in pool → leave alone (the natural pending state).
+                    // (#115 — addresses the user's "old ghosts still showing pending" case.)
+                    runCatching {
+                        val orphanHashes = cacheManager.getOrphanPendingHashes(activeWalletId, currentNetwork.name)
+                        if (orphanHashes.isNotEmpty()) {
+                            Log.w(TAG, "Legacy reconcile: ${orphanHashes.size} orphan PENDING tx(s) on ${currentNetwork.name}")
+                            scope.launch {
+                                delay(15_000) // give light client time to be ready
+                                for (hash in orphanHashes) {
+                                    val resp = getTransactionStatus(hash).getOrNull()
+                                    val newStatus = when {
+                                        resp == null -> "FAILED"
+                                        resp.status == "unknown" -> "FAILED"
+                                        resp.blockHash != null -> "CONFIRMED"
+                                        else -> null  // still in pool — leave PENDING
+                                    }
+                                    if (newStatus != null) {
+                                        cacheManager.updateTransactionStatus(hash, newStatus)
+                                        Log.d(TAG, "Legacy reconcile: $hash → $newStatus")
+                                    }
+                                }
+                            }
+                        }
+                    }
+
                     startSyncPolling()
                     startBackgroundSync()
                     return

--- a/android/app/src/main/java/com/rjnr/pocketnode/data/gateway/GatewayRepository.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/gateway/GatewayRepository.kt
@@ -1099,10 +1099,44 @@ class GatewayRepository @Inject constructor(
             val reserved: Set<OutPoint> = pending
                 .flatMap { json.decodeFromString<List<OutPoint>>(it.reservedInputs) }
                 .toSet()
-            val filtered = cellsResult.items.filter { it.outPoint !in reserved }
+            val liveFiltered = cellsResult.items.filter { it.outPoint !in reserved }
+
+            // Synthesize predicted change-output cells from in-flight broadcasts.
+            // Without this, rapid sequential sends exhaust live cells before the
+            // light client has synced the change outputs of prior sends — the
+            // observed "Not enough funds available" failure mode.
+            // We include each output of every active pending tx whose lock script
+            // matches the sender's lock (= change output going back to us).
+            // If a pending tx ultimately FAILs, downstream txs that consumed its
+            // synthetic change will also fail and the watchdog times them out.
+            val pendingChange: List<Cell> = pending.flatMap { row ->
+                val pendingTx = try {
+                    json.decodeFromString<Transaction>(row.signedTxJson)
+                } catch (e: Exception) {
+                    return@flatMap emptyList<Cell>()
+                }
+                pendingTx.cellOutputs.mapIndexedNotNull { idx, output ->
+                    val outAddr = try {
+                        AddressUtils.encode(output.lock, currentNetwork)
+                    } catch (e: Exception) {
+                        return@mapIndexedNotNull null
+                    }
+                    if (outAddr != fromAddress) return@mapIndexedNotNull null
+                    Cell(
+                        outPoint = OutPoint(row.txHash, "0x${idx.toString(16)}"),
+                        capacity = output.capacity,
+                        blockNumber = "0x0", // synthetic — not on chain yet
+                        lock = output.lock,
+                        type = output.type,
+                        data = "0x"
+                    )
+                }
+            }
+            val filtered = liveFiltered + pendingChange
             Log.d(
                 TAG,
-                "prepareAndSend: ${cellsResult.items.size} cells, ${reserved.size} reserved, ${filtered.size} available"
+                "prepareAndSend: ${cellsResult.items.size} live, ${reserved.size} reserved, " +
+                    "${pendingChange.size} synthetic-change, ${filtered.size} available"
             )
 
             val signed = transactionBuilder.buildTransfer(
@@ -1119,12 +1153,14 @@ class GatewayRepository @Inject constructor(
             val reservedJson = json.encodeToString(signed.cellInputs.map { it.previousOutput })
             val now = System.currentTimeMillis()
 
-            // Compute outgoing amount for activity-row balanceChange — same heuristic
-            // as sendTransaction (smallest-output is recipient for normal transfers).
+            // Outgoing amount for activity-row balanceChange. Stored as POSITIVE
+            // hex per existing convention; `direction = "out"` carries the sign
+            // for the UI. (Prior code used "-0x..." which broke capacityAsLong's
+            // hex parser and rendered as 0.)
             val outgoingAmount = signed.cellOutputs
                 .minOfOrNull { it.capacity.removePrefix("0x").toLong(16) }
                 ?: amountShannons
-            val balanceChangeHex = "-0x${outgoingAmount.toString(16)}"
+            val balanceChangeHex = "0x${outgoingAmount.toString(16)}"
 
             pendingBroadcastDao.insert(
                 PendingBroadcastEntity(
@@ -1212,7 +1248,8 @@ class GatewayRepository @Inject constructor(
         val outgoingAmount = transaction.cellOutputs
             .minOfOrNull { it.capacity.removePrefix("0x").toLong(16) }
             ?: 0L
-        val balanceChangeHex = "-0x${outgoingAmount.toString(16)}"
+        // Positive hex per existing convention; `direction = "out"` carries sign.
+        val balanceChangeHex = "0x${outgoingAmount.toString(16)}"
         val now = System.currentTimeMillis()
 
         Log.d(TAG, "📤 sendTransaction: JSON length=${txJson.length}, preHash=$txHash")

--- a/android/app/src/main/java/com/rjnr/pocketnode/data/gateway/GatewayRepository.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/gateway/GatewayRepository.kt
@@ -1002,6 +1002,91 @@ class GatewayRepository @Inject constructor(
         0L
     }
 
+    /**
+     * Single mutex-guarded prepare-and-send. Runs cell-fetch, reservation
+     * filter, build, sign, and pre-broadcast persistence all inside
+     * [sendMutex] — closing the read-filter-insert race that would
+     * otherwise let two rapid sends pick the same input cells (#115).
+     *
+     * The JNI broadcast call happens AFTER the mutex is released —
+     * locking that would needlessly serialize all sends. [sendTransaction]
+     * is idempotent on the pre-inserted hash, so it skips the duplicate
+     * insert and just performs the broadcast + post-broadcast CAS.
+     */
+    suspend fun prepareAndSend(
+        fromAddress: String,
+        toAddress: String,
+        amountShannons: Long,
+        privateKey: ByteArray
+    ): Result<String> = runCatching {
+        val walletId = activeWalletId
+        val network = currentNetwork.name
+        val tipNumber = currentTipNumberOrZero()
+
+        val signedTx = sendMutex.withLock {
+            val cellsResult = getCells(fromAddress).getOrThrow()
+            val pending = pendingBroadcastDao.getActive(walletId, network)
+            val reserved: Set<OutPoint> = pending
+                .flatMap { json.decodeFromString<List<OutPoint>>(it.reservedInputs) }
+                .toSet()
+            val filtered = cellsResult.items.filter { it.outPoint !in reserved }
+            Log.d(
+                TAG,
+                "prepareAndSend: ${cellsResult.items.size} cells, ${reserved.size} reserved, ${filtered.size} available"
+            )
+
+            val signed = transactionBuilder.buildTransfer(
+                fromAddress = fromAddress,
+                toAddress = toAddress,
+                amountShannons = amountShannons,
+                availableCells = filtered,
+                privateKey = privateKey,
+                network = currentNetwork
+            )
+
+            val txHash = transactionBuilder.computeTxHash(signed)
+            val txJson = json.encodeToString(signed)
+            val reservedJson = json.encodeToString(signed.cellInputs.map { it.previousOutput })
+            val now = System.currentTimeMillis()
+
+            // Compute outgoing amount for activity-row balanceChange — same heuristic
+            // as sendTransaction (smallest-output is recipient for normal transfers).
+            val outgoingAmount = signed.cellOutputs
+                .minOfOrNull { it.capacity.removePrefix("0x").toLong(16) }
+                ?: amountShannons
+            val balanceChangeHex = "-0x${outgoingAmount.toString(16)}"
+
+            pendingBroadcastDao.insert(
+                PendingBroadcastEntity(
+                    txHash = txHash,
+                    walletId = walletId,
+                    network = network,
+                    signedTxJson = txJson,
+                    reservedInputs = reservedJson,
+                    state = "BROADCASTING",
+                    submittedAtTipBlock = tipNumber,
+                    nullCount = 0,
+                    createdAt = now,
+                    lastCheckedAt = now
+                )
+            )
+            cacheManager.insertPendingTransaction(
+                txHash = txHash,
+                network = network,
+                walletId = walletId,
+                balanceChange = balanceChangeHex,
+                direction = "out",
+                fee = "0x0"
+            )
+            signed
+        }
+
+        // sendTransaction owns the JNI call + post-broadcast CAS.
+        // Its insert path is idempotent: it sees the row we just inserted
+        // and skips re-insertion, then performs broadcast + state CAS.
+        sendTransaction(signedTx).getOrThrow()
+    }
+
     suspend fun sendTransaction(transaction: Transaction): Result<String> = runCatching {
         Log.d(TAG, "📤 sendTransaction: building JSON")
         Log.d(TAG, "  Inputs: ${transaction.cellInputs.size}, Outputs: ${transaction.cellOutputs.size}")

--- a/android/app/src/main/java/com/rjnr/pocketnode/data/gateway/GatewayRepository.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/gateway/GatewayRepository.kt
@@ -429,6 +429,23 @@ class GatewayRepository @Inject constructor(
                 if (startResult) {
                     Log.d(TAG, "Node started successfully on ${targetNetwork.name} (attempt $attempt)")
                     _nodeReady.value = true
+
+                    // Cold-start recovery: surface any BROADCASTING orphan rows for the
+                    // active network so the watchdog can resolve them on the next tip.
+                    // Network-scoped — LightClientNative is per-network; querying for a
+                    // hash on a network whose light client isn't running would return null
+                    // spuriously and drive valid orphans to a false FAILED. (#115 §5)
+                    runCatching {
+                        val orphans = pendingBroadcastDao.getActive(activeWalletId, currentNetwork.name)
+                        val broadcasting = orphans.count { it.state == "BROADCASTING" }
+                        if (broadcasting > 0) {
+                            Log.w(
+                                TAG,
+                                "Cold-start: $broadcasting BROADCASTING orphan(s) on ${currentNetwork.name}; watchdog will resolve"
+                            )
+                        }
+                    }
+
                     startSyncPolling()
                     startBackgroundSync()
                     return

--- a/android/app/src/main/java/com/rjnr/pocketnode/data/gateway/GatewayRepository.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/gateway/GatewayRepository.kt
@@ -468,9 +468,15 @@ class GatewayRepository @Inject constructor(
                             scope.launch {
                                 delay(15_000) // give light client time to be ready
                                 for (hash in orphanHashes) {
-                                    val resp = getTransactionStatus(hash).getOrNull()
+                                    val result = getTransactionStatus(hash)
+                                    // Distinguish transient lookup failure (Result.failure) from
+                                    // a successful "unknown" response. Only the latter means the
+                                    // light client knows it doesn't have the tx; the former is a
+                                    // JNI/RPC hiccup and must NOT permanently mark the row FAILED.
+                                    val resp = result.getOrNull()
                                     val newStatus = when {
-                                        resp == null -> "FAILED"
+                                        result.isFailure -> null      // transient — retry next init
+                                        resp == null -> null           // defensive
                                         resp.status == "unknown" -> "FAILED"
                                         resp.blockHash != null -> "CONFIRMED"
                                         else -> null  // still in pool — leave PENDING

--- a/android/app/src/main/java/com/rjnr/pocketnode/data/gateway/GatewayRepository.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/gateway/GatewayRepository.kt
@@ -5,9 +5,11 @@ import android.util.Log
 import com.rjnr.pocketnode.data.database.AppDatabase
 import com.rjnr.pocketnode.data.database.DatabaseMaintenanceUtil
 import com.rjnr.pocketnode.data.database.dao.HeaderCacheDao
+import com.rjnr.pocketnode.data.database.dao.PendingBroadcastDao
 import com.rjnr.pocketnode.data.database.dao.SyncProgressDao
 import com.rjnr.pocketnode.data.database.dao.WalletDao
 import com.rjnr.pocketnode.data.database.entity.HeaderCacheEntity
+import com.rjnr.pocketnode.data.database.entity.PendingBroadcastEntity
 import com.rjnr.pocketnode.data.database.entity.SyncProgressEntity
 import com.rjnr.pocketnode.data.database.entity.WalletEntity
 import com.rjnr.pocketnode.data.gateway.models.*
@@ -34,6 +36,8 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
@@ -85,8 +89,12 @@ class GatewayRepository @Inject constructor(
     private val walletDao: WalletDao,
     private val appDatabase: AppDatabase,
     private val headerCacheDao: HeaderCacheDao,
-    private val syncProgressDao: SyncProgressDao
+    private val syncProgressDao: SyncProgressDao,
+    private val pendingBroadcastDao: PendingBroadcastDao,
+    private val broadcastClient: BroadcastClient
 ) {
+    private val sendMutex = Mutex()
+
     private val _walletInfo = MutableStateFlow<WalletInfo?>(null)
     val walletInfo: StateFlow<WalletInfo?> = _walletInfo.asStateFlow()
 
@@ -985,8 +993,17 @@ class GatewayRepository @Inject constructor(
         CellsResponse(liveCells, pag.lastCursor)
     }
 
+    private suspend fun currentTipNumberOrZero(): Long = try {
+        val tipStr = LightClientNative.nativeGetTipHeader() ?: return 0L
+        val tip = json.decodeFromString<JniHeaderView>(tipStr)
+        tip.number.removePrefix("0x").toLong(16)
+    } catch (e: Exception) {
+        Log.w(TAG, "currentTipNumberOrZero failed: ${e.message}")
+        0L
+    }
+
     suspend fun sendTransaction(transaction: Transaction): Result<String> = runCatching {
-        Log.d(TAG, "📤 sendTransaction: Building transaction JSON...")
+        Log.d(TAG, "📤 sendTransaction: building JSON")
         Log.d(TAG, "  Inputs: ${transaction.cellInputs.size}, Outputs: ${transaction.cellOutputs.size}")
 
         // Pre-flight checks (defense-in-depth, TransactionBuilder also validates)
@@ -999,19 +1016,120 @@ class GatewayRepository @Inject constructor(
             }
         }
 
+        // Snapshot at entry — pin to whichever wallet/network the user was on.
+        val walletId = activeWalletId
+        val network = currentNetwork.name
+        val tipNumber = currentTipNumberOrZero()
         val txJson = json.encodeToString(transaction)
-        Log.d(TAG, "📤 sendTransaction: JSON length=${txJson.length}")
-        Log.d(TAG, "📤 sendTransaction: JSON preview: ${txJson.take(300)}...")
+        val txHash = transactionBuilder.computeTxHash(transaction)
+        val reservedJson = json.encodeToString(
+            transaction.cellInputs.map { it.previousOutput }
+        )
 
-        val rawResult = LightClientNative.nativeSendTransaction(txJson)
-            ?: throw Exception("Send failed - native returned null")
+        // Compute balanceChange = -(smallest output) for the activity row.
+        // For a normal transfer the smallest output is the recipient; for a
+        // "send all" there's only one output. Either way: smallest by capacity.
+        val outgoingAmount = transaction.cellOutputs
+            .minOfOrNull { it.capacity.removePrefix("0x").toLong(16) }
+            ?: 0L
+        val balanceChangeHex = "-0x${outgoingAmount.toString(16)}"
+        val now = System.currentTimeMillis()
 
-        // The Rust JNI returns the tx hash as a JSON string (with quotes), so we need to parse it
-        val txHash = rawResult.trim('"')
-        Log.d(TAG, "✅ sendTransaction: Success! txHash=$txHash (raw: $rawResult)")
+        Log.d(TAG, "📤 sendTransaction: JSON length=${txJson.length}, preHash=$txHash")
 
-        // Cache pending transaction in Room
-        cacheManager.insertPendingTransaction(txHash, currentNetwork.name, walletId = activeWalletId)
+        // Critical section: pre-broadcast inserts under sendMutex.
+        // Idempotent: skip insert if a row already exists for this hash
+        // (Task 3's prepareAndSend pre-inserts under its own mutex hold).
+        sendMutex.withLock {
+            val existing = pendingBroadcastDao.getActive(walletId, network)
+                .firstOrNull { it.txHash == txHash }
+            if (existing == null) {
+                pendingBroadcastDao.insert(
+                    PendingBroadcastEntity(
+                        txHash = txHash,
+                        walletId = walletId,
+                        network = network,
+                        signedTxJson = txJson,
+                        reservedInputs = reservedJson,
+                        state = "BROADCASTING",
+                        submittedAtTipBlock = tipNumber,
+                        nullCount = 0,
+                        createdAt = now,
+                        lastCheckedAt = now
+                    )
+                )
+                cacheManager.insertPendingTransaction(
+                    txHash = txHash,
+                    network = network,
+                    walletId = walletId,
+                    balanceChange = balanceChangeHex,
+                    direction = "out",
+                    fee = "0x0"
+                )
+            } else {
+                Log.d(TAG, "sendTransaction: row exists (state=${existing.state}) — skipping insert")
+            }
+        }
+
+        // JNI broadcast — outside the mutex (long-running, no need to serialize).
+        val rawResult = try {
+            broadcastClient.sendRaw(txJson)
+        } catch (e: Exception) {
+            pendingBroadcastDao.delete(txHash)
+            cacheManager.deleteTransaction(txHash)
+            throw e
+        }
+
+        if (rawResult == null) {
+            pendingBroadcastDao.delete(txHash)
+            cacheManager.deleteTransaction(txHash)
+            throw Exception("Send failed - native returned null")
+        }
+
+        val returnedHash = rawResult.trim('"')
+        if (returnedHash.lowercase() != txHash.lowercase()) {
+            // Step 0 verified equality on testnet; this branch should be unreachable.
+            // If it fires in production, the tx WAS broadcast under returnedHash but
+            // our pre-broadcast hash derivation disagrees. Re-key both rows so cleanup
+            // paths align with what the network sees.
+            Log.e(TAG, "❌ Hash mismatch! pre=$txHash returned=$returnedHash — re-keying rows")
+            pendingBroadcastDao.delete(txHash)
+            cacheManager.deleteTransaction(txHash)
+            pendingBroadcastDao.insert(
+                PendingBroadcastEntity(
+                    txHash = returnedHash,
+                    walletId = walletId,
+                    network = network,
+                    signedTxJson = txJson,
+                    reservedInputs = reservedJson,
+                    state = "BROADCAST",
+                    submittedAtTipBlock = tipNumber,
+                    nullCount = 0,
+                    createdAt = now,
+                    lastCheckedAt = System.currentTimeMillis()
+                )
+            )
+            cacheManager.insertPendingTransaction(
+                txHash = returnedHash,
+                network = network,
+                walletId = walletId,
+                balanceChange = balanceChangeHex,
+                direction = "out",
+                fee = "0x0"
+            )
+        } else {
+            val ok = pendingBroadcastDao.compareAndUpdateState(
+                hash = txHash,
+                expected = "BROADCASTING",
+                next = "BROADCAST",
+                now = System.currentTimeMillis()
+            )
+            if (ok != 1) {
+                Log.w(TAG, "compareAndUpdateState saw row not in BROADCASTING (race?); proceeding")
+            }
+        }
+
+        Log.d(TAG, "✅ sendTransaction: returnedHash=$returnedHash")
 
         // After sending, nudge the light client to rescan from a few blocks back
         // so it picks up the new change output when the tx confirms. Capture the
@@ -1045,7 +1163,7 @@ class GatewayRepository @Inject constructor(
             }
         }
 
-        txHash
+        returnedHash
     }
 
     suspend fun getTransactions(limit: Int = 50, cursor: String? = null): Result<TransactionsResponse> = runCatching {

--- a/android/app/src/main/java/com/rjnr/pocketnode/data/gateway/GatewayRepository.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/gateway/GatewayRepository.kt
@@ -17,6 +17,7 @@ import com.rjnr.pocketnode.data.sync.SyncForegroundService
 import com.rjnr.pocketnode.data.sync.SyncProgressTracker
 import com.rjnr.pocketnode.data.migration.WalletMigrationHelper
 import com.rjnr.pocketnode.data.transaction.TransactionBuilder
+import com.rjnr.pocketnode.data.wallet.AddressUtils
 import com.rjnr.pocketnode.data.wallet.KeyManager
 import com.rjnr.pocketnode.data.wallet.WalletInfo
 import com.rjnr.pocketnode.data.wallet.WalletPreferences
@@ -53,6 +54,15 @@ data class SyncProgress(
     val percentage: Double = 0.0,
     val etaDisplay: String = "",
     val justReachedTip: Boolean = false
+)
+
+/**
+ * Prefill data extracted from a FAILED `pending_broadcasts` row, used to
+ * pre-populate `SendScreen` when the user taps the Failed chip's retry CTA.
+ */
+data class FailedTxPrefill(
+    val recipientAddress: String,
+    val amountShannons: Long
 )
 
 /**
@@ -1145,6 +1155,30 @@ class GatewayRepository @Inject constructor(
         // Its insert path is idempotent: it sees the row we just inserted
         // and skips re-insertion, then performs broadcast + state CAS.
         sendTransaction(signedTx).getOrThrow()
+    }
+
+    /**
+     * Loads a FAILED `pending_broadcasts` row, decodes the recipient/amount
+     * from its signed tx, and removes the failed-state rows so the retry
+     * doesn't see itself as a reservation. Caller (HomeViewModel) navigates
+     * to SendScreen with the returned prefill.
+     *
+     * Heuristic: smallest-capacity output is the recipient (matches what
+     * `sendTransaction` uses for `balanceChange`). For "send all" txs there's
+     * only one output and the heuristic still resolves correctly.
+     */
+    suspend fun loadFailedForRetry(txHash: String): Result<FailedTxPrefill> = runCatching {
+        val row = pendingBroadcastDao.getFailedRow(txHash)
+            ?: error("No FAILED row for $txHash")
+        val tx = json.decodeFromString<Transaction>(row.signedTxJson)
+        val recipientOutput = tx.cellOutputs.minByOrNull {
+            it.capacity.removePrefix("0x").toLong(16)
+        } ?: error("Tx has no outputs")
+        val recipientAmount = recipientOutput.capacity.removePrefix("0x").toLong(16)
+        val recipientAddress = AddressUtils.encode(recipientOutput.lock, currentNetwork)
+        pendingBroadcastDao.delete(txHash)
+        cacheManager.deleteTransaction(txHash)
+        FailedTxPrefill(recipientAddress, recipientAmount)
     }
 
     suspend fun sendTransaction(transaction: Transaction): Result<String> = runCatching {

--- a/android/app/src/main/java/com/rjnr/pocketnode/data/gateway/GatewayRepository.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/gateway/GatewayRepository.kt
@@ -1038,8 +1038,18 @@ class GatewayRepository @Inject constructor(
     }
 
     suspend fun getCells(address: String? = null, limit: Int = 100, cursor: String? = null): Result<CellsResponse> = runCatching {
-        val info = _walletInfo.value ?: throw Exception("No wallet")
-        val searchKey = JniSearchKey(script = info.script)
+        // If a caller passes an address, honor it — decode to script. This is what
+        // mutex-guarded send paths rely on: the snapshot taken at the top of
+        // prepareAndSend is authoritative even if _walletInfo.value mutates while
+        // we're holding the mutex (wallet switch). Falls back to active wallet
+        // for back-compat callers that don't pass address.
+        val script = if (address != null) {
+            AddressUtils.parseAddress(address)
+                ?: throw Exception("Invalid address: $address")
+        } else {
+            _walletInfo.value?.script ?: throw Exception("No wallet")
+        }
+        val searchKey = JniSearchKey(script = script)
 
         Log.d(TAG, "🔍 getCells: Fetching cells for script: ${json.encodeToString(searchKey)}")
 
@@ -1122,12 +1132,22 @@ class GatewayRepository @Inject constructor(
         amountShannons: Long,
         privateKey: ByteArray
     ): Result<String> = runCatching {
+        // Snapshot every piece of sender state at function entry. The user can
+        // switch wallet/network mid-send (rare, but possible — Settings is one
+        // tap away); we must not let live `_walletInfo.value` / `currentNetwork`
+        // reads inside the mutex retarget the send to the new wallet while we
+        // persist rows under the old walletId. fromAddress is the authoritative
+        // sender identity here — it was captured by SendViewModel before this
+        // call and we trust it over live repository globals.
+        val senderNetwork = currentNetwork
         val walletId = activeWalletId
-        val network = currentNetwork.name
+        val network = senderNetwork.name
         val tipNumber = currentTipNumberOrZero()
         publishTip(tipNumber)
 
         val signedTx = sendMutex.withLock {
+            // getCells(fromAddress) decodes the address to a script — honors the
+            // snapshot rather than reading _walletInfo.value live.
             val cellsResult = getCells(fromAddress).getOrThrow()
             val pending = pendingBroadcastDao.getActive(walletId, network)
             val reserved: Set<OutPoint> = pending
@@ -1151,7 +1171,7 @@ class GatewayRepository @Inject constructor(
                 }
                 pendingTx.cellOutputs.mapIndexedNotNull { idx, output ->
                     val outAddr = try {
-                        AddressUtils.encode(output.lock, currentNetwork)
+                        AddressUtils.encode(output.lock, senderNetwork)
                     } catch (e: Exception) {
                         return@mapIndexedNotNull null
                     }
@@ -1179,7 +1199,7 @@ class GatewayRepository @Inject constructor(
                 amountShannons = amountShannons,
                 availableCells = filtered,
                 privateKey = privateKey,
-                network = currentNetwork
+                network = senderNetwork
             )
 
             val txHash = transactionBuilder.computeTxHash(signed)

--- a/android/app/src/main/java/com/rjnr/pocketnode/data/gateway/GatewayRepository.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/gateway/GatewayRepository.kt
@@ -56,6 +56,23 @@ data class SyncProgress(
 )
 
 /**
+ * Narrow seam over [GatewayRepository] so [com.rjnr.pocketnode.data.sync.BroadcastWatchdog]
+ * can be unit-tested without instantiating a full Repository (whose
+ * constructor surface is wide). [GatewayRepository] implements this; tests
+ * use a small fake.
+ */
+interface TipSource {
+    /** Monotonic light-client tip stream. Initial value 0L until first publish. */
+    val tipFlow: kotlinx.coroutines.flow.StateFlow<Long>
+
+    /** Pull a fresh tip via JNI and publish to [tipFlow] if higher. Returns the tip read (or 0L). */
+    suspend fun fetchAndPublishTip(): Long
+
+    /** (walletId, networkName) of the active wallet, or null if no active wallet. */
+    fun activeWalletAndNetworkOrNull(): Pair<String, String>?
+}
+
+/**
  * Pure BALANCED filter algorithm — no I/O. Extracted from GatewayRepository
  * so unit tests exercise the production implementation directly without
  * having to construct a full GatewayRepository instance.
@@ -92,8 +109,33 @@ class GatewayRepository @Inject constructor(
     private val syncProgressDao: SyncProgressDao,
     private val pendingBroadcastDao: PendingBroadcastDao,
     private val broadcastClient: BroadcastClient
-) {
+) : TipSource {
     private val sendMutex = Mutex()
+
+    private val _tipFlow = MutableStateFlow(0L)
+    override val tipFlow: StateFlow<Long> = _tipFlow.asStateFlow()
+
+    /**
+     * Publish a fresh tip to [tipFlow]. Monotonic — older tips are ignored
+     * (light-client tip events can interleave). Public-by-package so the
+     * sync polling path and send path can both keep the flow warm without
+     * exposing a setter to outside callers.
+     */
+    internal fun publishTip(n: Long) {
+        if (n > _tipFlow.value) _tipFlow.value = n
+    }
+
+    override suspend fun fetchAndPublishTip(): Long {
+        val n = currentTipNumberOrZero()
+        if (n > 0) publishTip(n)
+        return n
+    }
+
+    override fun activeWalletAndNetworkOrNull(): Pair<String, String>? {
+        val id = activeWalletId
+        if (id.isBlank()) return null
+        return id to currentNetwork.name
+    }
 
     private val _walletInfo = MutableStateFlow<WalletInfo?>(null)
     val walletInfo: StateFlow<WalletInfo?> = _walletInfo.asStateFlow()
@@ -1022,6 +1064,7 @@ class GatewayRepository @Inject constructor(
         val walletId = activeWalletId
         val network = currentNetwork.name
         val tipNumber = currentTipNumberOrZero()
+        publishTip(tipNumber)
 
         val signedTx = sendMutex.withLock {
             val cellsResult = getCells(fromAddress).getOrThrow()
@@ -1105,6 +1148,7 @@ class GatewayRepository @Inject constructor(
         val walletId = activeWalletId
         val network = currentNetwork.name
         val tipNumber = currentTipNumberOrZero()
+        publishTip(tipNumber)
         val txJson = json.encodeToString(transaction)
         val txHash = transactionBuilder.computeTxHash(transaction)
         val reservedJson = json.encodeToString(

--- a/android/app/src/main/java/com/rjnr/pocketnode/data/gateway/GatewayRepository.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/gateway/GatewayRepository.kt
@@ -1233,7 +1233,7 @@ class GatewayRepository @Inject constructor(
      */
     suspend fun loadFailedForRetry(txHash: String): Result<FailedTxPrefill> = runCatching {
         val row = pendingBroadcastDao.getFailedRow(txHash)
-            ?: error("No FAILED row for $txHash")
+            ?: error("This transaction is too old to retry automatically. Please send a new one.")
         val tx = json.decodeFromString<Transaction>(row.signedTxJson)
         val recipientOutput = tx.cellOutputs.minByOrNull {
             it.capacity.removePrefix("0x").toLong(16)

--- a/android/app/src/main/java/com/rjnr/pocketnode/data/gateway/models/CkbModels.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/gateway/models/CkbModels.kt
@@ -96,7 +96,10 @@ data class TransactionRecord(
     // Raw hex timestamp from CKB block header (e.g. "0x18c8d0a7a00"), null if not yet fetched
     @SerialName("block_timestamp_hex") val blockTimestampHex: String? = null,
     // True if the transaction interacts with a DAO type script cell
-    @SerialName("is_dao_related") val isDaoRelated: Boolean = false
+    @SerialName("is_dao_related") val isDaoRelated: Boolean = false,
+    // "PENDING", "CONFIRMED", "FAILED" — defaults to CONFIRMED so historical
+    // rows that never had an explicit status (pre-#115) render as confirmed.
+    @SerialName("status") val status: String = "CONFIRMED"
 ) {
     /**
      * Get balance change as CKB amount (from shannons)

--- a/android/app/src/main/java/com/rjnr/pocketnode/data/sync/BroadcastWatchdog.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/sync/BroadcastWatchdog.kt
@@ -96,11 +96,29 @@ class BroadcastWatchdog(
                     }
                 }
                 TxFetchResult.InPool -> {
-                    if (row.state == "BROADCASTING") {
-                        dao.compareAndUpdateState(row.txHash, "BROADCASTING", "BROADCAST", now)
-                    }
-                    if (row.nullCount != 0) {
-                        dao.updateNullCount(row.txHash, 0, now)
+                    // In-pool past the commit window = network rejection masked by
+                    // a stale local-mempool entry. CKB proposal+commit completes in
+                    // ~12 blocks; if we're still in-pool at submitted+25 (~6.5 min)
+                    // the chain has rejected the tx (e.g. double-spend, dependency
+                    // on a tx that itself never landed). Mark FAILED so the user
+                    // sees a terminal state and the retry CTA, instead of stuck-pending.
+                    if (currentTip >= row.submittedAtTipBlock + BLOCK_TIMEOUT) {
+                        Log.w(TAG, "in-pool past +$BLOCK_TIMEOUT blocks for ${row.txHash} (submitted at ${row.submittedAtTipBlock}, tip $currentTip) — network rejected; marking FAILED")
+                        val ok = dao.compareAndUpdateState(
+                            hash = row.txHash, expected = row.state,
+                            next = "FAILED", now = now
+                        )
+                        if (ok == 1) {
+                            cache.updateTransactionStatus(row.txHash, "FAILED")
+                        }
+                    } else {
+                        // Healthy in-pool — waiting for commit.
+                        if (row.state == "BROADCASTING") {
+                            dao.compareAndUpdateState(row.txHash, "BROADCASTING", "BROADCAST", now)
+                        }
+                        if (row.nullCount != 0) {
+                            dao.updateNullCount(row.txHash, 0, now)
+                        }
                     }
                 }
                 TxFetchResult.NotFound -> {

--- a/android/app/src/main/java/com/rjnr/pocketnode/data/sync/BroadcastWatchdog.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/sync/BroadcastWatchdog.kt
@@ -84,61 +84,73 @@ class BroadcastWatchdog(
         val rows = dao.getActive(walletId, network)
         val now = System.currentTimeMillis()
         for (row in rows) {
-            when (val result = statusGateway.fetch(row.txHash)) {
-                is TxFetchResult.OnChain -> {
-                    val ok = dao.compareAndUpdateState(
+            // Per-row runCatching: cache-update-before-CAS can throw on a DB
+            // hiccup; we want the row to stay non-terminal AND we want sibling
+            // rows in the same pass to still be processed.
+            runCatching { processRow(row, currentTip, now) }
+                .onFailure { Log.w(TAG, "checkAll: row ${row.txHash} failed: ${it.message}") }
+        }
+    }
+
+    private suspend fun processRow(
+        row: com.rjnr.pocketnode.data.database.entity.PendingBroadcastEntity,
+        currentTip: Long,
+        now: Long
+    ) {
+        when (statusGateway.fetch(row.txHash)) {
+            is TxFetchResult.OnChain -> {
+                // Update cache BEFORE the terminal CAS: if the cache write throws,
+                // the pending row stays in non-terminal state and the watchdog
+                // retries on the next tick. Reverse order would drop the row from
+                // getActive() with a stale PENDING transactions row.
+                cache.updateTransactionStatus(row.txHash, "CONFIRMED")
+                val ok = dao.compareAndUpdateState(
+                    hash = row.txHash, expected = row.state,
+                    next = "CONFIRMED", now = now
+                )
+                if (ok == 1) {
+                    dao.delete(row.txHash)
+                }
+            }
+            TxFetchResult.InPool -> {
+                // In-pool past the commit window = network rejection masked by
+                // a stale local-mempool entry. CKB proposal+commit completes in
+                // ~12 blocks; if we're still in-pool at submitted+25 (~6.5 min)
+                // the chain has rejected the tx (e.g. double-spend, dependency
+                // on a tx that itself never landed). Mark FAILED so the user
+                // sees a terminal state and the retry CTA, instead of stuck-pending.
+                if (currentTip >= row.submittedAtTipBlock + BLOCK_TIMEOUT) {
+                    Log.w(TAG, "in-pool past +$BLOCK_TIMEOUT blocks for ${row.txHash} (submitted at ${row.submittedAtTipBlock}, tip $currentTip) — network rejected; marking FAILED")
+                    cache.updateTransactionStatus(row.txHash, "FAILED")
+                    dao.compareAndUpdateState(
                         hash = row.txHash, expected = row.state,
-                        next = "CONFIRMED", now = now
+                        next = "FAILED", now = now
                     )
-                    if (ok == 1) {
-                        cache.updateTransactionStatus(row.txHash, "CONFIRMED")
-                        dao.delete(row.txHash)
+                } else {
+                    // Healthy in-pool — waiting for commit.
+                    if (row.state == "BROADCASTING") {
+                        dao.compareAndUpdateState(row.txHash, "BROADCASTING", "BROADCAST", now)
+                    }
+                    if (row.nullCount != 0) {
+                        dao.updateNullCount(row.txHash, 0, now)
                     }
                 }
-                TxFetchResult.InPool -> {
-                    // In-pool past the commit window = network rejection masked by
-                    // a stale local-mempool entry. CKB proposal+commit completes in
-                    // ~12 blocks; if we're still in-pool at submitted+25 (~6.5 min)
-                    // the chain has rejected the tx (e.g. double-spend, dependency
-                    // on a tx that itself never landed). Mark FAILED so the user
-                    // sees a terminal state and the retry CTA, instead of stuck-pending.
-                    if (currentTip >= row.submittedAtTipBlock + BLOCK_TIMEOUT) {
-                        Log.w(TAG, "in-pool past +$BLOCK_TIMEOUT blocks for ${row.txHash} (submitted at ${row.submittedAtTipBlock}, tip $currentTip) — network rejected; marking FAILED")
-                        val ok = dao.compareAndUpdateState(
-                            hash = row.txHash, expected = row.state,
-                            next = "FAILED", now = now
-                        )
-                        if (ok == 1) {
-                            cache.updateTransactionStatus(row.txHash, "FAILED")
-                        }
-                    } else {
-                        // Healthy in-pool — waiting for commit.
-                        if (row.state == "BROADCASTING") {
-                            dao.compareAndUpdateState(row.txHash, "BROADCASTING", "BROADCAST", now)
-                        }
-                        if (row.nullCount != 0) {
-                            dao.updateNullCount(row.txHash, 0, now)
-                        }
-                    }
+            }
+            TxFetchResult.NotFound -> {
+                val newCount = row.nullCount + 1
+                dao.updateNullCount(row.txHash, newCount, now)
+                if (newCount >= NULL_THRESHOLD &&
+                    currentTip >= row.submittedAtTipBlock + BLOCK_TIMEOUT
+                ) {
+                    cache.updateTransactionStatus(row.txHash, "FAILED")
+                    dao.compareAndUpdateState(
+                        hash = row.txHash, expected = row.state,
+                        next = "FAILED", now = now
+                    )
                 }
-                TxFetchResult.NotFound -> {
-                    val newCount = row.nullCount + 1
-                    dao.updateNullCount(row.txHash, newCount, now)
-                    if (newCount >= NULL_THRESHOLD &&
-                        currentTip >= row.submittedAtTipBlock + BLOCK_TIMEOUT
-                    ) {
-                        val ok = dao.compareAndUpdateState(
-                            hash = row.txHash, expected = row.state,
-                            next = "FAILED", now = now
-                        )
-                        if (ok == 1) {
-                            cache.updateTransactionStatus(row.txHash, "FAILED")
-                        }
-                    }
-                }
-                TxFetchResult.Exception -> {
-                    Log.w(TAG, "fetch exception for ${row.txHash}; no state change")
-                }
+            }
+            TxFetchResult.Exception -> {
+                Log.w(TAG, "fetch exception for ${row.txHash}; no state change")
             }
         }
     }

--- a/android/app/src/main/java/com/rjnr/pocketnode/data/sync/BroadcastWatchdog.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/sync/BroadcastWatchdog.kt
@@ -1,0 +1,177 @@
+package com.rjnr.pocketnode.data.sync
+
+import android.util.Log
+import com.rjnr.pocketnode.data.database.dao.PendingBroadcastDao
+import com.rjnr.pocketnode.data.gateway.GatewayRepository
+import com.rjnr.pocketnode.data.gateway.TipSource
+import com.rjnr.pocketnode.data.gateway.TransactionStatusUpdater
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Drives `pending_broadcasts` rows to terminal states via the
+ * Neuron-style Monitor pattern (#94) adapted to CKB.
+ *
+ *   - Primary trigger: light-client tip events ([TipSource.tipFlow]).
+ *   - Fallback timer: 15s loop. Defensive — tip events stalling would
+ *     otherwise leave rows stuck.
+ *   - Both routes call [checkAll], internally idempotent (CAS UPDATEs
+ *     guard against tip-event vs fallback-timer races).
+ *
+ * Foreground-gated: skips checkAll when not at least STARTED.
+ * Phase A is foreground-only by design; cold-start recovery (Task 5)
+ * handles process death.
+ */
+@Singleton
+class BroadcastWatchdog(
+    private val dao: PendingBroadcastDao,
+    private val statusGateway: TransactionStatusGateway,
+    private val cache: TransactionStatusUpdater,
+    private val tipSource: TipSource,
+    private val lifecycleProvider: LifecycleProvider,
+    dispatcher: CoroutineDispatcher
+) {
+    /** Hilt entry point — uses [Dispatchers.IO]. Tests construct via the primary ctor. */
+    @Inject constructor(
+        dao: PendingBroadcastDao,
+        statusGateway: TransactionStatusGateway,
+        cache: TransactionStatusUpdater,
+        tipSource: TipSource,
+        lifecycleProvider: LifecycleProvider
+    ) : this(dao, statusGateway, cache, tipSource, lifecycleProvider, Dispatchers.IO)
+
+    private val scope = CoroutineScope(SupervisorJob() + dispatcher)
+    private var tipJob: Job? = null
+    private var fallbackJob: Job? = null
+
+    fun start() {
+        if (tipJob != null) return  // idempotent
+        tipJob = scope.launch {
+            tipSource.tipFlow.collect { tip ->
+                if (!lifecycleProvider.isAtLeastStarted()) return@collect
+                val (walletId, network) = tipSource.activeWalletAndNetworkOrNull() ?: return@collect
+                checkAll(currentTip = tip, walletId = walletId, network = network)
+            }
+        }
+        fallbackJob = scope.launch {
+            while (true) {
+                delay(FALLBACK_INTERVAL_MS)
+                if (!lifecycleProvider.isAtLeastStarted()) continue
+                runCatching {
+                    val tip = tipSource.fetchAndPublishTip()
+                    val (walletId, network) = tipSource.activeWalletAndNetworkOrNull()
+                        ?: return@runCatching
+                    checkAll(currentTip = tip, walletId = walletId, network = network)
+                }.onFailure { Log.w(TAG, "fallback checkAll: ${it.message}") }
+            }
+        }
+    }
+
+    fun stop() {
+        tipJob?.cancel(); tipJob = null
+        fallbackJob?.cancel(); fallbackJob = null
+    }
+
+    /** Public for testability; not called directly by app code. */
+    suspend fun checkAll(currentTip: Long, walletId: String, network: String) {
+        val rows = dao.getActive(walletId, network)
+        val now = System.currentTimeMillis()
+        for (row in rows) {
+            when (val result = statusGateway.fetch(row.txHash)) {
+                is TxFetchResult.OnChain -> {
+                    val ok = dao.compareAndUpdateState(
+                        hash = row.txHash, expected = row.state,
+                        next = "CONFIRMED", now = now
+                    )
+                    if (ok == 1) {
+                        cache.updateTransactionStatus(row.txHash, "CONFIRMED")
+                        dao.delete(row.txHash)
+                    }
+                }
+                TxFetchResult.InPool -> {
+                    if (row.state == "BROADCASTING") {
+                        dao.compareAndUpdateState(row.txHash, "BROADCASTING", "BROADCAST", now)
+                    }
+                    if (row.nullCount != 0) {
+                        dao.updateNullCount(row.txHash, 0, now)
+                    }
+                }
+                TxFetchResult.NotFound -> {
+                    val newCount = row.nullCount + 1
+                    dao.updateNullCount(row.txHash, newCount, now)
+                    if (newCount >= NULL_THRESHOLD &&
+                        currentTip >= row.submittedAtTipBlock + BLOCK_TIMEOUT
+                    ) {
+                        val ok = dao.compareAndUpdateState(
+                            hash = row.txHash, expected = row.state,
+                            next = "FAILED", now = now
+                        )
+                        if (ok == 1) {
+                            cache.updateTransactionStatus(row.txHash, "FAILED")
+                        }
+                    }
+                }
+                TxFetchResult.Exception -> {
+                    Log.w(TAG, "fetch exception for ${row.txHash}; no state change")
+                }
+            }
+        }
+    }
+
+    companion object {
+        private const val TAG = "BroadcastWatchdog"
+        const val NULL_THRESHOLD = 3
+        const val BLOCK_TIMEOUT = 25L
+        const val FALLBACK_INTERVAL_MS = 15_000L
+    }
+}
+
+sealed class TxFetchResult {
+    data class OnChain(val blockHash: String) : TxFetchResult()
+    data object InPool : TxFetchResult()
+    data object NotFound : TxFetchResult()
+    data object Exception : TxFetchResult()
+}
+
+/** Indirection over `GatewayRepository.getTransactionStatus` for testability. */
+fun interface TransactionStatusGateway {
+    suspend fun fetch(hash: String): TxFetchResult
+}
+
+/** Lifecycle-state indirection. Real impl reads ProcessLifecycleOwner. */
+fun interface LifecycleProvider {
+    fun isAtLeastStarted(): Boolean
+}
+
+/**
+ * Real adapter wrapping [GatewayRepository.getTransactionStatus]. Maps
+ * `TransactionStatusResponse` to the watchdog's narrower [TxFetchResult]
+ * vocabulary so the watchdog never has to re-parse JNI JSON.
+ */
+class RepositoryTransactionStatusGateway @Inject constructor(
+    private val gateway: GatewayRepository
+) : TransactionStatusGateway {
+    override suspend fun fetch(hash: String): TxFetchResult = runCatching {
+        val resp = gateway.getTransactionStatus(hash).getOrNull()
+            ?: return TxFetchResult.NotFound
+        when {
+            resp.status == "unknown" -> TxFetchResult.NotFound
+            resp.blockHash != null -> TxFetchResult.OnChain(resp.blockHash!!)
+            else -> TxFetchResult.InPool
+        }
+    }.getOrElse { TxFetchResult.Exception }
+}
+
+/** Real lifecycle provider reading [androidx.lifecycle.ProcessLifecycleOwner]. */
+class ProcessLifecycleProvider @Inject constructor() : LifecycleProvider {
+    override fun isAtLeastStarted(): Boolean =
+        androidx.lifecycle.ProcessLifecycleOwner.get()
+            .lifecycle.currentState.isAtLeast(androidx.lifecycle.Lifecycle.State.STARTED)
+}

--- a/android/app/src/main/java/com/rjnr/pocketnode/data/transaction/TransactionBuilder.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/transaction/TransactionBuilder.kt
@@ -5,6 +5,7 @@ import com.rjnr.pocketnode.data.gateway.DaoConstants
 import com.rjnr.pocketnode.data.gateway.models.*
 import com.rjnr.pocketnode.data.validation.NetworkValidator
 import com.rjnr.pocketnode.data.wallet.AddressUtils
+import com.rjnr.pocketnode.util.toHex
 import org.nervos.ckb.crypto.Blake2b
 import org.nervos.ckb.crypto.secp256k1.ECKeyPair
 import org.nervos.ckb.crypto.secp256k1.Sign
@@ -393,6 +394,23 @@ class TransactionBuilder @Inject constructor(
 
     private fun parseCapacity(hex: String): Long {
         return hex.removePrefix("0x").toLong(16)
+    }
+
+    /**
+     * Computes the canonical CKB transaction hash for [tx].
+     *
+     * Returned as `0x`-prefixed lowercase hex, matching the format the
+     * Rust JNI bridge returns from `nativeSendTransaction`. Witnesses are
+     * excluded from the hash by definition (CKB tx hash = blake2b of the
+     * raw tx serialization, which `serializeRawTransaction` already produces
+     * without witness bytes).
+     *
+     * Phase A (#115) relies on this matching the JNI-returned hash byte-for-byte;
+     * the on-device verification gate runs separately.
+     */
+    fun computeTxHash(tx: Transaction): String {
+        val rawTxBytes = serializeRawTransaction(tx)
+        return "0x" + blake2bHash(rawTxBytes).toHex()
     }
 
     private fun signTransaction(

--- a/android/app/src/main/java/com/rjnr/pocketnode/di/AppModule.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/di/AppModule.kt
@@ -24,9 +24,11 @@ import com.rjnr.pocketnode.data.database.dao.SyncProgressDao
 import com.rjnr.pocketnode.data.database.dao.TransactionDao
 import com.rjnr.pocketnode.data.database.dao.WalletDao
 import com.rjnr.pocketnode.data.migration.WalletMigrationHelper
+import com.rjnr.pocketnode.data.gateway.BroadcastClient
 import com.rjnr.pocketnode.data.gateway.CacheManager
 import com.rjnr.pocketnode.data.gateway.DaoSyncManager
 import com.rjnr.pocketnode.data.gateway.GatewayRepository
+import com.rjnr.pocketnode.data.gateway.LightClientBroadcastClient
 import com.rjnr.pocketnode.data.transaction.TransactionBuilder
 import com.rjnr.pocketnode.data.wallet.KeyManager
 import com.rjnr.pocketnode.data.wallet.MnemonicManager
@@ -179,6 +181,10 @@ object AppModule {
 
     @Provides
     @Singleton
+    fun provideBroadcastClient(impl: LightClientBroadcastClient): BroadcastClient = impl
+
+    @Provides
+    @Singleton
     fun provideGatewayRepository(
         @ApplicationContext context: Context,
         keyManager: KeyManager,
@@ -191,6 +197,8 @@ object AppModule {
         walletDao: WalletDao,
         appDatabase: AppDatabase,
         headerCacheDao: HeaderCacheDao,
-        syncProgressDao: SyncProgressDao
-    ): GatewayRepository = GatewayRepository(context, keyManager, walletPreferences, json, transactionBuilder, cacheManager, daoSyncManager, walletMigrationHelper, walletDao, appDatabase, headerCacheDao, syncProgressDao)
+        syncProgressDao: SyncProgressDao,
+        pendingBroadcastDao: PendingBroadcastDao,
+        broadcastClient: BroadcastClient
+    ): GatewayRepository = GatewayRepository(context, keyManager, walletPreferences, json, transactionBuilder, cacheManager, daoSyncManager, walletMigrationHelper, walletDao, appDatabase, headerCacheDao, syncProgressDao, pendingBroadcastDao, broadcastClient)
 }

--- a/android/app/src/main/java/com/rjnr/pocketnode/di/AppModule.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/di/AppModule.kt
@@ -29,6 +29,12 @@ import com.rjnr.pocketnode.data.gateway.CacheManager
 import com.rjnr.pocketnode.data.gateway.DaoSyncManager
 import com.rjnr.pocketnode.data.gateway.GatewayRepository
 import com.rjnr.pocketnode.data.gateway.LightClientBroadcastClient
+import com.rjnr.pocketnode.data.gateway.TipSource
+import com.rjnr.pocketnode.data.gateway.TransactionStatusUpdater
+import com.rjnr.pocketnode.data.sync.LifecycleProvider
+import com.rjnr.pocketnode.data.sync.ProcessLifecycleProvider
+import com.rjnr.pocketnode.data.sync.RepositoryTransactionStatusGateway
+import com.rjnr.pocketnode.data.sync.TransactionStatusGateway
 import com.rjnr.pocketnode.data.transaction.TransactionBuilder
 import com.rjnr.pocketnode.data.wallet.KeyManager
 import com.rjnr.pocketnode.data.wallet.MnemonicManager
@@ -182,6 +188,22 @@ object AppModule {
     @Provides
     @Singleton
     fun provideBroadcastClient(impl: LightClientBroadcastClient): BroadcastClient = impl
+
+    @Provides
+    @Singleton
+    fun provideTipSource(impl: GatewayRepository): TipSource = impl
+
+    @Provides
+    @Singleton
+    fun provideTransactionStatusUpdater(impl: CacheManager): TransactionStatusUpdater = impl
+
+    @Provides
+    @Singleton
+    fun provideTransactionStatusGateway(impl: RepositoryTransactionStatusGateway): TransactionStatusGateway = impl
+
+    @Provides
+    @Singleton
+    fun provideLifecycleProvider(): LifecycleProvider = ProcessLifecycleProvider()
 
     @Provides
     @Singleton

--- a/android/app/src/main/java/com/rjnr/pocketnode/di/AppModule.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/di/AppModule.kt
@@ -14,10 +14,12 @@ import com.rjnr.pocketnode.data.database.MIGRATION_3_4
 import com.rjnr.pocketnode.data.database.MIGRATION_4_5
 import com.rjnr.pocketnode.data.database.MIGRATION_5_6
 import com.rjnr.pocketnode.data.database.MIGRATION_6_7
+import com.rjnr.pocketnode.data.database.MIGRATION_7_8
 import com.rjnr.pocketnode.data.database.dao.BalanceCacheDao
 import com.rjnr.pocketnode.data.database.dao.DaoCellDao
 import com.rjnr.pocketnode.data.database.dao.HeaderCacheDao
 import com.rjnr.pocketnode.data.database.dao.KeyMaterialDao
+import com.rjnr.pocketnode.data.database.dao.PendingBroadcastDao
 import com.rjnr.pocketnode.data.database.dao.SyncProgressDao
 import com.rjnr.pocketnode.data.database.dao.TransactionDao
 import com.rjnr.pocketnode.data.database.dao.WalletDao
@@ -115,7 +117,7 @@ object AppModule {
     fun provideAppDatabase(@ApplicationContext context: Context): AppDatabase =
         Room.databaseBuilder(context, AppDatabase::class.java, "pocket_node.db")
             .setJournalMode(RoomDatabase.JournalMode.WRITE_AHEAD_LOGGING)
-            .addMigrations(MIGRATION_1_2, MIGRATION_2_3, MIGRATION_3_4, MIGRATION_4_5, MIGRATION_5_6, MIGRATION_6_7)
+            .addMigrations(MIGRATION_1_2, MIGRATION_2_3, MIGRATION_3_4, MIGRATION_4_5, MIGRATION_5_6, MIGRATION_6_7, MIGRATION_7_8)
             .build()
 
     @Provides
@@ -138,6 +140,10 @@ object AppModule {
 
     @Provides
     fun provideSyncProgressDao(db: AppDatabase): SyncProgressDao = db.syncProgressDao()
+
+    @Provides
+    @Singleton
+    fun providePendingBroadcastDao(db: AppDatabase): PendingBroadcastDao = db.pendingBroadcastDao()
 
     @Provides
     @Singleton

--- a/android/app/src/main/java/com/rjnr/pocketnode/di/AppModule.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/di/AppModule.kt
@@ -203,7 +203,7 @@ object AppModule {
 
     @Provides
     @Singleton
-    fun provideLifecycleProvider(): LifecycleProvider = ProcessLifecycleProvider()
+    fun provideLifecycleProvider(impl: ProcessLifecycleProvider): LifecycleProvider = impl
 
     @Provides
     @Singleton

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/MainScreen.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/MainScreen.kt
@@ -33,7 +33,7 @@ import com.rjnr.pocketnode.ui.theme.CkbWalletTheme
 
 @Composable
 fun MainScreen(
-    onNavigateToSend: () -> Unit,
+    onNavigateToSend: (recipient: String?, amountShannons: Long?) -> Unit,
     onNavigateToReceive: () -> Unit,
     onNavigateToNodeStatus: () -> Unit,
     onNavigateToBackup: () -> Unit,
@@ -147,7 +147,7 @@ private fun tabIcon(tab: BottomTab, selected: Boolean): ImageVector = when (tab)
 fun MainScreenPreview() {
     CkbWalletTheme {
         MainScreen(
-            onNavigateToSend = {},
+            onNavigateToSend = { _, _ -> },
             onNavigateToReceive = {},
             onNavigateToNodeStatus = {},
             onNavigateToBackup = {},

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/MainScreen.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/MainScreen.kt
@@ -112,7 +112,9 @@ fun MainScreen(
                 )
             }
             composable(BottomTab.Activity.route) {
-                ActivityScreen()
+                ActivityScreen(
+                    onNavigateToSend = onNavigateToSend
+                )
             }
             composable(BottomTab.DAO.route) {
                 DaoScreen(

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/navigation/NavGraph.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/navigation/NavGraph.kt
@@ -190,26 +190,32 @@ fun CkbNavGraph(
                         PinMode.VERIFY -> {
                             val previousRoute = navController.previousBackStackEntry
                                 ?.destination?.route
-                            when (previousRoute) {
-                                Screen.SecuritySettings.route -> {
+                            // The Send route is registered with optional query args
+                            // (e.g. "send?recipient=…&amountShannons=…"), so match on
+                            // the base segment rather than full equality.
+                            val isSendRoute = previousRoute != null &&
+                                (previousRoute == Screen.Send.route ||
+                                    previousRoute.startsWith("${Screen.Send.route}?"))
+                            when {
+                                previousRoute == Screen.SecuritySettings.route -> {
                                     navController.previousBackStackEntry
                                         ?.savedStateHandle
                                         ?.set("pin_verified", true)
                                     navController.popBackStack()
                                 }
-                                Screen.Send.route -> {
+                                isSendRoute -> {
                                     navController.previousBackStackEntry
                                         ?.savedStateHandle
                                         ?.set("send_pin_verified", true)
                                     navController.popBackStack()
                                 }
-                                Screen.Main.route -> {
+                                previousRoute == Screen.Main.route -> {
                                     navController.previousBackStackEntry
                                         ?.savedStateHandle
                                         ?.set("dao_pin_verified", true)
                                     navController.popBackStack()
                                 }
-                                Screen.WalletDetail.route -> {
+                                previousRoute == Screen.WalletDetail.route -> {
                                     navController.previousBackStackEntry
                                         ?.savedStateHandle
                                         ?.set("pin_verified", true)
@@ -278,7 +284,23 @@ fun CkbNavGraph(
             }
 
             MainScreen(
-                onNavigateToSend = { navController.navigate(Screen.Send.route) },
+                onNavigateToSend = { recipient, amountShannons ->
+                    val route = if (recipient != null || amountShannons != null) {
+                        val r = recipient?.let { android.net.Uri.encode(it) }
+                        buildString {
+                            append(Screen.Send.route)
+                            append("?")
+                            if (r != null) append("recipient=$r")
+                            if (amountShannons != null) {
+                                if (r != null) append("&")
+                                append("amountShannons=$amountShannons")
+                            }
+                        }
+                    } else {
+                        Screen.Send.route
+                    }
+                    navController.navigate(route)
+                },
                 onNavigateToReceive = { navController.navigate(Screen.Receive.route) },
                 onNavigateToNodeStatus = { navController.navigate(Screen.NodeStatus.route) },
                 onNavigateToBackup = { navController.navigate(Screen.MnemonicBackup.createRoute()) },
@@ -297,7 +319,25 @@ fun CkbNavGraph(
             )
         }
 
-        composable(Screen.Send.route) { backStackEntry ->
+        composable(
+            // Optional query args for retry-failed-tx prefill (#115). Both
+            // nullable; arg-less navigation to "send" still matches because
+            // both default to null.
+            route = "${Screen.Send.route}?recipient={recipient}&amountShannons={amountShannons}",
+            arguments = listOf(
+                navArgument("recipient") {
+                    type = NavType.StringType
+                    nullable = true
+                    defaultValue = null
+                },
+                navArgument("amountShannons") {
+                    // StringType so we can carry null; parse to Long below.
+                    type = NavType.StringType
+                    nullable = true
+                    defaultValue = null
+                }
+            )
+        ) { backStackEntry ->
             val sendPinVerified = backStackEntry.savedStateHandle
                 .get<Boolean>("send_pin_verified") == true
             if (sendPinVerified) {
@@ -305,6 +345,10 @@ fun CkbNavGraph(
                     backStackEntry.savedStateHandle.remove<Boolean>("send_pin_verified")
                 }
             }
+
+            val prefillRecipient = backStackEntry.arguments?.getString("recipient")
+            val prefillAmountShannons = backStackEntry.arguments
+                ?.getString("amountShannons")?.toLongOrNull()
 
             SendScreen(
                 onNavigateBack = { navController.popBackStack() },
@@ -315,6 +359,8 @@ fun CkbNavGraph(
                 scannedAddress = backStackEntry.savedStateHandle
                     .get<String>("scanned_address"),
                 sendAuthVerified = sendPinVerified,
+                prefillRecipient = prefillRecipient,
+                prefillAmountShannons = prefillAmountShannons,
             )
         }
 

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/activity/ActivityScreen.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/activity/ActivityScreen.kt
@@ -21,6 +21,7 @@ import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Card
@@ -36,6 +37,7 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.pulltorefresh.PullToRefreshBox
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.material3.rememberModalBottomSheetState
@@ -65,6 +67,7 @@ import androidx.paging.compose.collectAsLazyPagingItems
 import com.composables.icons.lucide.*
 import com.rjnr.pocketnode.data.gateway.models.NetworkType
 import com.rjnr.pocketnode.data.gateway.models.TransactionRecord
+import com.rjnr.pocketnode.ui.screens.home.HomeNavEvent
 import com.rjnr.pocketnode.ui.theme.ErrorRed
 import com.rjnr.pocketnode.ui.theme.PendingAmber
 import com.rjnr.pocketnode.ui.theme.SuccessGreen
@@ -78,13 +81,45 @@ private val AmberPending = PendingAmber
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun ActivityScreen(
+    onNavigateToSend: (recipient: String?, amountShannons: Long?) -> Unit = { _, _ -> },
     viewModel: ActivityViewModel = hiltViewModel()
 ) {
     val uiState by viewModel.uiState.collectAsState()
     var selectedTransaction by remember { mutableStateOf<TransactionRecord?>(null) }
+    var retryDialogTx by remember { mutableStateOf<TransactionRecord?>(null) }
     val clipboardManager = LocalClipboardManager.current
     val context = LocalContext.current
     var pendingCsvContent by remember { mutableStateOf<String?>(null) }
+
+    // Collect one-shot nav events from the ViewModel (e.g. retry-failed-tx).
+    LaunchedEffect(Unit) {
+        viewModel.navEvents.collect { event ->
+            when (event) {
+                is HomeNavEvent.NavigateToSendWithPrefill -> {
+                    onNavigateToSend(event.recipientAddress, event.amountShannons)
+                }
+            }
+        }
+    }
+
+    // Retry-failed-tx confirmation. Copy mirrors HomeScreen exactly: FAILED is
+    // a heuristic, not proof the network rejected the tx.
+    retryDialogTx?.let { tx ->
+        AlertDialog(
+            onDismissRequest = { retryDialogTx = null },
+            title = { Text("Retry transaction?") },
+            text = { Text("This transaction may not have reached the network. Retry?") },
+            confirmButton = {
+                TextButton(onClick = {
+                    retryDialogTx = null
+                    viewModel.retryFailedTransaction(tx.txHash)
+                }) { Text("Retry") }
+            },
+            dismissButton = {
+                TextButton(onClick = { retryDialogTx = null }) { Text("Cancel") }
+            }
+        )
+    }
 
     val exportLauncher = rememberLauncherForActivityResult(
         contract = ActivityResultContracts.CreateDocument("text/csv")
@@ -205,7 +240,10 @@ fun ActivityScreen(
 
                             ActivityTransactionItem(
                                 transaction = tx,
-                                onClick = { selectedTransaction = tx }
+                                onClick = { selectedTransaction = tx },
+                                onRetry = if (tx.status == "FAILED") {
+                                    { retryDialogTx = tx }
+                                } else null
                             )
                         }
 
@@ -328,9 +366,11 @@ private fun DateGroupHeader(label: String) {
 @Composable
 private fun ActivityTransactionItem(
     transaction: TransactionRecord,
-    onClick: () -> Unit
+    onClick: () -> Unit,
+    onRetry: (() -> Unit)? = null
 ) {
-    val isPending = transaction.isPending()
+    val isFailed = transaction.status == "FAILED"
+    val isPending = !isFailed && transaction.isPending()
 
     val primaryColor = MaterialTheme.colorScheme.primary
     val onSurfaceVariantColor = MaterialTheme.colorScheme.onSurfaceVariant
@@ -386,7 +426,25 @@ private fun ActivityTransactionItem(
                     style = MaterialTheme.typography.bodyMedium,
                     fontWeight = FontWeight.Medium
                 )
-                if (isPending) {
+                if (isFailed) {
+                    Spacer(modifier = Modifier.width(6.dp))
+                    Surface(
+                        color = ErrorRed.copy(alpha = 0.15f),
+                        shape = RoundedCornerShape(4.dp),
+                        modifier = if (onRetry != null) {
+                            Modifier.clickable { onRetry() }
+                        } else {
+                            Modifier
+                        }
+                    ) {
+                        Text(
+                            text = "Failed",
+                            style = MaterialTheme.typography.labelSmall,
+                            color = ErrorRed,
+                            modifier = Modifier.padding(horizontal = 6.dp, vertical = 2.dp)
+                        )
+                    }
+                } else if (isPending) {
                     Spacer(modifier = Modifier.width(6.dp))
                     Surface(
                         color = AmberPending.copy(alpha = 0.15f),

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/activity/ActivityScreen.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/activity/ActivityScreen.kt
@@ -602,7 +602,7 @@ private fun TransactionDetailSheet(
                     style = MaterialTheme.typography.titleLarge,
                     fontWeight = FontWeight.Bold
                 )
-                StatusBadge(confirmed = transaction.isConfirmed())
+                StatusBadge(transaction = transaction)
             }
 
             Spacer(modifier = Modifier.height(20.dp))
@@ -729,17 +729,20 @@ private fun TransactionDetailSheet(
 }
 
 @Composable
-private fun StatusBadge(confirmed: Boolean) {
+private fun StatusBadge(transaction: TransactionRecord) {
     val primaryColor = MaterialTheme.colorScheme.primary
-
-    Surface(
-        color = if (confirmed) primaryColor.copy(alpha = 0.15f) else AmberPending.copy(alpha = 0.15f),
-        shape = RoundedCornerShape(8.dp)
-    ) {
+    val errorColor = MaterialTheme.colorScheme.error
+    val isFailed = transaction.status == "FAILED"
+    val (label, fg, bg) = when {
+        isFailed -> Triple("Failed", errorColor, errorColor.copy(alpha = 0.15f))
+        transaction.isConfirmed() -> Triple("Confirmed", primaryColor, primaryColor.copy(alpha = 0.15f))
+        else -> Triple("Pending", AmberPending, AmberPending.copy(alpha = 0.15f))
+    }
+    Surface(color = bg, shape = RoundedCornerShape(8.dp)) {
         Text(
-            text = if (confirmed) "Confirmed" else "Pending",
+            text = label,
             style = MaterialTheme.typography.labelMedium,
-            color = if (confirmed) primaryColor else AmberPending,
+            color = fg,
             modifier = Modifier.padding(horizontal = 12.dp, vertical = 6.dp)
         )
     }

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/activity/ActivityScreen.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/activity/ActivityScreen.kt
@@ -241,7 +241,7 @@ fun ActivityScreen(
                             ActivityTransactionItem(
                                 transaction = tx,
                                 onClick = { selectedTransaction = tx },
-                                onRetry = if (tx.status == "FAILED") {
+                                onRetry = if (tx.status == "FAILED" && tx.isOutgoing()) {
                                     { retryDialogTx = tx }
                                 } else null
                             )
@@ -730,9 +730,8 @@ private fun TransactionDetailSheet(
                 )
             }
 
-            // Retry CTA — only for FAILED rows; legacy ghosts (no signedTxJson)
-            // surface a friendly error from loadFailedForRetry instead.
-            if (transaction.status == "FAILED" && onRetry != null) {
+            // Retry CTA — only for FAILED plain transfers (see HomeScreen for why).
+            if (transaction.status == "FAILED" && transaction.isOutgoing() && onRetry != null) {
                 Spacer(modifier = Modifier.height(24.dp))
                 Button(
                     onClick = { onRetry(transaction) },

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/activity/ActivityScreen.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/activity/ActivityScreen.kt
@@ -273,6 +273,10 @@ fun ActivityScreen(
                     onCopyTxHash = { hash ->
                         clipboardManager.setText(AnnotatedString(hash))
                     },
+                    onRetry = { failed ->
+                        selectedTransaction = null
+                        retryDialogTx = failed
+                    },
                     onOpenExplorer = { url ->
                         try {
                             context.startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(url)))
@@ -565,7 +569,8 @@ private fun TransactionDetailSheet(
     network: NetworkType,
     onDismiss: () -> Unit,
     onCopyTxHash: (String) -> Unit,
-    onOpenExplorer: (String) -> Unit
+    onOpenExplorer: (String) -> Unit,
+    onRetry: ((TransactionRecord) -> Unit)? = null
 ) {
     val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
     val amountColor = when {
@@ -723,6 +728,22 @@ private fun TransactionDetailSheet(
                     label = "Fee",
                     value = "$feeFormatted CKB"
                 )
+            }
+
+            // Retry CTA — only for FAILED rows; legacy ghosts (no signedTxJson)
+            // surface a friendly error from loadFailedForRetry instead.
+            if (transaction.status == "FAILED" && onRetry != null) {
+                Spacer(modifier = Modifier.height(24.dp))
+                Button(
+                    onClick = { onRetry(transaction) },
+                    modifier = Modifier.fillMaxWidth(),
+                    colors = ButtonDefaults.buttonColors(
+                        containerColor = MaterialTheme.colorScheme.error,
+                        contentColor = MaterialTheme.colorScheme.onError
+                    )
+                ) {
+                    Text("Retry Transaction")
+                }
             }
         }
     }

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/activity/ActivityViewModel.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/activity/ActivityViewModel.kt
@@ -14,7 +14,9 @@ import com.rjnr.pocketnode.data.gateway.GatewayRepository
 import com.rjnr.pocketnode.data.gateway.models.NetworkType
 import com.rjnr.pocketnode.data.gateway.models.TransactionRecord
 import com.rjnr.pocketnode.data.wallet.WalletPreferences
+import com.rjnr.pocketnode.ui.screens.home.HomeNavEvent
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -26,6 +28,7 @@ import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import javax.inject.Inject
@@ -53,6 +56,11 @@ class ActivityViewModel @Inject constructor(
 
     private val _exportEvent = MutableSharedFlow<String>()
     val exportEvent: SharedFlow<String> = _exportEvent.asSharedFlow()
+
+    // One-shot nav events (e.g. retry-failed-tx → SendScreen with prefill).
+    // Reuses HomeNavEvent — same nav semantics as the Home tab's retry CTA.
+    private val _navEvents = Channel<HomeNavEvent>(Channel.BUFFERED)
+    val navEvents = _navEvents.receiveAsFlow()
 
     @OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
     val transactionPagingFlow: Flow<PagingData<TransactionRecord>> = combine(
@@ -102,6 +110,29 @@ class ActivityViewModel @Inject constructor(
 
     fun setFilter(filter: Filter) {
         _uiState.update { it.copy(filter = filter) }
+    }
+
+    /**
+     * Handles a tap on the Failed chip in the activity list. Loads the failed
+     * `pending_broadcasts` row and emits a nav event with the decoded
+     * recipient + amount for SendScreen prefill. Mirrors HomeViewModel.
+     */
+    fun retryFailedTransaction(txHash: String) {
+        viewModelScope.launch {
+            repository.loadFailedForRetry(txHash)
+                .onSuccess { prefill ->
+                    _navEvents.send(
+                        HomeNavEvent.NavigateToSendWithPrefill(
+                            recipientAddress = prefill.recipientAddress,
+                            amountShannons = prefill.amountShannons
+                        )
+                    )
+                }
+                .onFailure { e ->
+                    Log.e(TAG, "retryFailedTransaction failed for $txHash", e)
+                    _uiState.update { it.copy(error = "Couldn't retry: ${e.message}") }
+                }
+        }
     }
 
     fun exportTransactions() {

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/home/Components.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/home/Components.kt
@@ -282,9 +282,11 @@ fun ActionButton(
 @Composable
 fun TransactionItems(
     transaction: TransactionRecord,
-    onClick: () -> Unit
+    onClick: () -> Unit,
+    onRetry: (() -> Unit)? = null
 ) {
-    val isPending = transaction.isPending()
+    val isFailed = transaction.status == "FAILED"
+    val isPending = !isFailed && transaction.isPending()
     val daoColor = MaterialTheme.colorScheme.primary
 
     val backgroundColor by animateColorAsState(
@@ -426,21 +428,26 @@ fun TransactionItems(
                         )
                     }
                 }
+                // Status chip — distinct visuals for Failed vs Pending vs
+                // Confirmed. Failed is tappable; the parent renders the
+                // confirm dialog and routes the retry through HomeViewModel.
+                val (chipText, chipFg, chipBg) = when {
+                    isFailed -> Triple("Failed", ErrorRed, ErrorRed.copy(alpha = 0.15f))
+                    transaction.isConfirmed() -> Triple("Confirmed", SuccessGreen, SuccessGreen.copy(alpha = 0.15f))
+                    else -> Triple("Pending", PendingAmber, PendingAmber.copy(alpha = 0.15f))
+                }
                 Surface(
-                    color = if (transaction.isConfirmed()) {
-                        SuccessGreen.copy(alpha = 0.15f)
+                    color = chipBg,
+                    shape = CircleShape,
+                    modifier = if (isFailed && onRetry != null) {
+                        Modifier.clickable { onRetry() }
                     } else {
-                        PendingAmber.copy(alpha = 0.15f)
-                    },
-                    shape = CircleShape
+                        Modifier
+                    }
                 ) {
                     Text(
-                        if (transaction.isConfirmed()) "Confirmed" else "Pending",
-                        color = if (transaction.isConfirmed()) {
-                            SuccessGreen
-                        } else {
-                            PendingAmber
-                        },
+                        chipText,
+                        color = chipFg,
                         fontSize = 12.sp,
                         fontWeight = FontWeight.Bold,
                         modifier = Modifier.padding(horizontal = 12.dp, vertical = 4.dp)

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/home/HomeScreen.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/home/HomeScreen.kt
@@ -307,6 +307,10 @@ fun HomeScreen(
                 } catch (_: android.content.ActivityNotFoundException) {
                     // No browser available
                 }
+            },
+            onRetry = { tx ->
+                selectedTransaction = null
+                retryDialogTx = tx
             }
         )
     }
@@ -881,7 +885,8 @@ private fun TransactionDetailSheet(
     network: NetworkType,
     onDismiss: () -> Unit,
     onCopyTxHash: (String) -> Unit,
-    onOpenExplorer: (String) -> Unit
+    onOpenExplorer: (String) -> Unit,
+    onRetry: ((TransactionRecord) -> Unit)? = null
 ) {
     val isIncoming = transaction.isIncoming()
     val isOutgoing = transaction.isOutgoing()
@@ -1057,6 +1062,23 @@ private fun TransactionDetailSheet(
                     value = displayBlockHash,
                     isMonospace = true
                 )
+            }
+
+            // Retry CTA — only for FAILED rows that came through the broadcast
+            // state machine (legacy ghosts pass null for onRetry from the
+            // call site, since loadFailedForRetry can't prefill them).
+            if (transaction.status == "FAILED" && onRetry != null) {
+                Spacer(modifier = Modifier.height(24.dp))
+                Button(
+                    onClick = { onRetry(transaction) },
+                    modifier = Modifier.fillMaxWidth(),
+                    colors = ButtonDefaults.buttonColors(
+                        containerColor = MaterialTheme.colorScheme.error,
+                        contentColor = MaterialTheme.colorScheme.onError
+                    )
+                ) {
+                    Text("Retry Transaction")
+                }
             }
         }
     }

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/home/HomeScreen.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/home/HomeScreen.kt
@@ -100,7 +100,7 @@ import kotlinx.coroutines.launch
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun HomeScreen(
-    onNavigateToSend: () -> Unit = {},
+    onNavigateToSend: (recipient: String?, amountShannons: Long?) -> Unit = { _, _ -> },
     onNavigateToReceive: () -> Unit = {},
     onNavigateToBackup: () -> Unit = {},
     onNavigateToDao: () -> Unit = {},
@@ -114,9 +114,21 @@ fun HomeScreen(
     val context = LocalContext.current
     val snackbarHostState = remember { SnackbarHostState() }
     var selectedTransaction by remember { mutableStateOf<TransactionRecord?>(null) }
+    var retryDialogTx by remember { mutableStateOf<TransactionRecord?>(null) }
     var showAccountSelector by remember { mutableStateOf(false) }
     val scope = rememberCoroutineScope()
     val lifecycleOwner = androidx.lifecycle.compose.LocalLifecycleOwner.current
+
+    // Collect one-shot nav events from the ViewModel (e.g. retry-failed-tx).
+    LaunchedEffect(Unit) {
+        viewModel.navEvents.collect { event ->
+            when (event) {
+                is HomeNavEvent.NavigateToSendWithPrefill -> {
+                    onNavigateToSend(event.recipientAddress, event.amountShannons)
+                }
+            }
+        }
+    }
 
     // Refresh security state (PIN, backup) when returning from setup screens
     DisposableEffect(lifecycleOwner) {
@@ -252,6 +264,26 @@ fun HomeScreen(
             Log.e("HomeScreen", "Error: $error")
             viewModel.clearError()
         }
+    }
+
+    // Retry-failed-tx confirmation. Copy intentionally hedges: FAILED is a
+    // heuristic (null × 3 + tip past +25), not proof the network rejected
+    // the tx. See spec §6 cases a–d.
+    retryDialogTx?.let { tx ->
+        AlertDialog(
+            onDismissRequest = { retryDialogTx = null },
+            title = { Text("Retry transaction?") },
+            text = { Text("This transaction may not have reached the network. Retry?") },
+            confirmButton = {
+                TextButton(onClick = {
+                    retryDialogTx = null
+                    viewModel.retryFailedTransaction(tx.txHash)
+                }) { Text("Retry") }
+            },
+            dismissButton = {
+                TextButton(onClick = { retryDialogTx = null }) { Text("Cancel") }
+            }
+        )
     }
 
     // Transaction detail bottom sheet
@@ -398,7 +430,8 @@ fun HomeScreen(
                     clipboardManager = clipboardManager,
                     snackbarHostState = snackbarHostState,
                     scope = scope,
-                    selectedTransaction = { selectedTransaction = it }
+                    selectedTransaction = { selectedTransaction = it },
+                    onRetryFailed = { retryDialogTx = it }
                 )
                 if (uiState.isSwitchingWallet) {
                     LinearProgressIndicator(
@@ -419,7 +452,7 @@ fun HomeScreenUI(
     refresh: () -> Unit,
     padding: PaddingValues,
     onNavigateToBackup: () -> Unit,
-    onNavigateToSend: () -> Unit,
+    onNavigateToSend: (recipient: String?, amountShannons: Long?) -> Unit,
     onNavigateToReceive: () -> Unit,
     onNavigateToDao: () -> Unit = {},
     onNavigateToActivity: () -> Unit = {},
@@ -430,6 +463,7 @@ fun HomeScreenUI(
     snackbarHostState: SnackbarHostState,
     scope: CoroutineScope,
     selectedTransaction: (tx: TransactionRecord) -> Unit,
+    onRetryFailed: (tx: TransactionRecord) -> Unit = {},
 ) {
     PullToRefreshBox(
         isRefreshing = uiState.isRefreshing,
@@ -524,7 +558,7 @@ fun HomeScreenUI(
             // Quick Actions Row
             item {
                 ActionRow(
-                    onSend = onNavigateToSend,
+                    onSend = { onNavigateToSend(null, null) },
                     onReceive = onNavigateToReceive,
                     onStake = onNavigateToDao
                 )
@@ -575,7 +609,10 @@ fun HomeScreenUI(
                 ) { tx ->
                     TransactionItems(
                         transaction = tx,
-                        onClick = { selectedTransaction(tx) }
+                        onClick = { selectedTransaction(tx) },
+                        onRetry = if (tx.status == "FAILED") {
+                            { onRetryFailed(tx) }
+                        } else null
                     )
                 }
             }
@@ -1142,7 +1179,7 @@ private fun HomeScreenUIPreview() {
             refresh = {},
             padding = PaddingValues(0.dp),
             onNavigateToBackup = {},
-            onNavigateToSend = {},
+            onNavigateToSend = { _, _ -> },
             onNavigateToReceive = {},
             dismissBackupReminder = {},
             onToggleBalanceVisibility = {},

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/home/HomeScreen.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/home/HomeScreen.kt
@@ -911,23 +911,30 @@ private fun TransactionDetailSheet(
                     fontWeight = FontWeight.Bold
                 )
 
-                // Status badge
-                Surface(
-                    color = if (transaction.isConfirmed()) {
+                // Status badge — Confirmed / Pending / Failed (#115)
+                val isFailed = transaction.status == "FAILED"
+                val (badgeLabel, badgeFg, badgeBg) = when {
+                    isFailed -> Triple(
+                        "Failed",
+                        MaterialTheme.colorScheme.error,
+                        MaterialTheme.colorScheme.error.copy(alpha = 0.15f)
+                    )
+                    transaction.isConfirmed() -> Triple(
+                        "Confirmed",
+                        SuccessGreen,
                         SuccessGreen.copy(alpha = 0.15f)
-                    } else {
+                    )
+                    else -> Triple(
+                        "Pending",
+                        MaterialTheme.colorScheme.tertiary,
                         MaterialTheme.colorScheme.tertiary.copy(alpha = 0.2f)
-                    },
-                    shape = RoundedCornerShape(8.dp)
-                ) {
+                    )
+                }
+                Surface(color = badgeBg, shape = RoundedCornerShape(8.dp)) {
                     Text(
-                        text = if (transaction.isConfirmed()) "Confirmed" else "Pending",
+                        text = badgeLabel,
                         style = MaterialTheme.typography.labelMedium,
-                        color = if (transaction.isConfirmed()) {
-                            SuccessGreen
-                        } else {
-                            MaterialTheme.colorScheme.tertiary
-                        },
+                        color = badgeFg,
                         modifier = Modifier.padding(horizontal = 12.dp, vertical = 6.dp)
                     )
                 }

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/home/HomeScreen.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/home/HomeScreen.kt
@@ -614,7 +614,7 @@ fun HomeScreenUI(
                     TransactionItems(
                         transaction = tx,
                         onClick = { selectedTransaction(tx) },
-                        onRetry = if (tx.status == "FAILED") {
+                        onRetry = if (tx.status == "FAILED" && tx.isOutgoing()) {
                             { onRetryFailed(tx) }
                         } else null
                     )
@@ -1064,10 +1064,11 @@ private fun TransactionDetailSheet(
                 )
             }
 
-            // Retry CTA — only for FAILED rows that came through the broadcast
-            // state machine (legacy ghosts pass null for onRetry from the
-            // call site, since loadFailedForRetry can't prefill them).
-            if (transaction.status == "FAILED" && onRetry != null) {
+            // Retry CTA — only for FAILED plain transfers. DAO deposit/withdraw/unlock
+            // and self-transfers can't be retried via the simple recipient/amount
+            // prefill path (loadFailedForRetry's smallest-output heuristic produces
+            // bogus data for them).
+            if (transaction.status == "FAILED" && transaction.isOutgoing() && onRetry != null) {
                 Spacer(modifier = Modifier.height(24.dp))
                 Button(
                     onClick = { onRetry(transaction) },

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/home/HomeViewModel.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/home/HomeViewModel.kt
@@ -22,6 +22,7 @@ import com.rjnr.pocketnode.data.wallet.WalletInfo
 import com.rjnr.pocketnode.data.wallet.WalletRepository
 import com.rjnr.pocketnode.ui.components.WalletGroup
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.*
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
@@ -31,6 +32,23 @@ import java.util.Locale
 import javax.inject.Inject
 
 private const val TAG = "HomeViewModel"
+
+/**
+ * One-shot navigation events from [HomeViewModel]. UI collects via
+ * `viewModel.navEvents` and routes the user accordingly. Modeled as a
+ * [Channel]-backed flow so each event is delivered exactly once and
+ * re-collection (e.g. after config change) doesn't replay stale events.
+ */
+sealed class HomeNavEvent {
+    /**
+     * Navigate to SendScreen with prefilled recipient + amount, used by the
+     * Failed-tx retry CTA in the activity list.
+     */
+    data class NavigateToSendWithPrefill(
+        val recipientAddress: String,
+        val amountShannons: Long
+    ) : HomeNavEvent()
+}
 
 @HiltViewModel
 class HomeViewModel @Inject constructor(
@@ -52,6 +70,11 @@ class HomeViewModel @Inject constructor(
 
     private val _uiState = MutableStateFlow(HomeUiState())
     val uiState: StateFlow<HomeUiState> = _uiState.asStateFlow()
+
+    // One-shot nav events (e.g. retry-failed-tx → SendScreen with prefill).
+    // BUFFERED so an event isn't dropped if the UI is mid-recomposition.
+    private val _navEvents = Channel<HomeNavEvent>(Channel.BUFFERED)
+    val navEvents = _navEvents.receiveAsFlow()
 
     private var previousBalanceWasZero = true
 
@@ -335,6 +358,35 @@ class HomeViewModel @Inject constructor(
 
     fun clearError() {
         _uiState.update { it.copy(error = null) }
+    }
+
+    /**
+     * Handles a tap on the Failed chip in the activity list. Loads the failed
+     * `pending_broadcasts` row, deletes the failed-state rows so the retry
+     * doesn't see itself as a reservation, and emits a nav event with the
+     * decoded recipient + amount for SendScreen prefill.
+     */
+    fun retryFailedTransaction(txHash: String) {
+        viewModelScope.launch {
+            repository.loadFailedForRetry(txHash)
+                .onSuccess { prefill ->
+                    _navEvents.send(
+                        HomeNavEvent.NavigateToSendWithPrefill(
+                            recipientAddress = prefill.recipientAddress,
+                            amountShannons = prefill.amountShannons
+                        )
+                    )
+                    // Drop the row from the in-memory list so the chip disappears
+                    // immediately (the next refresh will confirm the row is gone).
+                    _uiState.update { state ->
+                        state.copy(transactions = state.transactions.filter { it.txHash != txHash })
+                    }
+                }
+                .onFailure { e ->
+                    Log.e(TAG, "retryFailedTransaction failed for $txHash", e)
+                    _uiState.update { it.copy(error = "Couldn't retry: ${e.message}") }
+                }
+        }
     }
 
     /**

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/send/SendScreen.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/send/SendScreen.kt
@@ -98,6 +98,8 @@ fun SendScreen(
     onNavigateToPinVerify: () -> Unit = {},
     scannedAddress: String? = null,
     sendAuthVerified: Boolean = false,
+    prefillRecipient: String? = null,
+    prefillAmountShannons: Long? = null,
     viewModel: SendViewModel = hiltViewModel()
 ) {
     val uiState by viewModel.uiState.collectAsState()
@@ -108,6 +110,18 @@ fun SendScreen(
             if (address.isNotBlank()) {
                 viewModel.updateRecipient(address)
             }
+        }
+    }
+
+    // Retry-failed-tx prefill (#115). One-shot — keyed on the inputs so it
+    // runs once per navigation. updateRecipient/updateAmount are the same
+    // ViewModel hooks the rest of the screen uses.
+    LaunchedEffect(prefillRecipient, prefillAmountShannons) {
+        prefillRecipient?.let { viewModel.updateRecipient(it) }
+        prefillAmountShannons?.let { shannons ->
+            val ckb = shannons / 100_000_000.0
+            val text = "%.8f".format(ckb).trimEnd('0').trimEnd('.')
+            viewModel.updateAmount(text.ifEmpty { "0" })
         }
     }
 

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/send/SendScreen.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/send/SendScreen.kt
@@ -120,7 +120,8 @@ fun SendScreen(
         prefillRecipient?.let { viewModel.updateRecipient(it) }
         prefillAmountShannons?.let { shannons ->
             val ckb = shannons / 100_000_000.0
-            val text = "%.8f".format(ckb).trimEnd('0').trimEnd('.')
+            // Locale.US — sanitizeAmount rejects comma decimals.
+            val text = String.format(Locale.US, "%.8f", ckb).trimEnd('0').trimEnd('.')
             viewModel.updateAmount(text.ifEmpty { "0" })
         }
     }

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/send/SendViewModel.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/send/SendViewModel.kt
@@ -150,8 +150,9 @@ class SendViewModel @Inject constructor(
         val feeShannons = transactionBuilder.estimateTransferFee(inputCount = 1, outputCount = 1)
         val maxShannons = (balanceShannons - feeShannons).coerceAtLeast(0L)
         val maxCkb = maxShannons / 100_000_000.0
-        // Format to 8 decimal places, then strip trailing zeros (and trailing dot)
-        val formatted = "%.8f".format(maxCkb)
+        // Locale.US — sanitizeAmount rejects comma decimals; on de/fr/es devices
+        // `"%.8f".format(...)` would emit "0,12345678" and silently drop the prefill.
+        val formatted = String.format(java.util.Locale.US, "%.8f", maxCkb)
             .trimEnd('0')
             .trimEnd('.')
         updateAmount(formatted.ifEmpty { "0" })

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/send/SendViewModel.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/send/SendViewModel.kt
@@ -217,7 +217,6 @@ class SendViewModel @Inject constructor(
 
         // Capture wallet identity upfront to prevent wallet-switch race conditions
         val capturedAddress = repository.getCurrentAddress()
-        val capturedNetwork = repository.currentNetwork
 
         if (capturedAddress == null) {
             _uiState.update { it.copy(error = "Wallet not initialized") }
@@ -244,31 +243,15 @@ class SendViewModel @Inject constructor(
                 Log.d(TAG, "  Amount: ${state.amountCkb} CKB ($amountShannons shannons)")
                 Log.d(TAG, "  From address: $capturedAddress")
 
-                Log.d(TAG, "Fetching available cells...")
-                val cellsResult = repository.getCells(capturedAddress)
-                val cells = cellsResult.getOrThrow().items
-                Log.d(TAG, "Got ${cells.size} cells")
-                cells.forEachIndexed { i, cell ->
-                    Log.d(TAG, "  Cell[$i]: ${cell.capacityAsLong()} shannons")
-                }
+                _uiState.update { it.copy(statusMessage = "Broadcasting transaction...") }
+                Log.d(TAG, "📡 prepareAndSend: fetching cells, filtering reserved, building, broadcasting...")
 
-                _uiState.update { it.copy(statusMessage = "Signing transaction...") }
-                Log.d(TAG, "Building and signing transaction...")
-
-                val signedTx = transactionBuilder.buildTransfer(
+                val txHash = repository.prepareAndSend(
                     fromAddress = capturedAddress,
                     toAddress = state.recipientAddress,
                     amountShannons = amountShannons,
-                    availableCells = cells,
-                    privateKey = capturedKey,
-                    network = capturedNetwork
-                )
-                Log.d(TAG, "✅ Transaction built: ${signedTx.cellInputs.size} inputs, ${signedTx.cellOutputs.size} outputs")
-
-                _uiState.update { it.copy(statusMessage = "Broadcasting transaction...") }
-                Log.d(TAG, "📡 Broadcasting transaction...")
-
-                val txHash = repository.sendTransaction(signedTx).getOrThrow()
+                    privateKey = capturedKey
+                ).getOrThrow()
                 Log.d(TAG, "✅ Transaction sent! Hash: $txHash")
 
                 _uiState.update {

--- a/android/app/src/test/java/com/rjnr/pocketnode/data/database/MigrationTest.kt
+++ b/android/app/src/test/java/com/rjnr/pocketnode/data/database/MigrationTest.kt
@@ -31,7 +31,7 @@ class MigrationTest {
     fun setup() {
         val context = ApplicationProvider.getApplicationContext<Context>()
         db = Room.inMemoryDatabaseBuilder(context, AppDatabase::class.java)
-            .addMigrations(MIGRATION_1_2, MIGRATION_2_3, MIGRATION_3_4, MIGRATION_4_5, MIGRATION_5_6, MIGRATION_6_7)
+            .addMigrations(MIGRATION_1_2, MIGRATION_2_3, MIGRATION_3_4, MIGRATION_4_5, MIGRATION_5_6, MIGRATION_6_7, MIGRATION_7_8)
             .allowMainThreadQueries()
             .build()
     }
@@ -177,6 +177,12 @@ class MigrationTest {
 
         db.keyMaterialDao().delete("to-delete")
         assertEquals(0, db.keyMaterialDao().count())
+    }
+
+    @Test
+    fun `v8 pending_broadcasts table is accessible`() = runTest {
+        val dao = db.pendingBroadcastDao()
+        assertEquals(0, dao.getActive("any", "TESTNET").size)
     }
 
     @Test

--- a/android/app/src/test/java/com/rjnr/pocketnode/data/database/dao/PendingBroadcastDaoTest.kt
+++ b/android/app/src/test/java/com/rjnr/pocketnode/data/database/dao/PendingBroadcastDaoTest.kt
@@ -1,0 +1,142 @@
+package com.rjnr.pocketnode.data.database.dao
+
+import android.content.Context
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import com.rjnr.pocketnode.data.database.AppDatabase
+import com.rjnr.pocketnode.data.database.entity.PendingBroadcastEntity
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class PendingBroadcastDaoTest {
+
+    private lateinit var db: AppDatabase
+    private lateinit var dao: PendingBroadcastDao
+
+    @Before
+    fun setup() {
+        val ctx = ApplicationProvider.getApplicationContext<Context>()
+        db = Room.inMemoryDatabaseBuilder(ctx, AppDatabase::class.java)
+            .allowMainThreadQueries().build()
+        dao = db.pendingBroadcastDao()
+    }
+
+    @After fun teardown() = db.close()
+
+    private fun row(
+        hash: String = "0xaa",
+        wallet: String = "w1",
+        net: String = "TESTNET",
+        state: String = "BROADCASTING",
+        nullCount: Int = 0
+    ) = PendingBroadcastEntity(
+        txHash = hash, walletId = wallet, network = net,
+        signedTxJson = "{}", reservedInputs = "[]",
+        state = state, submittedAtTipBlock = 100L, nullCount = nullCount,
+        createdAt = 0L, lastCheckedAt = 0L
+    )
+
+    @Test
+    fun `insert and getActive returns row`() = runTest {
+        dao.insert(row())
+        val active = dao.getActive("w1", "TESTNET")
+        assertEquals(1, active.size)
+        assertEquals("0xaa", active[0].txHash)
+    }
+
+    @Test
+    fun `getActive filters out terminal states`() = runTest {
+        dao.insert(row(hash = "0xaa", state = "BROADCASTING"))
+        dao.insert(row(hash = "0xbb", state = "BROADCAST"))
+        dao.insert(row(hash = "0xcc", state = "CONFIRMED"))
+        dao.insert(row(hash = "0xdd", state = "FAILED"))
+        val active = dao.getActive("w1", "TESTNET")
+        assertEquals(2, active.size)
+        assertEquals(setOf("0xaa", "0xbb"), active.map { it.txHash }.toSet())
+    }
+
+    @Test
+    fun `getActive scopes to walletId and network`() = runTest {
+        dao.insert(row(hash = "0xaa", wallet = "w1", net = "TESTNET"))
+        dao.insert(row(hash = "0xbb", wallet = "w2", net = "TESTNET"))
+        dao.insert(row(hash = "0xcc", wallet = "w1", net = "MAINNET"))
+        val active = dao.getActive("w1", "TESTNET")
+        assertEquals(1, active.size)
+        assertEquals("0xaa", active[0].txHash)
+    }
+
+    @Test
+    fun `compareAndUpdateState succeeds when expected matches`() = runTest {
+        dao.insert(row(state = "BROADCASTING"))
+        val rows = dao.compareAndUpdateState("0xaa", expected = "BROADCASTING", next = "BROADCAST", now = 5L)
+        assertEquals(1, rows)
+        val updated = dao.getActive("w1", "TESTNET")[0]
+        assertEquals("BROADCAST", updated.state)
+        assertEquals(5L, updated.lastCheckedAt)
+    }
+
+    @Test
+    fun `compareAndUpdateState fails when expected mismatches`() = runTest {
+        dao.insert(row(state = "BROADCAST"))
+        val rows = dao.compareAndUpdateState("0xaa", expected = "BROADCASTING", next = "FAILED", now = 5L)
+        assertEquals(0, rows)
+        val unchanged = dao.getActive("w1", "TESTNET")[0]
+        assertEquals("BROADCAST", unchanged.state)
+    }
+
+    @Test
+    fun `updateNullCount writes count and timestamp`() = runTest {
+        dao.insert(row(nullCount = 0))
+        dao.updateNullCount("0xaa", count = 2, now = 10L)
+        val r = dao.getActive("w1", "TESTNET")[0]
+        assertEquals(2, r.nullCount)
+        assertEquals(10L, r.lastCheckedAt)
+    }
+
+    @Test
+    fun `delete removes row`() = runTest {
+        dao.insert(row())
+        dao.delete("0xaa")
+        assertEquals(0, dao.getActive("w1", "TESTNET").size)
+    }
+
+    @Test
+    fun `observeActive emits current snapshot then updates`() = runTest {
+        dao.insert(row(hash = "0xaa", state = "BROADCASTING"))
+        val first = dao.observeActive("w1", "TESTNET").first()
+        assertEquals(1, first.size)
+
+        dao.compareAndUpdateState("0xaa", "BROADCASTING", "CONFIRMED", now = 0L)
+        val afterTerminal = dao.observeActive("w1", "TESTNET").first()
+        assertEquals(0, afterTerminal.size)
+    }
+
+    @Test
+    fun `observeFailed emits FAILED rows only`() = runTest {
+        dao.insert(row(hash = "0xaa", state = "FAILED"))
+        dao.insert(row(hash = "0xbb", state = "BROADCASTING"))
+        val failed = dao.observeFailed("w1", "TESTNET").first()
+        assertEquals(1, failed.size)
+        assertEquals("0xaa", failed[0].txHash)
+    }
+
+    @Test
+    fun `getFailedRow returns null for non-FAILED rows`() = runTest {
+        dao.insert(row(hash = "0xaa", state = "BROADCAST"))
+        assertEquals(null, dao.getFailedRow("0xaa"))
+    }
+
+    @Test
+    fun `getFailedRow returns the row when FAILED`() = runTest {
+        dao.insert(row(hash = "0xaa", state = "FAILED"))
+        val r = dao.getFailedRow("0xaa")
+        assertEquals("0xaa", r?.txHash)
+    }
+}

--- a/android/app/src/test/java/com/rjnr/pocketnode/data/gateway/CellReservationFilterTest.kt
+++ b/android/app/src/test/java/com/rjnr/pocketnode/data/gateway/CellReservationFilterTest.kt
@@ -1,0 +1,122 @@
+package com.rjnr.pocketnode.data.gateway
+
+import android.content.Context
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import com.rjnr.pocketnode.data.database.AppDatabase
+import com.rjnr.pocketnode.data.database.entity.PendingBroadcastEntity
+import com.rjnr.pocketnode.data.gateway.models.OutPoint
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.builtins.ListSerializer
+import kotlinx.serialization.json.Json
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+/**
+ * Verifies the cell-reservation filter logic that runs inside
+ * GatewayRepository.prepareAndSend's sendMutex section. The filter
+ * is a pure function over (live cells, reserved OutPoints), so the
+ * test exercises that function shape directly rather than instantiating
+ * the full Repository — same approach as GatewayRepositorySendTransactionTest.
+ */
+@RunWith(RobolectricTestRunner::class)
+class CellReservationFilterTest {
+
+    private lateinit var db: AppDatabase
+    private val json = Json { ignoreUnknownKeys = true; encodeDefaults = true }
+
+    @Before
+    fun setup() {
+        val ctx = ApplicationProvider.getApplicationContext<Context>()
+        db = Room.inMemoryDatabaseBuilder(ctx, AppDatabase::class.java)
+            .allowMainThreadQueries().build()
+    }
+
+    @After
+    fun teardown() = db.close()
+
+    private fun outPoint(hash: String, idx: String = "0x0") = OutPoint(hash, idx)
+
+    private fun row(
+        txHash: String,
+        inputs: List<OutPoint>,
+        state: String = "BROADCAST",
+        wallet: String = "w1",
+        net: String = "TESTNET"
+    ) = PendingBroadcastEntity(
+        txHash = txHash,
+        walletId = wallet,
+        network = net,
+        signedTxJson = "{}",
+        reservedInputs = json.encodeToString(
+            ListSerializer(OutPoint.serializer()),
+            inputs
+        ),
+        state = state,
+        submittedAtTipBlock = 0L,
+        nullCount = 0,
+        createdAt = 0L,
+        lastCheckedAt = 0L
+    )
+
+    /** Mirrors the filter logic in GatewayRepository.prepareAndSend. */
+    private suspend fun filterAvailable(
+        live: List<OutPoint>, walletId: String, network: String
+    ): List<OutPoint> {
+        val pending = db.pendingBroadcastDao().getActive(walletId, network)
+        val reserved = pending.flatMap {
+            json.decodeFromString(
+                ListSerializer(OutPoint.serializer()),
+                it.reservedInputs
+            )
+        }.toSet()
+        return live.filter { it !in reserved }
+    }
+
+    @Test
+    fun `with no pending rows returns all live cells`() = runTest {
+        val live = listOf(outPoint("0x01"), outPoint("0x02"), outPoint("0x03"))
+        val available = filterAvailable(live, "w1", "TESTNET")
+        assertEquals(3, available.size)
+    }
+
+    @Test
+    fun `excludes inputs reserved by an active row`() = runTest {
+        db.pendingBroadcastDao().insert(row("0xaa", listOf(outPoint("0x01"))))
+        val live = listOf(outPoint("0x01"), outPoint("0x02"), outPoint("0x03"))
+        val available = filterAvailable(live, "w1", "TESTNET")
+        assertEquals(2, available.size)
+        assertEquals(setOf(outPoint("0x02"), outPoint("0x03")), available.toSet())
+    }
+
+    @Test
+    fun `excludes union across multiple active rows`() = runTest {
+        db.pendingBroadcastDao().insert(row("0xaa", listOf(outPoint("0x01"), outPoint("0x02"))))
+        db.pendingBroadcastDao().insert(row("0xbb", listOf(outPoint("0x03"))))
+        val live = (1..5).map { outPoint("0x0$it") }
+        val available = filterAvailable(live, "w1", "TESTNET")
+        assertEquals(setOf(outPoint("0x04"), outPoint("0x05")), available.toSet())
+    }
+
+    @Test
+    fun `terminal-state rows do not reserve anything`() = runTest {
+        db.pendingBroadcastDao().insert(row("0xaa", listOf(outPoint("0x01")), state = "CONFIRMED"))
+        db.pendingBroadcastDao().insert(row("0xbb", listOf(outPoint("0x02")), state = "FAILED"))
+        val live = listOf(outPoint("0x01"), outPoint("0x02"))
+        val available = filterAvailable(live, "w1", "TESTNET")
+        assertEquals(2, available.size)
+    }
+
+    @Test
+    fun `wallet and network scope is honored`() = runTest {
+        db.pendingBroadcastDao().insert(row("0xaa", listOf(outPoint("0x01")), wallet = "w2"))
+        db.pendingBroadcastDao().insert(row("0xbb", listOf(outPoint("0x02")), net = "MAINNET"))
+        val live = listOf(outPoint("0x01"), outPoint("0x02"), outPoint("0x03"))
+        val available = filterAvailable(live, "w1", "TESTNET")
+        assertEquals(3, available.size)  // neither reservation matches w1+TESTNET
+    }
+}

--- a/android/app/src/test/java/com/rjnr/pocketnode/data/gateway/GatewayRepositorySendTransactionTest.kt
+++ b/android/app/src/test/java/com/rjnr/pocketnode/data/gateway/GatewayRepositorySendTransactionTest.kt
@@ -1,0 +1,278 @@
+package com.rjnr.pocketnode.data.gateway
+
+import android.content.Context
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import com.rjnr.pocketnode.data.database.AppDatabase
+import com.rjnr.pocketnode.data.database.entity.PendingBroadcastEntity
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+/**
+ * Tests for the persistence side-effects of #115 Phase A Task 2 —
+ * the new pre-broadcast insert + CAS / rollback logic that lives inside
+ * GatewayRepository.sendTransaction.
+ *
+ * Test approach: persistence-pattern simulation (NOT full Repository
+ * instantiation). Reason: GatewayRepository's constructor pulls in
+ * KeyManager, WalletPreferences, AppDatabase, multiple DAOs, the
+ * TransactionBuilder, and the JNI bridge — wiring all of those up in
+ * Robolectric for a unit test would require extensive stubbing while
+ * adding little signal beyond what we get by exercising the exact
+ * persistence pattern (insert under sendMutex, CAS on success, delete
+ * on null/exception) directly against an in-memory Room DB. The
+ * BroadcastClient indirection (introduced in this task) is also
+ * exercised here via fake implementations.
+ *
+ * If the persistence logic in GatewayRepository diverges from this
+ * pattern, the integration must be re-validated by hand or via an
+ * instrumentation test; the contract this test pins is:
+ *
+ *   1. Happy path:   pending_broadcasts ends in BROADCAST,
+ *                    transactions row remains PENDING with the
+ *                    actual balanceChange (not "0x0").
+ *   2. JNI null:     both rows deleted.
+ *   3. JNI throws:   both rows deleted.
+ *   4. Idempotent:   second insert with same hash is skipped.
+ *   5. CAS guard:    compareAndUpdateState returns 1 only when state
+ *                    is BROADCASTING; subsequent calls return 0.
+ */
+@RunWith(RobolectricTestRunner::class)
+class GatewayRepositorySendTransactionTest {
+
+    private lateinit var db: AppDatabase
+    private lateinit var cacheManager: CacheManager
+    private val sendMutex = Mutex()
+
+    private val walletId = "wallet-1"
+    private val network = "TESTNET"
+    private val txHash = "0x" + "ab".repeat(32)
+    private val signedJson = """{"version":"0x0"}"""
+    private val reservedJson = """[]"""
+
+    @Before
+    fun setup() {
+        val ctx = ApplicationProvider.getApplicationContext<Context>()
+        db = Room.inMemoryDatabaseBuilder(ctx, AppDatabase::class.java)
+            .allowMainThreadQueries()
+            .build()
+        cacheManager = CacheManager(db.transactionDao(), db.balanceCacheDao())
+    }
+
+    @After
+    fun teardown() {
+        db.close()
+    }
+
+    /** Mirrors the sendMutex.withLock block from sendTransaction. */
+    private suspend fun preBroadcastInsert(
+        balanceChangeHex: String,
+        tipNumber: Long = 100L,
+        now: Long = System.currentTimeMillis()
+    ) {
+        sendMutex.withLock {
+            val existing = db.pendingBroadcastDao().getActive(walletId, network)
+                .firstOrNull { it.txHash == txHash }
+            if (existing == null) {
+                db.pendingBroadcastDao().insert(
+                    PendingBroadcastEntity(
+                        txHash = txHash,
+                        walletId = walletId,
+                        network = network,
+                        signedTxJson = signedJson,
+                        reservedInputs = reservedJson,
+                        state = "BROADCASTING",
+                        submittedAtTipBlock = tipNumber,
+                        nullCount = 0,
+                        createdAt = now,
+                        lastCheckedAt = now
+                    )
+                )
+                cacheManager.insertPendingTransaction(
+                    txHash = txHash,
+                    network = network,
+                    walletId = walletId,
+                    balanceChange = balanceChangeHex,
+                    direction = "out",
+                    fee = "0x0"
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `happy path - rows persist and CAS to BROADCAST`() = runTest {
+        val balanceChangeHex = "-0x" + 6_100_000_000L.toString(16)
+        val fakeBroadcast = BroadcastClient { _ -> "\"$txHash\"" }
+
+        // Pre-broadcast insert
+        preBroadcastInsert(balanceChangeHex)
+
+        // After insert: pending_broadcasts row in BROADCASTING; transactions row PENDING.
+        val activeBefore = db.pendingBroadcastDao().getActive(walletId, network)
+        assertEquals(1, activeBefore.size)
+        assertEquals("BROADCASTING", activeBefore.first().state)
+
+        val txBefore = db.transactionDao().getByTxHash(txHash)
+        assertNotNull(txBefore)
+        assertEquals("PENDING", txBefore!!.status)
+        assertEquals(balanceChangeHex, txBefore.balanceChange)
+        // UX bug guard: the old code wrote "0x0" here.
+        assertTrue(
+            "balanceChange must not be the placeholder '0x0'",
+            txBefore.balanceChange != "0x0"
+        )
+        assertEquals("out", txBefore.direction)
+
+        // Broadcast (outside mutex) — JNI returns matching hash.
+        val raw = fakeBroadcast.sendRaw(signedJson)
+        val returnedHash = raw!!.trim('"')
+        assertEquals(txHash, returnedHash)
+
+        val cas = db.pendingBroadcastDao().compareAndUpdateState(
+            hash = txHash,
+            expected = "BROADCASTING",
+            next = "BROADCAST",
+            now = System.currentTimeMillis()
+        )
+        assertEquals(1, cas)
+
+        val activeAfter = db.pendingBroadcastDao().getActive(walletId, network)
+        assertEquals(1, activeAfter.size)
+        assertEquals("BROADCAST", activeAfter.first().state)
+        // Tx row still PENDING — that's the user-facing ledger state.
+        assertEquals("PENDING", db.transactionDao().getByTxHash(txHash)!!.status)
+    }
+
+    @Test
+    fun `JNI null - both rows deleted`() = runTest {
+        val balanceChangeHex = "-0x" + 6_100_000_000L.toString(16)
+        val fakeBroadcast = BroadcastClient { _ -> null }
+
+        preBroadcastInsert(balanceChangeHex)
+        assertEquals(1, db.pendingBroadcastDao().getActive(walletId, network).size)
+        assertNotNull(db.transactionDao().getByTxHash(txHash))
+
+        val raw = fakeBroadcast.sendRaw(signedJson)
+        if (raw == null) {
+            db.pendingBroadcastDao().delete(txHash)
+            cacheManager.deleteTransaction(txHash)
+        }
+
+        assertEquals(0, db.pendingBroadcastDao().getActive(walletId, network).size)
+        assertNull(db.transactionDao().getByTxHash(txHash))
+    }
+
+    @Test
+    fun `JNI throws - both rows deleted`() = runTest {
+        val balanceChangeHex = "-0x" + 6_100_000_000L.toString(16)
+        val fakeBroadcast = BroadcastClient { _ -> throw RuntimeException("boom") }
+
+        preBroadcastInsert(balanceChangeHex)
+        assertEquals(1, db.pendingBroadcastDao().getActive(walletId, network).size)
+        assertNotNull(db.transactionDao().getByTxHash(txHash))
+
+        try {
+            fakeBroadcast.sendRaw(signedJson)
+            error("should have thrown")
+        } catch (e: RuntimeException) {
+            db.pendingBroadcastDao().delete(txHash)
+            cacheManager.deleteTransaction(txHash)
+        }
+
+        assertEquals(0, db.pendingBroadcastDao().getActive(walletId, network).size)
+        assertNull(db.transactionDao().getByTxHash(txHash))
+    }
+
+    @Test
+    fun `idempotent - second insert with same hash skipped`() = runTest {
+        val balanceChangeHex = "-0x" + 6_100_000_000L.toString(16)
+
+        preBroadcastInsert(balanceChangeHex)
+        // Second call should observe the existing row and skip.
+        preBroadcastInsert(balanceChangeHex)
+
+        val active = db.pendingBroadcastDao().getActive(walletId, network)
+        assertEquals(1, active.size)
+        assertEquals("BROADCASTING", active.first().state)
+    }
+
+    @Test
+    fun `CAS guard - second compareAndUpdateState returns zero`() = runTest {
+        preBroadcastInsert("-0x1")
+
+        val first = db.pendingBroadcastDao().compareAndUpdateState(
+            hash = txHash,
+            expected = "BROADCASTING",
+            next = "BROADCAST",
+            now = System.currentTimeMillis()
+        )
+        assertEquals(1, first)
+
+        // Second CAS from BROADCASTING is a no-op (row already in BROADCAST).
+        val second = db.pendingBroadcastDao().compareAndUpdateState(
+            hash = txHash,
+            expected = "BROADCASTING",
+            next = "BROADCAST",
+            now = System.currentTimeMillis()
+        )
+        assertEquals(0, second)
+    }
+
+    @Test
+    fun `hash mismatch path - re-key under returned hash`() = runTest {
+        val balanceChangeHex = "-0x" + 6_100_000_000L.toString(16)
+        val returnedHash = "0x" + "cd".repeat(32)
+        val fakeBroadcast = BroadcastClient { _ -> "\"$returnedHash\"" }
+
+        preBroadcastInsert(balanceChangeHex)
+
+        val raw = fakeBroadcast.sendRaw(signedJson)!!
+        val rh = raw.trim('"')
+        assertTrue(rh.lowercase() != txHash.lowercase())
+
+        // Re-key (mirroring the production fallback).
+        db.pendingBroadcastDao().delete(txHash)
+        cacheManager.deleteTransaction(txHash)
+        db.pendingBroadcastDao().insert(
+            PendingBroadcastEntity(
+                txHash = rh,
+                walletId = walletId,
+                network = network,
+                signedTxJson = signedJson,
+                reservedInputs = reservedJson,
+                state = "BROADCAST",
+                submittedAtTipBlock = 100L,
+                nullCount = 0,
+                createdAt = System.currentTimeMillis(),
+                lastCheckedAt = System.currentTimeMillis()
+            )
+        )
+        cacheManager.insertPendingTransaction(
+            txHash = rh,
+            network = network,
+            walletId = walletId,
+            balanceChange = balanceChangeHex,
+            direction = "out",
+            fee = "0x0"
+        )
+
+        // Old hash gone, new hash present in BROADCAST.
+        assertNull(db.transactionDao().getByTxHash(txHash))
+        val active = db.pendingBroadcastDao().getActive(walletId, network)
+        assertEquals(1, active.size)
+        assertEquals(rh, active.first().txHash)
+        assertEquals("BROADCAST", active.first().state)
+        assertNotNull(db.transactionDao().getByTxHash(rh))
+    }
+}

--- a/android/app/src/test/java/com/rjnr/pocketnode/data/sync/BroadcastWatchdogTest.kt
+++ b/android/app/src/test/java/com/rjnr/pocketnode/data/sync/BroadcastWatchdogTest.kt
@@ -34,7 +34,7 @@ class BroadcastWatchdogTest {
         statusGateway = statusGateway,
         cache = cache,
         tipSource = FakeTipSource(),
-        lifecycleProvider = LifecycleProvider { true },
+        lifecycleProvider = { true },
         dispatcher = StandardTestDispatcher(scheduler)
     )
 
@@ -57,6 +57,21 @@ class BroadcastWatchdogTest {
         val r = dao.getActive("w1", "TESTNET").single()
         assertEquals("BROADCAST", r.state)
         assertEquals(0, r.nullCount)
+    }
+
+    @Test
+    fun `in-pool past threshold fails and updates transactions status`() = runTest {
+        // Light client mempool says "pending" indefinitely (e.g. dependency on a
+        // never-landed tx); chain doesn't commit. Watchdog must time out instead
+        // of leaving the row stuck-pending forever.
+        val dao = FakePendingBroadcastDao(initial = listOf(row(state = "BROADCAST", submittedAt = 100L)))
+        val cache = FakeCacheManager()
+        val wd = watchdog(dao, TransactionStatusGateway { TxFetchResult.InPool }, cache, testScheduler)
+        // tip 130 >= 100 + 25
+        wd.checkAll(currentTip = 130L, walletId = "w1", network = "TESTNET")
+        val r = dao.allRows.single()
+        assertEquals("FAILED", r.state)
+        assertEquals("FAILED", cache.statusUpdates["0xaa"])
     }
 
     @Test

--- a/android/app/src/test/java/com/rjnr/pocketnode/data/sync/BroadcastWatchdogTest.kt
+++ b/android/app/src/test/java/com/rjnr/pocketnode/data/sync/BroadcastWatchdogTest.kt
@@ -1,0 +1,151 @@
+package com.rjnr.pocketnode.data.sync
+
+import com.rjnr.pocketnode.data.database.dao.PendingBroadcastDao
+import com.rjnr.pocketnode.data.database.entity.PendingBroadcastEntity
+import com.rjnr.pocketnode.data.gateway.TransactionStatusUpdater
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [28], manifest = Config.NONE)
+class BroadcastWatchdogTest {
+
+    private fun row(state: String = "BROADCAST", nullCount: Int = 0, submittedAt: Long = 100L) =
+        PendingBroadcastEntity(
+            txHash = "0xaa", walletId = "w1", network = "TESTNET",
+            signedTxJson = "{}", reservedInputs = "[]", state = state,
+            submittedAtTipBlock = submittedAt, nullCount = nullCount,
+            createdAt = 0L, lastCheckedAt = 0L
+        )
+
+    private fun watchdog(
+        dao: FakePendingBroadcastDao,
+        statusGateway: TransactionStatusGateway,
+        cache: FakeCacheManager,
+        scheduler: kotlinx.coroutines.test.TestCoroutineScheduler
+    ) = BroadcastWatchdog(
+        dao = dao,
+        statusGateway = statusGateway,
+        cache = cache,
+        tipSource = FakeTipSource(),
+        lifecycleProvider = LifecycleProvider { true },
+        dispatcher = StandardTestDispatcher(scheduler)
+    )
+
+    @Test
+    fun `on-chain response confirms and deletes`() = runTest {
+        val dao = FakePendingBroadcastDao(initial = listOf(row(state = "BROADCAST")))
+        val cache = FakeCacheManager()
+        val wd = watchdog(dao, TransactionStatusGateway { TxFetchResult.OnChain("0xbb") }, cache, testScheduler)
+        wd.checkAll(currentTip = 130L, walletId = "w1", network = "TESTNET")
+        assertEquals(0, dao.getActive("w1", "TESTNET").size)
+        assertEquals("CONFIRMED", cache.statusUpdates["0xaa"])
+    }
+
+    @Test
+    fun `in-pool response promotes BROADCASTING and resets nullCount`() = runTest {
+        val dao = FakePendingBroadcastDao(initial = listOf(row(state = "BROADCASTING", nullCount = 2)))
+        val cache = FakeCacheManager()
+        val wd = watchdog(dao, TransactionStatusGateway { TxFetchResult.InPool }, cache, testScheduler)
+        wd.checkAll(currentTip = 105L, walletId = "w1", network = "TESTNET")
+        val r = dao.getActive("w1", "TESTNET").single()
+        assertEquals("BROADCAST", r.state)
+        assertEquals(0, r.nullCount)
+    }
+
+    @Test
+    fun `null below threshold does not fail`() = runTest {
+        val dao = FakePendingBroadcastDao(initial = listOf(row(state = "BROADCAST", nullCount = 0)))
+        val cache = FakeCacheManager()
+        val wd = watchdog(dao, TransactionStatusGateway { TxFetchResult.NotFound }, cache, testScheduler)
+        wd.checkAll(currentTip = 130L, walletId = "w1", network = "TESTNET")
+        val r = dao.getActive("w1", "TESTNET").single()
+        assertEquals("BROADCAST", r.state)
+        assertEquals(1, r.nullCount)
+    }
+
+    @Test
+    fun `null at threshold but tip not advanced does not fail`() = runTest {
+        val dao = FakePendingBroadcastDao(initial = listOf(row(state = "BROADCAST", nullCount = 3, submittedAt = 100L)))
+        val cache = FakeCacheManager()
+        val wd = watchdog(dao, TransactionStatusGateway { TxFetchResult.NotFound }, cache, testScheduler)
+        // tip 120 < 100 + 25 = 125
+        wd.checkAll(currentTip = 120L, walletId = "w1", network = "TESTNET")
+        val r = dao.getActive("w1", "TESTNET").single()
+        assertEquals("BROADCAST", r.state)
+        assertEquals(4, r.nullCount)
+    }
+
+    @Test
+    fun `null at threshold and tip advanced fails and updates transactions status`() = runTest {
+        val dao = FakePendingBroadcastDao(initial = listOf(row(state = "BROADCAST", nullCount = 3, submittedAt = 100L)))
+        val cache = FakeCacheManager()
+        val wd = watchdog(dao, TransactionStatusGateway { TxFetchResult.NotFound }, cache, testScheduler)
+        wd.checkAll(currentTip = 130L, walletId = "w1", network = "TESTNET")
+        val r = dao.allRows.single()
+        assertEquals("FAILED", r.state)
+        assertEquals("FAILED", cache.statusUpdates["0xaa"])
+    }
+
+    @Test
+    fun `exception leaves state unchanged`() = runTest {
+        val dao = FakePendingBroadcastDao(initial = listOf(row(state = "BROADCAST", nullCount = 1)))
+        val cache = FakeCacheManager()
+        val wd = watchdog(dao, TransactionStatusGateway { TxFetchResult.Exception }, cache, testScheduler)
+        wd.checkAll(currentTip = 130L, walletId = "w1", network = "TESTNET")
+        val r = dao.getActive("w1", "TESTNET").single()
+        assertEquals("BROADCAST", r.state)
+        assertEquals(1, r.nullCount)
+    }
+}
+
+// ----- fakes -----
+
+class FakePendingBroadcastDao(
+    initial: List<PendingBroadcastEntity> = emptyList()
+) : PendingBroadcastDao {
+    private val rows = initial.toMutableList()
+    val allRows: List<PendingBroadcastEntity> get() = rows.toList()
+    override suspend fun insert(row: PendingBroadcastEntity) {
+        rows.removeAll { it.txHash == row.txHash }; rows.add(row)
+    }
+    override suspend fun delete(hash: String) { rows.removeAll { it.txHash == hash } }
+    override suspend fun getActive(walletId: String, network: String) =
+        rows.filter { it.walletId == walletId && it.network == network && it.state in setOf("BROADCASTING","BROADCAST") }
+    override suspend fun compareAndUpdateState(hash: String, expected: String, next: String, now: Long): Int {
+        val idx = rows.indexOfFirst { it.txHash == hash && it.state == expected }
+        if (idx < 0) return 0
+        rows[idx] = rows[idx].copy(state = next, lastCheckedAt = now)
+        return 1
+    }
+    override suspend fun updateNullCount(hash: String, count: Int, now: Long) {
+        val idx = rows.indexOfFirst { it.txHash == hash }
+        if (idx >= 0) rows[idx] = rows[idx].copy(nullCount = count, lastCheckedAt = now)
+    }
+    override fun observeActive(walletId: String, network: String) =
+        throw NotImplementedError("watchdog uses snapshot getActive only")
+    override fun observeFailed(walletId: String, network: String) =
+        throw NotImplementedError("not used by watchdog")
+    override suspend fun getFailedRow(hash: String): PendingBroadcastEntity? =
+        rows.firstOrNull { it.txHash == hash && it.state == "FAILED" }
+}
+
+class FakeCacheManager : TransactionStatusUpdater {
+    val statusUpdates = mutableMapOf<String, String>()
+    override suspend fun updateTransactionStatus(hash: String, status: String) {
+        statusUpdates[hash] = status
+    }
+}
+
+class FakeTipSource : com.rjnr.pocketnode.data.gateway.TipSource {
+    private val _tip = MutableStateFlow(0L)
+    override val tipFlow = _tip
+    override suspend fun fetchAndPublishTip(): Long = 0L
+    override fun activeWalletAndNetworkOrNull(): Pair<String, String>? = "w1" to "TESTNET"
+}

--- a/android/app/src/test/java/com/rjnr/pocketnode/data/sync/ColdStartRecoveryTest.kt
+++ b/android/app/src/test/java/com/rjnr/pocketnode/data/sync/ColdStartRecoveryTest.kt
@@ -1,0 +1,90 @@
+package com.rjnr.pocketnode.data.sync
+
+import com.rjnr.pocketnode.data.database.entity.PendingBroadcastEntity
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * Cold-start scenario: a `BROADCASTING` row exists at app launch (the
+ * previous process died between INSERT and the JNI call returning).
+ * Phase A does not auto-rebroadcast; the watchdog observes the row
+ * and resolves it via `nativeGetTransaction`.
+ *
+ * Reuses the fakes defined in BroadcastWatchdogTest (same package).
+ * Robolectric runner required because BroadcastWatchdog logs via
+ * android.util.Log on the exception branch.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [28], manifest = Config.NONE)
+class ColdStartRecoveryTest {
+
+    private fun orphan(submittedAt: Long = 100L) = PendingBroadcastEntity(
+        txHash = "0xaa", walletId = "w1", network = "TESTNET",
+        signedTxJson = "{}", reservedInputs = "[]", state = "BROADCASTING",
+        submittedAtTipBlock = submittedAt, nullCount = 0,
+        createdAt = 0L, lastCheckedAt = 0L
+    )
+
+    private fun watchdog(
+        dao: FakePendingBroadcastDao,
+        statusGateway: TransactionStatusGateway,
+        cache: FakeCacheManager,
+        scheduler: kotlinx.coroutines.test.TestCoroutineScheduler
+    ) = BroadcastWatchdog(
+        dao = dao,
+        statusGateway = statusGateway,
+        cache = cache,
+        tipSource = FakeTipSource(),
+        lifecycleProvider = LifecycleProvider { true },
+        dispatcher = StandardTestDispatcher(scheduler)
+    )
+
+    @Test
+    fun `orphan resolves to CONFIRMED when JNI reports on-chain`() = runTest {
+        val dao = FakePendingBroadcastDao(initial = listOf(orphan()))
+        val cache = FakeCacheManager()
+        val wd = watchdog(dao, TransactionStatusGateway { TxFetchResult.OnChain("0xbb") }, cache, testScheduler)
+        wd.checkAll(currentTip = 130L, walletId = "w1", network = "TESTNET")
+        assertEquals(0, dao.getActive("w1", "TESTNET").size)
+        assertEquals("CONFIRMED", cache.statusUpdates["0xaa"])
+    }
+
+    @Test
+    fun `orphan upgrades to BROADCAST when JNI reports in-pool`() = runTest {
+        val dao = FakePendingBroadcastDao(initial = listOf(orphan()))
+        val cache = FakeCacheManager()
+        val wd = watchdog(dao, TransactionStatusGateway { TxFetchResult.InPool }, cache, testScheduler)
+        wd.checkAll(currentTip = 105L, walletId = "w1", network = "TESTNET")
+        assertEquals("BROADCAST", dao.getActive("w1", "TESTNET").single().state)
+    }
+
+    @Test
+    fun `orphan stays BROADCASTING with elevated nullCount when JNI null and tip not advanced`() = runTest {
+        val dao = FakePendingBroadcastDao(initial = listOf(orphan(submittedAt = 100L)))
+        val cache = FakeCacheManager()
+        val wd = watchdog(dao, TransactionStatusGateway { TxFetchResult.NotFound }, cache, testScheduler)
+        wd.checkAll(currentTip = 110L, walletId = "w1", network = "TESTNET")
+        val r = dao.getActive("w1", "TESTNET").single()
+        assertEquals("BROADCASTING", r.state)
+        assertEquals(1, r.nullCount)
+        assertNull(cache.statusUpdates["0xaa"])
+    }
+
+    @Test
+    fun `orphan resolves to FAILED after threshold and tip past timeout`() = runTest {
+        val seeded = orphan(submittedAt = 100L).copy(nullCount = 3)
+        val dao = FakePendingBroadcastDao(initial = listOf(seeded))
+        val cache = FakeCacheManager()
+        val wd = watchdog(dao, TransactionStatusGateway { TxFetchResult.NotFound }, cache, testScheduler)
+        wd.checkAll(currentTip = 130L, walletId = "w1", network = "TESTNET")
+        val r = dao.allRows.single()
+        assertEquals("FAILED", r.state)
+        assertEquals("FAILED", cache.statusUpdates["0xaa"])
+    }
+}

--- a/android/app/src/test/java/com/rjnr/pocketnode/data/transaction/TxHashEqualityTest.kt
+++ b/android/app/src/test/java/com/rjnr/pocketnode/data/transaction/TxHashEqualityTest.kt
@@ -1,0 +1,63 @@
+package com.rjnr.pocketnode.data.transaction
+
+import com.rjnr.pocketnode.data.gateway.models.CellInput
+import com.rjnr.pocketnode.data.gateway.models.CellOutput
+import com.rjnr.pocketnode.data.gateway.models.OutPoint
+import com.rjnr.pocketnode.data.gateway.models.Script
+import com.rjnr.pocketnode.data.gateway.models.Transaction
+import com.rjnr.pocketnode.data.validation.NetworkValidator
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class TxHashEqualityTest {
+
+    private val builder = TransactionBuilder(
+        networkValidator = NetworkValidator()
+    )
+
+    private fun sampleTx(): Transaction = Transaction(
+        cellDeps = emptyList(),
+        cellInputs = listOf(
+            CellInput(
+                previousOutput = OutPoint(
+                    txHash = "0x" + "11".repeat(32),
+                    index = "0x0"
+                )
+            )
+        ),
+        cellOutputs = listOf(
+            CellOutput(
+                capacity = "0x" + 61_00000000L.toString(16),
+                lock = Script(
+                    codeHash = Script.SECP256K1_CODE_HASH,
+                    hashType = "type",
+                    args = "0x" + "22".repeat(20)
+                )
+            )
+        ),
+        outputsData = listOf("0x"),
+        witnesses = listOf("0x")
+    )
+
+    @Test
+    fun `computeTxHash returns 0x-prefixed 64-char lowercase hex`() {
+        val hash = builder.computeTxHash(sampleTx())
+        assertTrue("expected 0x prefix, got $hash", hash.startsWith("0x"))
+        assertEquals(66, hash.length)
+        assertEquals(hash, hash.lowercase())
+    }
+
+    @Test
+    fun `computeTxHash is deterministic across calls`() {
+        val tx = sampleTx()
+        assertEquals(builder.computeTxHash(tx), builder.computeTxHash(tx))
+    }
+
+    @Test
+    fun `computeTxHash ignores witnesses`() {
+        val tx1 = sampleTx().copy(witnesses = listOf("0x"))
+        val tx2 = sampleTx().copy(witnesses = listOf("0x" + "ff".repeat(65)))
+        assertEquals(builder.computeTxHash(tx1), builder.computeTxHash(tx2))
+    }
+}

--- a/android/gradle/libs.versions.toml
+++ b/android/gradle/libs.versions.toml
@@ -31,6 +31,7 @@ kotlinx-serialization-json = { group = "org.jetbrains.kotlinx", name = "kotlinx-
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
 androidx-lifecycle-runtime-ktx = { group = "androidx.lifecycle", name = "lifecycle-runtime-ktx", version.ref = "lifecycleRuntimeKtx" }
 androidx-lifecycle-viewmodel-compose = { group = "androidx.lifecycle", name = "lifecycle-viewmodel-compose", version.ref = "lifecycleRuntimeKtx" }
+androidx-lifecycle-process = { group = "androidx.lifecycle", name = "lifecycle-process", version.ref = "lifecycleRuntimeKtx" }
 androidx-activity-compose = { group = "androidx.activity", name = "activity-compose", version.ref = "activityCompose" }
 androidx-compose-bom = { group = "androidx.compose", name = "compose-bom", version.ref = "composeBom" }
 androidx-ui = { group = "androidx.compose.ui", name = "ui" }


### PR DESCRIPTION
Closes #115. Spun out of #88 (umbrella stays open).

## Why

At CKB Off-Chain Lagos 2026, sending CKB to ~23 attendees in rapid succession produced **ghost-pending transactions**: the app received a tx hash, the row sat as `Pending` for days, never appeared on the explorer. Re-importing the wallet was the only workaround.

Root cause: rapid sequential sends picked the **same input cells** because the change output of send #1 wasn't visible to the light client yet, and the app had no local cell reservation. Light client accepted both optimistically; network rejected the loser during P2P propagation; loser sat in local pool forever.

## What changed

Phased fix per the design spec — Phase A only. Phase B (foreground service / WorkManager) deferred until field data shows it's needed.

- **`pending_broadcasts` Room table (v7→v8)** as the broadcast state machine, separate from the user-facing `transactions` ledger. States: `BROADCASTING → BROADCAST → CONFIRMED / FAILED` via CAS updates.
- **`sendMutex` in `GatewayRepository.prepareAndSend`** wraps cell-fetch → reservation read → build → DB inserts in a single critical section. JNI broadcast happens outside the lock. Two rapid sends now produce disjoint input sets.
- **Synthesized predicted change** — pending broadcasts' change outputs are added to the available-cells set so rapid sends don't exhaust live cells while waiting for the light client to sync.
- **`BroadcastWatchdog`** drives non-terminal rows to terminal via `getTransactionStatus` polling. Tip-event primary trigger + 15s fallback timer, foreground-gated. `null × 3 + tip past +25 blocks → FAILED`. **In-pool past +25 blocks → FAILED** (caught a real failure mode in field testing where local mempool kept stale entries indefinitely).
- **Cold-start recovery** — `BROADCASTING` orphans from prior process death are picked up automatically.
- **Legacy PENDING reconciliation at init** — pre-Phase-A ghosts are reconciled against the chain (CONFIRMED if they actually landed, FAILED if not), so the user no longer needs to wallet-reimport to clear them.
- **UI: Failed chip + prominent "Retry Transaction" button** in the tx-detail bottom sheet for both Home and Activity tabs. Retry copy: *"This transaction may not have reached the network. Retry?"* (FAILED is heuristic, not proof of network rejection — see spec §6).
- **Step 0 BLOCKING gate**: `TransactionBuilder.computeTxHash` exposed and verified byte-for-byte equality with the JNI-returned hash on 8/8 testnet broadcasts before any dependent code shipped.
- **UX fix surfaced in field testing**: pending rows previously showed `-0.00000 CKB`. Root cause: `balanceChange` was hardcoded `0x0` and an early format mistake (`-0x...`) broke the hex parser. Now stores positive hex per existing convention; `direction = "out"` carries the sign.

## Test plan

- [x] All 519 unit tests pass: `cd android && ./gradlew testDebugUnitTest`
- [x] **Step 0 gate**: 8/8 testnet broadcasts match precomputed hash byte-for-byte
- [x] **Cell-reservation stress test**: 5 rapid sequential testnet sends produce 5 distinct rows in `pending_broadcasts` with disjoint `reservedInputs`
- [x] **Real ghost reproduced and resolved in field**: 2 of 5 sends initially stuck in pool 15+ min; watchdog InPool-timeout fix transitioned them to FAILED with red retry chip; retries succeeded
- [x] **Legacy ghosts reconciled**: 2 pre-Phase-A ghosts marked FAILED on next app launch
- [x] **UX**: pending rows now show real amounts (e.g. `-300.00 CKB`); Failed badge renders red in both activity-row chip and tx-detail bottom sheet; Retry Transaction button visible inside the sheet
- [ ] Multi-day soak — run on testnet over several days to catch any stuck-state edge cases not covered by the 6.5-min block timeout

## New unit tests (24 total in this branch)

- `TxHashEqualityTest` (3): format / determinism / witness-independence
- `PendingBroadcastDaoTest` (11): insert / CAS / scope / observe / getFailed
- `MigrationTest` (1 new v8 test, existing 9 preserved)
- `GatewayRepositorySendTransactionTest` (6): persistence-pattern simulation
- `CellReservationFilterTest` (5): reservation logic
- `BroadcastWatchdogTest` (7 incl. in-pool-timeout): full state-machine coverage
- `ColdStartRecoveryTest` (4): orphan resolution scenarios

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added failed transaction retry capability with prefilled recipient and amount.
  * Added automatic background recovery of stuck pending transactions.
  * Enhanced transaction status display to show failed, confirmed, and pending states.

* **Bug Fixes**
  * Improved transaction state tracking for reliable broadcast handling.

* **Tests**
  * Added comprehensive test coverage for broadcast recovery, database migrations, and transaction hash computation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->