### PR TITLE
feat(sync): explorer deeplink helper for custom block height (#85)

### DIFF
--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/components/SyncOptionsDialog.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/components/SyncOptionsDialog.kt
@@ -46,7 +46,12 @@ internal fun SyncOptionsDialog(
     description: String = "Choose how much transaction history to sync:",
     availableModes: List<SyncMode> = SyncMode.entries.toList(),
     savedCustomBlockHeight: Long? = null,
-    tipBlockNumber: Long = 0L
+    tipBlockNumber: Long = 0L,
+    // Optional — when supplied and CUSTOM is selected, render a "Don't know
+    // your block height? Look up on explorer" helper that opens the user's
+    // address page in the CKB explorer (#85). Caller owns the URL launch so
+    // this composable stays free of Intent / Network plumbing.
+    onLookupAddressOnExplorer: (() -> Unit)? = null
 ) {
     // If the parent hides currentMode from availableModes, fall back to the first
     // shown option so the dialog never opens with an invisible selection.
@@ -155,6 +160,27 @@ internal fun SyncOptionsDialog(
                             else -> null
                         }
                     )
+
+                    // "Don't know your block height?" helper (#85). Opens the
+                    // CKB explorer at the user's address so they can scroll to
+                    // their first transaction and read the block number off.
+                    if (onLookupAddressOnExplorer != null) {
+                        TextButton(
+                            onClick = onLookupAddressOnExplorer,
+                            contentPadding = androidx.compose.foundation.layout.PaddingValues(0.dp)
+                        ) {
+                            Icon(
+                                Lucide.ExternalLink,
+                                contentDescription = null,
+                                modifier = Modifier.size(16.dp)
+                            )
+                            Spacer(Modifier.width(6.dp))
+                            Text(
+                                text = "Don't know your block height? Look up on explorer",
+                                style = MaterialTheme.typography.bodySmall
+                            )
+                        }
+                    }
                 }
 
                 if (selectedMode == SyncMode.FULL_HISTORY && SyncMode.FULL_HISTORY in availableModes) {

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/home/HomeScreen.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/home/HomeScreen.kt
@@ -147,6 +147,23 @@ fun HomeScreen(
 
     val tipBlockNumberLong = uiState.tipBlockNumber.toLongOrNull() ?: 0L
 
+    // "Don't know your block height?" helper — opens the user's address page
+    // on the CKB explorer so non-technical users can scroll to their first
+    // transaction and read the block number off (#85). Disabled when no
+    // address is loaded yet (pre-init / locked).
+    val onLookupBlockHeight: (() -> Unit)? = uiState.address.takeIf { it.isNotBlank() }?.let { addr ->
+        {
+            val url = buildExplorerAddressUrl(addr, uiState.currentNetwork)
+            try {
+                context.startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(url)))
+            } catch (_: android.content.ActivityNotFoundException) {
+                scope.launch {
+                    snackbarHostState.showSnackbar("No browser available to open the explorer")
+                }
+            }
+        }
+    }
+
     // Sync options dialog (settings path)
     if (uiState.showSyncOptionsDialog) {
         SyncOptionsDialog(
@@ -157,7 +174,8 @@ fun HomeScreen(
                 viewModel.changeSyncMode(mode, customBlock)
             },
             savedCustomBlockHeight = uiState.savedCustomBlockHeight,
-            tipBlockNumber = tipBlockNumberLong
+            tipBlockNumber = tipBlockNumberLong,
+            onLookupAddressOnExplorer = onLookupBlockHeight
         )
     }
 
@@ -175,7 +193,8 @@ fun HomeScreen(
                     viewModel.changeSyncMode(mode, customBlock)
                 }
             },
-            tipBlockNumber = tipBlockNumberLong
+            tipBlockNumber = tipBlockNumberLong,
+            onLookupAddressOnExplorer = onLookupBlockHeight
         )
     }
 
@@ -1231,6 +1250,19 @@ private fun buildExplorerUrl(txHash: String, network: NetworkType): String {
         NetworkType.TESTNET -> "https://testnet.explorer.nervos.org/transaction"
     }
     return "$base/$txHash"
+}
+
+/**
+ * Address page URL on the public CKB explorer (#85). Used by
+ * SyncOptionsDialog's "Don't know your block height?" helper so non-technical
+ * users can scroll to their first transaction and read the block number off.
+ */
+internal fun buildExplorerAddressUrl(address: String, network: NetworkType): String {
+    val base = when (network) {
+        NetworkType.MAINNET -> "https://explorer.nervos.org/address"
+        NetworkType.TESTNET -> "https://testnet.explorer.nervos.org/address"
+    }
+    return "$base/$address"
 }
 
 @Preview(showBackground = true)

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/settings/SettingsScreen.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/settings/SettingsScreen.kt
@@ -159,12 +159,29 @@ fun SettingsScreen(
 
     // Sync options dialog
     if (uiState.showSyncDialog) {
+        // "Don't know your block height?" helper (#85). Opens the user's
+        // address page on the CKB explorer when CUSTOM is selected.
+        val onLookupBlockHeight: (() -> Unit)? = uiState.address?.takeIf { it.isNotBlank() }?.let { addr ->
+            {
+                val url = com.rjnr.pocketnode.ui.screens.home.buildExplorerAddressUrl(
+                    addr, uiState.currentNetwork
+                )
+                try {
+                    context.startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(url)))
+                } catch (_: android.content.ActivityNotFoundException) {
+                    scope.launch {
+                        snackbarHostState.showSnackbar("No browser available to open the explorer")
+                    }
+                }
+            }
+        }
         SyncOptionsDialog(
             currentMode = uiState.syncMode,
             onDismiss = { viewModel.hideSyncDialog() },
             onSelectMode = { mode, customBlock -> viewModel.setSyncMode(mode, customBlock) },
             savedCustomBlockHeight = uiState.savedCustomBlockHeight,
-            tipBlockNumber = uiState.tipBlockNumber
+            tipBlockNumber = uiState.tipBlockNumber,
+            onLookupAddressOnExplorer = onLookupBlockHeight
         )
     }
 

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/settings/SettingsViewModel.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/settings/SettingsViewModel.kt
@@ -40,6 +40,9 @@ class SettingsViewModel @Inject constructor(
         val showThemeDialog: Boolean = false,
         val pendingNetworkSwitch: NetworkType? = null,
         val tipBlockNumber: Long = 0L,
+        // Active wallet address — used by SyncOptionsDialog's "look up on explorer"
+        // helper for the CUSTOM mode (#85). Null until the wallet is initialized.
+        val address: String? = null,
         val error: String? = null
     )
 
@@ -52,7 +55,20 @@ class SettingsViewModel @Inject constructor(
         // Keep network in sync with repository's live StateFlow
         viewModelScope.launch {
             repository.network.collect { network ->
-                _uiState.update { it.copy(currentNetwork = network) }
+                _uiState.update {
+                    it.copy(
+                        currentNetwork = network,
+                        // Address derives from network — keep it fresh on switch.
+                        address = repository.getCurrentAddress()
+                    )
+                }
+            }
+        }
+
+        // Track wallet info changes so address updates when the active wallet flips.
+        viewModelScope.launch {
+            repository.walletInfo.collect { _ ->
+                _uiState.update { it.copy(address = repository.getCurrentAddress()) }
             }
         }
 


### PR DESCRIPTION
Closes #85.

## Problem

Non-technical users picking the **Custom Block Height** sync mode have no way to know what block to enter. From the issue:

> non technical not seeing their transaction after creating the wallet, change device and try to reimport using mnemonic

If you re-import a mnemonic on a new device, you need to pick a sync start block at least as old as your wallet's first transaction — otherwise the history doesn't show. There was no in-app help for finding that block.

## Fix

Smallest viable: when the user selects **Custom** in \`SyncOptionsDialog\`, render a "**Don't know your block height? Look up on explorer**" text button that opens the user's address page on the public CKB explorer:

- Mainnet: \`https://explorer.nervos.org/address/{address}\`
- Testnet: \`https://testnet.explorer.nervos.org/address/{address}\`

Users scroll to the oldest transaction in their address history and read the block number off it directly.

## Why deeplink instead of API lookup

The original issue suggests "look up their transaction on the blockchain" automatically. Considered but skipped:

- Adds an HTTP dependency on the explorer's API surface (which is undocumented for free use).
- Same geo-availability concerns we hit with CoinGecko (#117).
- Parsing schema risk and ongoing maintenance.

Deeplinking lets users perform the lookup with the explorer's own well-tested UI; we don't take on a new external API surface.

## Implementation

- New \`onLookupAddressOnExplorer: (() -> Unit)?\` param on \`SyncOptionsDialog\` (composable stays free of Intent/Uri plumbing).
- \`buildExplorerAddressUrl\` helper in \`HomeScreen.kt\` (next to existing \`buildExplorerUrl\` for tx pages).
- All three call sites (Home settings path, Home post-import dialog, SettingsScreen) pass a lambda that builds the URL from the active address+network and launches via \`Intent.ACTION_VIEW\`. Snackbar fallback if no browser is available.
- \`SettingsViewModel\` gains an \`address\` field on its UiState (collected from \`repository.walletInfo\`).

## Test plan

- [x] \`./gradlew compileDebugKotlin\` — green
- [x] \`./gradlew testDebugUnitTest\` — green
- [ ] On-device: open Settings → Sync Mode → Custom; "Don't know your block height?" link visible; tap opens browser at \`explorer.nervos.org/address/<your-address>\`
- [ ] Switch to testnet; same flow opens \`testnet.explorer.nervos.org/address/<your-address>\`
- [ ] Pre-init state (no address yet): link is hidden — no broken behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a helper button in sync options to look up the current wallet address on the CKB blockchain explorer with one tap. Gracefully handles cases where no browser is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->