### PR TITLE
fix(sync): force IO dispatcher for script registration (#109)

### DIFF
--- a/android/app/src/main/java/com/rjnr/pocketnode/data/gateway/GatewayRepository.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/gateway/GatewayRepository.kt
@@ -721,6 +721,9 @@ class GatewayRepository @Inject constructor(
         savePreference: Boolean = true,
         forceResync: Boolean = false
     ): Result<Unit> = runCatching {
+        // Force IO dispatcher — see registerAllWalletScripts above for the same
+        // reasoning. ACTIVE_ONLY callers also block Main without this. (#109)
+        withContext(Dispatchers.IO) {
         // Wait for node to be ready
         if (!awaitNodeReady()) {
              throw Exception("Node initialization failed")
@@ -797,6 +800,7 @@ class GatewayRepository @Inject constructor(
             }
             walletPreferences.setInitialSyncCompleted(true, walletId = wId)
         }
+        }  // end withContext(Dispatchers.IO)
     }
 
     suspend fun resyncAccount(
@@ -2306,7 +2310,13 @@ class GatewayRepository @Inject constructor(
     private suspend fun registerAllWalletScripts(
         preFetchedWallets: List<WalletEntity>? = null,
         preFilteredCandidates: List<WalletEntity>? = null
-    ) {
+    ) = withContext(Dispatchers.IO) {
+        // Force IO dispatcher for the whole body — JNI calls (nativeGetTipHeader,
+        // nativeSetScripts via setScriptsAndRecord) block the UI thread otherwise.
+        // Symptom #109: adding the 3rd wallet (which triggers a re-registration
+        // of all scripts) flashed the screen white because the caller chain ran
+        // on viewModelScope.launch (Main) and the JNI round-trip blocked Main
+        // long enough for Android to render a blank surface.
         if (!awaitNodeReady()) {
             throw Exception("Node initialization failed")
         }
@@ -2389,7 +2399,7 @@ class GatewayRepository @Inject constructor(
 
         if (pairs.isEmpty()) {
             Log.w(TAG, "registerAllWalletScripts: no scripts to register")
-            return
+            return@withContext
         }
 
         val scriptStatuses = pairs.map { it.second }


### PR DESCRIPTION
Closes #109.

## Symptom

Adding the 3rd wallet flashed the screen white. App needed to be reopened to recover. Wallet was correctly created and syncing — so this is a UI/lifecycle issue, not data corruption (matching the original investigation in #109).

## Root cause

JNI calls inside `registerAllWalletScripts` and `registerAccount` ran on the Main thread:

    AddWalletViewModel.createNewWallet
        viewModelScope.launch                      // Main dispatcher
            walletRepository.createWallet(...)
            gatewayRepository.onActiveWalletChanged(wallet)
                registerAllWalletScripts()
                    LightClientNative.nativeGetTipHeader()       // BLOCKS Main
                    setScriptsAndRecord(...)
                        LightClientNative.nativeSetScripts(...)  // BLOCKS Main

The existing `async(Dispatchers.IO)` block (line 2349) protected only the per-wallet key-derivation loop. The surrounding JNI calls — `nativeGetTipHeader` at the top of the function, and `nativeSetScripts` via `setScriptsAndRecord` at the bottom — ran on whatever dispatcher the caller used.

Reproduces specifically at the 3rd-wallet boundary because that's when the strategy-driven re-registration runs with the largest payload (3 scripts via `CMD_SET_SCRIPTS_ALL`). The blocking JNI round-trip is long enough for Android to render a blank surface before the next frame.

## Fix

Wrap both `registerAllWalletScripts` and `registerAccount` bodies in `withContext(Dispatchers.IO)`. Internal `async(Dispatchers.IO)` blocks remain as-is — no-op when the parent context is already IO, but they still parallelize per-wallet key derivation.

12 lines added, 2 changed.

## Test plan

- [x] `./gradlew compileDebugKotlin` — green
- [x] `./gradlew testDebugUnitTest` — green
- [ ] On-device repro from #109: with 2 wallets, complete the add flow for a 3rd wallet — screen should NOT flash white; transition from AddWallet → MnemonicBackup completes normally

## Related

- #118 (separate fix in #122) — silently-failing 4th wallet creation due to unrendered cap warning
- Phase A (#115) is unaffected; that work was on the send path, not wallet registration

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved wallet account and script registration to enhance stability and performance during multi-wallet operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->