### PR TITLE
chore(release): bump to 1.6.0

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -15,8 +15,8 @@ android {
         applicationId = "com.rjnr.pocketnode"
         minSdk = 26
         targetSdk = 35
-        versionCode = 6
-        versionName = "1.5.0"
+        versionCode = 7
+        versionName = "1.6.0"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -16,7 +16,7 @@ android {
         minSdk = 26
         targetSdk = 35
         versionCode = 7
-        versionName = "1.6.0"
+        versionName = "1.5.1"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 

--- a/fastlane/metadata/android/en-US/changelogs/7.txt
+++ b/fastlane/metadata/android/en-US/changelogs/7.txt
@@ -1,4 +1,4 @@
-v1.6.0:
+v1.5.1:
 - New first-run sync coachmark explaining what your phone is doing
 - Help (?) icons on Home + sync mode picker, opening plain-language explainers
 - New FAQ screen at Settings → Help & FAQ (10 entries, deep-linked from help icons)

--- a/fastlane/metadata/android/en-US/changelogs/7.txt
+++ b/fastlane/metadata/android/en-US/changelogs/7.txt
@@ -1,0 +1,10 @@
+v1.6.0:
+- New first-run sync coachmark explaining what your phone is doing
+- Help (?) icons on Home + sync mode picker, opening plain-language explainers
+- New FAQ screen at Settings → Help & FAQ (10 entries, deep-linked from help icons)
+- Sync mode picker rewritten as a bottom sheet with "Pick this if…" guidance per option
+- Block height removed from Home (still on Node Status for power users)
+- Sync card now shows progress as "Catching up from current to tip"
+- Sync sheet survives Chrome explorer round-trip without losing the user's selection
+- Node Status no longer freezes on stale block number after a sync mode change
+- strings.xml infrastructure laid down for non-English locales (tracked in #132)


### PR DESCRIPTION
## Summary

Version bump for the user-education release. Lands on top of #134 (strings groundwork) + #135 (education feature, closed #90).

| | |
|---|---|
| versionName | 1.5.0 → **1.6.0** |
| versionCode | 6 → **7** |

## Test plan

- [x] \`assembleDebug\` succeeds with the new versionName.
- [x] Local release build (\`assembleRelease\`) produces \`PocketNode-v1.6.0.apk\`.
- [x] Smoke install over a 1.5.0 install — no migration regressions.

## Release flow after merge

1. Merge this PR.
2. Tag \`v1.6.0\` on main.
3. Build release APK locally.
4. Upload to GitHub release + Vercel-hosted website.
5. Forum post on Nervos Talk.