### PR TITLE
feat(dao): pull-to-refresh on the DAO deposit screen

### DIFF
--- a/android/app/src/main/java/com/rjnr/pocketnode/data/gateway/models/DaoModels.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/gateway/models/DaoModels.kt
@@ -96,7 +96,12 @@ data class DaoUiState(
     val activeDeposits: List<DaoDeposit> = emptyList(),
     val completedDeposits: List<DaoDeposit> = emptyList(),
     val selectedTab: DaoTab = DaoTab.ACTIVE,
+    // Initial-load spinner. Driven once on first refresh; subsequent refreshes
+    // surface through `isRefreshing` (the pull-to-refresh indicator) instead.
     val isLoading: Boolean = true,
+    // Pull-to-refresh indicator. Distinct from `isLoading` so the user can
+    // refresh without the screen blanking out into a fullscreen spinner.
+    val isRefreshing: Boolean = false,
     val error: String? = null,
     val pendingAction: DaoAction? = null,
     val requiresAuth: Boolean = false,

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/dao/DaoScreen.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/dao/DaoScreen.kt
@@ -32,6 +32,7 @@ import com.rjnr.pocketnode.ui.theme.TestnetOrange
 
 private val DaoGreen = Color(0xFF1ED882)
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun DaoScreen(
     viewModel: DaoViewModel,

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/dao/DaoScreen.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/dao/DaoScreen.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Lock
 import androidx.compose.material3.*
+import androidx.compose.material3.pulltorefresh.PullToRefreshBox
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -49,103 +50,128 @@ fun DaoScreen(
     Scaffold(
         snackbarHost = { SnackbarHost(snackbarHostState) }
     ) { padding ->
-        Column(
+        // Initial-load fullscreen spinner (only on first ever load — subsequent
+        // refreshes use the PullToRefresh indicator).
+        if (uiState.isLoading) {
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(padding),
+                contentAlignment = Alignment.Center
+            ) {
+                CircularProgressIndicator()
+            }
+            return@Scaffold
+        }
+
+        // Whole content lives inside PullToRefreshBox so the user can refresh
+        // from anywhere on the screen (overview card, tabs, list, or the empty
+        // state) without needing to navigate away and back. Single LazyColumn
+        // hosts every section as an `item { ... }` — same pattern as HomeScreen.
+        PullToRefreshBox(
+            isRefreshing = uiState.isRefreshing,
+            onRefresh = { viewModel.refresh() },
             modifier = Modifier
                 .fillMaxSize()
                 .padding(padding)
                 .padding(horizontal = com.rjnr.pocketnode.ui.util.screenHorizontalPadding())
         ) {
-            Spacer(modifier = Modifier.height(16.dp))
-
-            DaoOverviewCard(
-                overview = uiState.overview,
-                availableBalance = availableBalance,
-                networkType = networkType,
-                onDepositClick = { showDepositSheet = true }
-            )
-
-            Spacer(modifier = Modifier.height(16.dp))
-
-            DaoTabRow(
-                selectedTab = uiState.selectedTab,
-                activeCount = uiState.overview.activeCount,
-                completedCount = uiState.overview.completedCount,
-                onTabSelected = viewModel::selectTab
-            )
-
-            Spacer(modifier = Modifier.height(8.dp))
-
-            // Pending action indicator
-            uiState.pendingAction?.let { action ->
-                Surface(
-                    modifier = Modifier.fillMaxWidth(),
-                    shape = RoundedCornerShape(12.dp),
-                    color = PendingAmber.copy(alpha = 0.1f)
-                ) {
-                    Row(
-                        modifier = Modifier.padding(12.dp),
-                        verticalAlignment = Alignment.CenterVertically,
-                        horizontalArrangement = Arrangement.spacedBy(12.dp)
-                    ) {
-                        CircularProgressIndicator(
-                            modifier = Modifier.size(20.dp),
-                            strokeWidth = 2.dp,
-                            color = PendingAmber
-                        )
-                        Text(
-                            text = when (action) {
-                                is DaoAction.Depositing -> "Depositing ${formatCkb(action.amount)} CKB..."
-                                is DaoAction.Withdrawing -> "Withdrawing from DAO..."
-                                is DaoAction.Unlocking -> "Unlocking DAO deposit..."
-                            },
-                            style = MaterialTheme.typography.bodyMedium,
-                            color = PendingAmber
-                        )
-                    }
-                }
-                Spacer(modifier = Modifier.height(8.dp))
-            }
-
             val deposits = when (uiState.selectedTab) {
                 DaoTab.ACTIVE -> uiState.activeDeposits
                 DaoTab.COMPLETED -> uiState.completedDeposits
             }
 
-            if (uiState.isLoading) {
-                Box(
-                    modifier = Modifier.fillMaxSize(),
-                    contentAlignment = Alignment.Center
-                ) {
-                    CircularProgressIndicator()
+            LazyColumn(
+                modifier = Modifier.fillMaxSize(),
+                verticalArrangement = Arrangement.spacedBy(12.dp),
+                contentPadding = PaddingValues(vertical = 16.dp)
+            ) {
+                item("overview") {
+                    DaoOverviewCard(
+                        overview = uiState.overview,
+                        availableBalance = availableBalance,
+                        networkType = networkType,
+                        onDepositClick = { showDepositSheet = true }
+                    )
                 }
-            } else if (deposits.isEmpty() && uiState.selectedTab == DaoTab.ACTIVE) {
-                DaoEmptyState(onDepositClick = { showDepositSheet = true })
-            } else if (deposits.isEmpty()) {
-                Box(
-                    modifier = Modifier.fillMaxSize(),
-                    contentAlignment = Alignment.Center
-                ) {
-                    Column(horizontalAlignment = Alignment.CenterHorizontally) {
-                        Text(
-                            text = "No completed deposits",
-                            style = MaterialTheme.typography.bodyLarge,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant
-                        )
-                        Spacer(modifier = Modifier.height(8.dp))
-                        Text(
-                            text = "Fully unlocked deposits are consumed on-chain. Check your transaction history for past DAO activity.",
-                            style = MaterialTheme.typography.bodySmall,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.6f),
-                            textAlign = TextAlign.Center,
-                            modifier = Modifier.padding(horizontal = 32.dp)
-                        )
+
+                item("tabs") {
+                    DaoTabRow(
+                        selectedTab = uiState.selectedTab,
+                        activeCount = uiState.overview.activeCount,
+                        completedCount = uiState.overview.completedCount,
+                        onTabSelected = viewModel::selectTab
+                    )
+                }
+
+                // Pending action banner — only when an action is in flight.
+                uiState.pendingAction?.let { action ->
+                    item("pending-action") {
+                        Surface(
+                            modifier = Modifier.fillMaxWidth(),
+                            shape = RoundedCornerShape(12.dp),
+                            color = PendingAmber.copy(alpha = 0.1f)
+                        ) {
+                            Row(
+                                modifier = Modifier.padding(12.dp),
+                                verticalAlignment = Alignment.CenterVertically,
+                                horizontalArrangement = Arrangement.spacedBy(12.dp)
+                            ) {
+                                CircularProgressIndicator(
+                                    modifier = Modifier.size(20.dp),
+                                    strokeWidth = 2.dp,
+                                    color = PendingAmber
+                                )
+                                Text(
+                                    text = when (action) {
+                                        is DaoAction.Depositing -> "Depositing ${formatCkb(action.amount)} CKB..."
+                                        is DaoAction.Withdrawing -> "Withdrawing from DAO..."
+                                        is DaoAction.Unlocking -> "Unlocking DAO deposit..."
+                                    },
+                                    style = MaterialTheme.typography.bodyMedium,
+                                    color = PendingAmber
+                                )
+                            }
+                        }
                     }
                 }
-            } else {
-                LazyColumn(
-                    verticalArrangement = Arrangement.spacedBy(12.dp),
-                    contentPadding = PaddingValues(vertical = 8.dp)
-                ) {
+
+                if (deposits.isEmpty() && uiState.selectedTab == DaoTab.ACTIVE) {
+                    item("empty-active") {
+                        // fillParentMaxHeight gives the empty-state vertical
+                        // breathing room AND keeps the LazyColumn scrollable so
+                        // pull-to-refresh still detects the gesture.
+                        Box(
+                            modifier = Modifier.fillParentMaxHeight(0.85f),
+                            contentAlignment = Alignment.Center
+                        ) {
+                            DaoEmptyState(onDepositClick = { showDepositSheet = true })
+                        }
+                    }
+                } else if (deposits.isEmpty()) {
+                    item("empty-completed") {
+                        Box(
+                            modifier = Modifier.fillParentMaxHeight(0.6f),
+                            contentAlignment = Alignment.Center
+                        ) {
+                            Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                                Text(
+                                    text = "No completed deposits",
+                                    style = MaterialTheme.typography.bodyLarge,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                                )
+                                Spacer(modifier = Modifier.height(8.dp))
+                                Text(
+                                    text = "Fully unlocked deposits are consumed on-chain. Check your transaction history for past DAO activity.",
+                                    style = MaterialTheme.typography.bodySmall,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.6f),
+                                    textAlign = TextAlign.Center,
+                                    modifier = Modifier.padding(horizontal = 32.dp)
+                                )
+                            }
+                        }
+                    }
+                } else {
                     items(deposits, key = { "${it.outPoint.txHash}:${it.outPoint.index}" }) { deposit ->
                         DaoDepositCard(
                             deposit = deposit,

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/dao/DaoViewModel.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/dao/DaoViewModel.kt
@@ -182,6 +182,24 @@ class DaoViewModel @Inject constructor(
         _uiState.update { it.copy(selectedTab = tab) }
     }
 
+    /**
+     * Pull-to-refresh entry point. Distinct from the periodic poll started in
+     * [startPolling] — this fires immediately on user gesture and surfaces
+     * its progress through `isRefreshing` (the PTR indicator) rather than the
+     * fullscreen `isLoading` spinner.
+     */
+    fun refresh() {
+        if (_uiState.value.isRefreshing) return
+        viewModelScope.launch {
+            _uiState.update { it.copy(isRefreshing = true) }
+            try {
+                refreshDaoData()
+            } finally {
+                _uiState.update { it.copy(isRefreshing = false) }
+            }
+        }
+    }
+
     fun clearError() {
         _uiState.update { it.copy(error = null) }
     }


### PR DESCRIPTION
## Why

Until now the DAO screen only refreshed via the 30s background poll (10s when a pending action is in flight) or by navigating away and back. Both surfaces produced the "Withdrawing..." spinner repro in the prior session — the user had to leave the screen and return to see the cell-card update.

HomeScreen and ActivityScreen already have pull-to-refresh; DAO didn't. This PR makes DAO consistent.

## What

- **\`isRefreshing\` on \`DaoUiState\`** — distinct from \`isLoading\` (the initial-load fullscreen spinner). PTR uses the new flag so a refresh doesn't blank the screen.
- **\`DaoViewModel.refresh()\`** — public, re-entry-guarded, sets \`isRefreshing\` while delegating to the existing private \`refreshDaoData()\`. Polling and PTR paths share one fetch impl.
- **\`PullToRefreshBox\` wrapping DaoScreen content** — inner Column becomes a single LazyColumn with \`item { ... }\` slots for overview / tabs / pending-action banner / list-or-empty. Same pattern as HomeScreen.
- **Empty states use \`fillParentMaxHeight\`** so the LazyColumn stays scrollable — pull gesture works even when there are zero deposits.
- **Initial-load spinner** moved to an early-return Scaffold branch (matches HomeScreen).

## Test plan

- [x] \`./gradlew compileDebugKotlin\` — green
- [x] \`./gradlew testDebugUnitTest\` — green
- [ ] On-device, populated list: pull down — refresh indicator appears, deposits re-fetch, indicator dismisses
- [ ] On-device, empty Active tab (no deposits): pull down — refresh indicator works, screen doesn't change layout
- [ ] During an in-flight withdraw: pull down to manually refresh — pending banner / cell-card update without leaving the screen
- [ ] Initial app launch on DAO tab: fullscreen spinner shows briefly, then content + PTR-ready

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added pull-to-refresh capability to the DAO screen, enabling users to manually refresh data with a downward swipe.
  * Improved loading state presentation with distinct visual indicators: full-screen spinner for initial loads and a pull-to-refresh indicator for subsequent refreshes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->