### PR TITLE
fix(wallet): remove wallet-creation cap (#118)

### DIFF
--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/wallet/AddWalletViewModel.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/wallet/AddWalletViewModel.kt
@@ -25,7 +25,6 @@ data class AddWalletUiState(
     val createdWallet: WalletEntity? = null,
     val isNewlyGenerated: Boolean = false,
     val error: String? = null,
-    val showSyncCapWarning: Boolean = false,
     val parentWallets: List<WalletEntity> = emptyList(),
     val selectedParentId: String? = null
 )
@@ -150,13 +149,12 @@ class AddWalletViewModel @Inject constructor(
             return
         }
 
+        // Wallet count is no longer capped at creation time (#118). The cap is
+        // applied at sync-registration time only — `registerAllWalletScripts`
+        // takes the first MAX_CONCURRENT_WALLET_SCRIPTS under the ALL_WALLETS
+        // strategy. Users can create as many wallets as they want; only the
+        // first N stay actively synced when ALL_WALLETS is selected.
         viewModelScope.launch {
-            val count = walletRepository.walletCount()
-            if (count >= 3) {
-                _uiState.update { it.copy(showSyncCapWarning = true) }
-                return@launch
-            }
-
             _uiState.update { it.copy(isLoading = true, error = null) }
             runCatching {
                 walletRepository.createWallet(name)


### PR DESCRIPTION
Closes #118.

## Symptom

Reporter (`gpBlockchain`, Xiaomi 15 Pro / Android 16, app 1.5.0): tapping **Create Wallet** with the name "wallet 4" produced no response. UI looked frozen.

## Root cause

[`AddWalletViewModel.createNewWallet`](android/app/src/main/java/com/rjnr/pocketnode/ui/screens/wallet/AddWalletViewModel.kt) checked `walletRepository.walletCount() >= 3` and set \`showSyncCapWarning = true\`. **`AddWalletScreen` never reads that flag** — no dialog, no banner, nothing surfaces. The send-button's `viewModelScope.launch` returns silently and `isLoading` is never set, so the user sees zero feedback.

## Why the cap is the wrong layer

\`MAX_CONCURRENT_WALLET_SCRIPTS = 3\` exists in `GatewayRepository` to limit how many wallet scripts the embedded light client tracks at once under the `ALL_WALLETS` sync strategy. \`registerAllWalletScripts\` already enforces this:

\`\`\`kotlin
// GatewayRepository.kt:2328
val wallets = candidateWallets.take(MAX_CONCURRENT_WALLET_SCRIPTS)
\`\`\`

Capping wallet creation conflates "active sync slots" with "owned wallets". Users may want 5 wallets but only sync 3 at a time — the existing `take(N)` already does the right thing.

## Fix

Drop the count check and the unused `showSyncCapWarning` field. Users can create as many wallets as they want; only the first N stay actively synced when `ALL_WALLETS` is selected.

`walletCount()` itself is preserved — used legitimately by `SecuritySettings` (gate PIN removal) and `WalletSettings`.

## Test plan

- [x] `./gradlew compileDebugKotlin` — green
- [x] `./gradlew testDebugUnitTest` — green (all 519 tests still pass)
- [ ] On-device: from the reporter's repro state (3 existing wallets), tap **Add Wallet → + New Wallet → "wallet 4" → Create Wallet** — wallet creates successfully and becomes active
- [ ] Verify under `ALL_WALLETS` sync strategy: with 4+ wallets, only the first 3 are registered with the light client (existing `take(MAX_CONCURRENT_WALLET_SCRIPTS)` behavior — unchanged)

## Related

#109 is a separate UI/lifecycle bug at the same boundary (screen flashes white when creating the 3rd wallet). Different fix, needs `AndroidRuntime:E` logcat to diagnose.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Modified wallet creation flow to defer sync capacity validation until the registration process instead of blocking wallet creation upfront.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->