### PR TITLE
fix(dao): include fee input in DAO withdraw Phase 1 (#119)

### DIFF
--- a/android/app/src/main/java/com/rjnr/pocketnode/data/gateway/GatewayRepository.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/gateway/GatewayRepository.kt
@@ -2081,6 +2081,7 @@ class GatewayRepository @Inject constructor(
     suspend fun withdrawFromDao(depositOutPoint: OutPoint): Result<String> = runCatching {
         val info = _walletInfo.value ?: throw Exception("No wallet")
         val net = _network.value
+        val address = getCurrentAddress() ?: throw Exception("No address")
 
         // Find the deposit cell
         val deposits = getDaoDeposits().getOrThrow()
@@ -2092,6 +2093,12 @@ class GatewayRepository @Inject constructor(
         require(deposit.depositBlockHash.isNotBlank()) {
             "Deposit block hash unavailable. Please retry after sync."
         }
+
+        // Fetch normal cells to cover the fee — DAO Phase 1 preserves the
+        // deposit capacity exactly so a fee input cell is mandatory (#119).
+        // getCells already excludes typed (DAO) cells, so this list is only
+        // regular CKB cells safe to spend as fee.
+        val availableCells = getCells(address).getOrThrow().items
 
         // Build a Cell from the deposit for the transaction builder
         val depositCell = Cell(
@@ -2109,7 +2116,8 @@ class GatewayRepository @Inject constructor(
             depositBlockHash = deposit.depositBlockHash,
             senderScript = info.script,
             privateKey = privateKey,
-            network = net
+            network = net,
+            availableCells = availableCells
         )
 
         val txHash = sendTransaction(tx).getOrThrow()

--- a/android/app/src/main/java/com/rjnr/pocketnode/data/transaction/TransactionBuilder.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/transaction/TransactionBuilder.kt
@@ -274,9 +274,20 @@ class TransactionBuilder @Inject constructor(
         depositBlockHash: String,
         senderScript: Script,
         privateKey: ByteArray,
-        network: NetworkType
+        network: NetworkType,
+        availableCells: List<Cell>
     ): Transaction {
-        val capacity = depositCell.capacity
+        // Phase 1 (deposit → withdrawing) preserves the deposit cell's capacity
+        // exactly. The fee must come from a separate normal cell (CKB RFC 0023).
+        // The previous implementation used the deposit cell as the only input,
+        // making `inputs == outputs`, so the network rejected the tx and the
+        // JNI bridge returned null ("send failed - native returned null", #119).
+        val (feeCells, feeTotal) = selectCells(availableCells, DEFAULT_FEE + MIN_CELL_CAPACITY)
+        if (feeTotal < DEFAULT_FEE) {
+            throw Exception(
+                "Insufficient balance to cover withdraw fee. Need ${DEFAULT_FEE} shannons, have $feeTotal"
+            )
+        }
 
         // Output mirrors the deposit cell but with block number as data
         val blockNumberBytes = ByteArray(8)
@@ -287,14 +298,25 @@ class TransactionBuilder @Inject constructor(
         }
         val blockNumberHex = "0x" + blockNumberBytes.joinToString("") { "%02x".format(it) }
 
-        val inputs = listOf(CellInput(previousOutput = depositCell.outPoint))
-        val outputs = listOf(
-            CellOutput(
-                capacity = capacity,
-                lock = senderScript,
-                type = DaoConstants.DAO_TYPE_SCRIPT
-            )
+        val inputs = listOf(CellInput(previousOutput = depositCell.outPoint)) +
+            feeCells.map { CellInput(previousOutput = it.outPoint) }
+
+        val withdrawingOutput = CellOutput(
+            capacity = depositCell.capacity,
+            lock = senderScript,
+            type = DaoConstants.DAO_TYPE_SCRIPT
         )
+
+        // Change output (if any). feeTotal - DEFAULT_FEE goes back to the user.
+        // Skip the change cell when its capacity would fall below the 61 CKB
+        // minimum — that residue is absorbed into the fee.
+        val change = feeTotal - DEFAULT_FEE
+        val outputs = mutableListOf(withdrawingOutput)
+        val outputsData = mutableListOf(blockNumberHex)
+        if (change >= MIN_CELL_CAPACITY) {
+            outputs.add(CellOutput(capacity = "0x${change.toString(16)}", lock = senderScript))
+            outputsData.add("0x")
+        }
 
         val secp256k1Dep = when (network) {
             NetworkType.TESTNET -> CellDep.SECP256K1_TESTNET
@@ -306,11 +328,11 @@ class TransactionBuilder @Inject constructor(
             headerDeps = listOf(depositBlockHash),
             cellInputs = inputs,
             cellOutputs = outputs,
-            outputsData = listOf(blockNumberHex),
-            witnesses = listOf("0x")
+            outputsData = outputsData,
+            witnesses = inputs.map { "0x" }
         )
 
-        return signTransaction(unsignedTx, privateKey, 1)
+        return signTransaction(unsignedTx, privateKey, inputs.size)
     }
 
     fun buildDaoUnlock(

--- a/android/app/src/test/java/com/rjnr/pocketnode/data/transaction/TransactionBuilderDaoTest.kt
+++ b/android/app/src/test/java/com/rjnr/pocketnode/data/transaction/TransactionBuilderDaoTest.kt
@@ -146,7 +146,8 @@ class TransactionBuilderDaoTest {
             depositBlockHash = "0x" + "ee".repeat(32),
             senderScript = testScript,
             privateKey = testPrivateKey,
-            network = NetworkType.TESTNET
+            network = NetworkType.TESTNET,
+            availableCells = listOf(makeCell(200_00000000L, index = 1))
         )
         // 12345 = 0x3039, LE bytes: 39 30 00 00 00 00 00 00
         assertEquals("0x3930000000000000", tx.outputsData[0])
@@ -161,7 +162,8 @@ class TransactionBuilderDaoTest {
             depositBlockHash = depositBlockHash,
             senderScript = testScript,
             privateKey = testPrivateKey,
-            network = NetworkType.TESTNET
+            network = NetworkType.TESTNET,
+            availableCells = listOf(makeCell(200_00000000L, index = 1))
         )
         assertEquals(1, tx.headerDeps.size)
         assertEquals(depositBlockHash, tx.headerDeps[0])
@@ -175,9 +177,54 @@ class TransactionBuilderDaoTest {
             depositBlockHash = "0x" + "ee".repeat(32),
             senderScript = testScript,
             privateKey = testPrivateKey,
-            network = NetworkType.TESTNET
+            network = NetworkType.TESTNET,
+            availableCells = listOf(makeCell(200_00000000L, index = 1))
         )
         assertEquals(DaoConstants.DAO_TYPE_SCRIPT, tx.cellOutputs[0].type)
+    }
+
+    @Test
+    fun `buildDaoWithdraw includes fee input cell so fee is positive (#119)`() {
+        val feeCellCapacity = 200_00000000L
+        val tx = builder.buildDaoWithdraw(
+            depositCell = makeDepositCell(),
+            depositBlockNumber = 100L,
+            depositBlockHash = "0x" + "ee".repeat(32),
+            senderScript = testScript,
+            privateKey = testPrivateKey,
+            network = NetworkType.TESTNET,
+            availableCells = listOf(makeCell(feeCellCapacity, index = 1))
+        )
+        // 1 deposit input + 1 fee input
+        assertEquals(2, tx.cellInputs.size)
+        // First output is the withdrawing cell — same capacity as the deposit
+        val depositCapacity = DaoConstants.MIN_DEPOSIT_SHANNONS
+        assertEquals("0x${depositCapacity.toString(16)}", tx.cellOutputs[0].capacity)
+        // Total inputs > total outputs so fee > 0 (the heart of the #119 fix)
+        val totalInputs = depositCapacity + feeCellCapacity
+        val totalOutputs = tx.cellOutputs.sumOf { it.capacity.removePrefix("0x").toLong(16) }
+        assertEquals(true, totalInputs > totalOutputs)
+    }
+
+    @Test
+    fun `buildDaoWithdraw throws when no fee-covering cells available`() {
+        try {
+            builder.buildDaoWithdraw(
+                depositCell = makeDepositCell(),
+                depositBlockNumber = 100L,
+                depositBlockHash = "0x" + "ee".repeat(32),
+                senderScript = testScript,
+                privateKey = testPrivateKey,
+                network = NetworkType.TESTNET,
+                availableCells = emptyList()
+            )
+            org.junit.Assert.fail("Expected exception")
+        } catch (e: Exception) {
+            org.junit.Assert.assertTrue(
+                "expected 'Insufficient' in '${e.message}'",
+                e.message?.contains("Insufficient") == true
+            )
+        }
     }
 
     // --- buildDaoUnlock ---


### PR DESCRIPTION
Closes #119.

## Symptom

\`gpBlockchain\` (Xiaomi 15 Pro / Android 16): tapping **Withdraw** on a DAO deposit returned \"send failed native returned null\". Image attached on the issue.

## Root cause

\`TransactionBuilder.buildDaoWithdraw\` produced a transaction with the deposit cell as the only input and a withdrawing cell at the same capacity as the only output:

\`\`\`
inputs  = [deposit cell @ N CKB]
outputs = [withdrawing cell @ N CKB]
fee     = inputs - outputs = 0
\`\`\`

CKB rejects 0-fee transactions at the pool layer. The local light client validation also rejects, and \`nativeSendTransaction\` returns null.

Per [CKB RFC 0023](https://github.com/nervosnetwork/rfcs/blob/master/rfcs/0023-dao-deposit-withdraw/0023-dao-deposit-withdraw.md), DAO withdraw Phase 1 (deposit → withdrawing state) preserves the deposit cell's capacity **exactly**. The fee must come from a **separate normal cell input**. This is what Neuron, ckb-cli, and ckb-sdk-js all do.

## Fix

- \`buildDaoWithdraw\` now takes \`availableCells: List<Cell>\` and uses the existing \`selectCells\` helper to pick fee-covering inputs. Adds a change output when leftover ≥ \`MIN_CELL_CAPACITY\` (61 CKB).
- \`withdrawFromDao\` caller fetches normal cells via \`getCells\`, which already excludes typed/DAO cells (line 1098 in GatewayRepository), so the list is safely fee-spendable.
- Throws a clear "Insufficient balance to cover withdraw fee" error when the wallet has no normal cells available — much better UX than the cryptic null return.

## Tests

- Updated 3 existing \`TransactionBuilderDaoTest\` cases to pass \`availableCells\`.
- Added two new tests:
  - \`buildDaoWithdraw includes fee input cell so fee is positive\` — asserts \`totalInputs > totalOutputs\` (the regression that caused #119).
  - \`buildDaoWithdraw throws when no fee-covering cells available\` — exercises the friendly error path.

## Test plan

- [x] \`./gradlew compileDebugKotlin\` — green
- [x] \`./gradlew testDebugUnitTest\` — all 521 tests pass (519 prior + 2 new)
- [ ] On-device, gp's repro: open DAO, tap Withdraw on a deposit; transaction is built with deposit cell + 1 normal fee cell as inputs, broadcast succeeds, deposit transitions to withdrawing state
- [ ] Negative case: with a wallet that has 0 normal cells (only DAO deposits), Withdraw shows "Insufficient balance to cover withdraw fee" instead of crashing

🤖 Generated with [Claude Code](https://claude.com/claude-code)