### PR TITLE
fix(release): v1.5.2 hotfix — migration crash + broken auto-update URL

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -15,8 +15,8 @@ android {
         applicationId = "com.rjnr.pocketnode"
         minSdk = 26
         targetSdk = 35
-        versionCode = 7
-        versionName = "1.5.1"
+        versionCode = 8
+        versionName = "1.5.2"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 

--- a/android/app/src/main/java/com/rjnr/pocketnode/data/database/entity/BalanceCacheEntity.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/database/entity/BalanceCacheEntity.kt
@@ -1,5 +1,6 @@
 package com.rjnr.pocketnode.data.database.entity
 
+import androidx.room.ColumnInfo
 import androidx.room.Entity
 import com.rjnr.pocketnode.data.gateway.models.BalanceResponse
 
@@ -8,7 +9,9 @@ import com.rjnr.pocketnode.data.gateway.models.BalanceResponse
     primaryKeys = ["walletId", "network"]
 )
 data class BalanceCacheEntity(
-    val walletId: String,
+    // MIGRATION_2_3 / MIGRATION_3_4 created this column with `DEFAULT ''`.
+    // Annotation must match for Room schema validation. (v1.5.1 hotfix)
+    @ColumnInfo(defaultValue = "''") val walletId: String,
     val network: String,
     val address: String,
     val capacity: String,

--- a/android/app/src/main/java/com/rjnr/pocketnode/data/database/entity/DaoCellEntity.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/database/entity/DaoCellEntity.kt
@@ -1,5 +1,6 @@
 package com.rjnr.pocketnode.data.database.entity
 
+import androidx.room.ColumnInfo
 import androidx.room.Entity
 import androidx.room.Index
 
@@ -29,5 +30,6 @@ data class DaoCellEntity(
     val depositTimestamp: Long,
     val network: String,
     val lastUpdatedAt: Long,
-    val walletId: String = ""
+    // MIGRATION_2_3 created this column with `DEFAULT ''`. (v1.5.1 hotfix)
+    @ColumnInfo(defaultValue = "''") val walletId: String = ""
 )

--- a/android/app/src/main/java/com/rjnr/pocketnode/data/database/entity/TransactionEntity.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/database/entity/TransactionEntity.kt
@@ -1,5 +1,6 @@
 package com.rjnr.pocketnode.data.database.entity
 
+import androidx.room.ColumnInfo
 import androidx.room.Entity
 import androidx.room.Index
 import androidx.room.PrimaryKey
@@ -11,6 +12,19 @@ import com.rjnr.pocketnode.data.gateway.models.TransactionRecord
         Index(
             value = ["walletId", "network", "timestamp"],
             name = "idx_tx_wallet_network_time",
+            orders = [Index.Order.ASC, Index.Order.ASC, Index.Order.DESC]
+        ),
+        // MIGRATION_5_6 created this index (originally as a partial index keyed
+        // on PENDING rows). Room does not see WHERE clauses via the pragmas it
+        // uses for schema validation, so declaring it here as a regular @Index
+        // matches what Room observes in the migrated schema. Fresh installs get
+        // the regular form; both forms have identical query-planner shape on
+        // the (walletId, network, timestamp DESC) prefix the activity sort
+        // uses. Without this declaration, Room flags the index as an unexpected
+        // extra and crashes on launch after migration. (#90 v1.5.1 hotfix)
+        Index(
+            value = ["walletId", "network", "timestamp"],
+            name = "idx_tx_pending",
             orders = [Index.Order.ASC, Index.Order.ASC, Index.Order.DESC]
         )
     ]
@@ -29,7 +43,10 @@ data class TransactionEntity(
     val status: String,       // "PENDING", "CONFIRMED", "FAILED"
     val isLocal: Boolean,     // true = broadcast but not yet synced
     val cachedAt: Long,
-    val walletId: String = ""
+    // MIGRATION_2_3 added this column with `DEFAULT ''`. Without the
+    // matching @ColumnInfo annotation, Room expects no default and crashes
+    // schema validation after migration. (v1.5.1 hotfix)
+    @ColumnInfo(defaultValue = "''") val walletId: String = ""
 ) {
     fun toTransactionRecord(): TransactionRecord = TransactionRecord(
         txHash = txHash,

--- a/android/app/src/main/java/com/rjnr/pocketnode/data/update/UpdateRepository.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/update/UpdateRepository.kt
@@ -12,8 +12,12 @@ import javax.inject.Inject
 import javax.inject.Singleton
 
 private const val TAG = "UpdateRepository"
+// Auto-update polls the actual project repo; v1.5.0 + v1.5.1 shipped with a
+// stale fork URL (`AgustaRC/ckb-wallet-gateway`) that 404s, so the in-app
+// "new version available" notification never fired. Users on those releases
+// must manually grab v1.5.2 once; auto-update works from v1.5.2 onward.
 private const val GITHUB_API_URL =
-    "https://api.github.com/repos/AgustaRC/ckb-wallet-gateway/releases/latest"
+    "https://api.github.com/repos/RaheemJnr/pocket-node/releases/latest"
 
 @Serializable
 internal data class GitHubReleaseAsset(

--- a/fastlane/metadata/android/en-US/changelogs/8.txt
+++ b/fastlane/metadata/android/en-US/changelogs/8.txt
@@ -1,0 +1,5 @@
+v1.5.2:
+- Fixes app crash on launch when upgrading from v1.5.0 or earlier (Room schema mismatch).
+- Fixes the in-app update notification: previous releases polled the wrong GitHub
+  repo and silently dropped every check. Users on v1.5.0 / v1.5.1 must install
+  v1.5.2 manually once; auto-update works from v1.5.2 onward.


### PR DESCRIPTION
## Summary

Emergency hotfix for two blockers discovered after v1.5.1 shipped.

### 1. v1.5.1 crashes on upgrade

Users upgrading from v1.5.0 (or any earlier version) hit:

\`\`\`
java.lang.IllegalStateException: Migration didn't properly handle: transactions(...).
\`\`\`

Two specific diffs:

| Mismatch | Cause | Fix |
|---|---|---|
| \`idx_tx_pending\` in migrated DB, not in entity | \`MIGRATION_5_6\` created it as raw-SQL partial index. The migration comment claimed Room ignored uncreated indices, which is not true. | Declare it as \`@Index\` on \`TransactionEntity\`. Room compares by name + columns + orders, not WHERE clauses, so partial-from-migration matches non-partial-from-entity. |
| \`transactions.walletId\` has \`DEFAULT ''\`, entity has no annotation | \`MIGRATION_2_3\` added the column with the SQL default; entity had only Kotlin default. Same shape on \`balance_cache.walletId\` and \`dao_cells.walletId\`. | \`@ColumnInfo(defaultValue = \"''\")\` on all three fields. |

The existing \`MigrationTest\` uses \`inMemoryDatabaseBuilder\` which creates a fresh schema without exercising migrations, which is why this wasn't caught in CI. Adding a proper instrumented \`MigrationTestHelper\` test (with \`exportSchema = true\`) is tracked as follow-up.

### 2. In-app auto-update notification never fires

\`UpdateRepository\` polled \`api.github.com/repos/AgustaRC/ckb-wallet-gateway/releases/latest\` which 404s, so every release check returned an exception that was silently logged. Users have never received an auto-update notification.

Fixed by pointing at \`RaheemJnr/pocket-node\`.

**Important caveat:** users on v1.5.0 / v1.5.1 are running code that polls the broken URL. They will not get an auto-update notification for v1.5.2 either; they have to grab it from the website or GitHub release manually once. From v1.5.2 onward, auto-update works.

## Version

| | |
|---|---|
| versionName | 1.5.1 → **1.5.2** |
| versionCode | 7 → **8** |

## Test plan

- [x] \`assembleDebug\` succeeds with the new annotations.
- [x] \`testDebugUnitTest\` passes (548 tests).
- [ ] Smoke install over a clean v1.5.0 install on a real device. Confirm no crash on launch.
- [ ] Confirm in-app update check actually fires the dialog when v1.5.3 (future) is released. (Will be validated naturally on the next release.)

## Follow-ups

- Enable Room \`exportSchema = true\` and add an instrumented \`MigrationTestHelper\` test that exercises every migration path with realistic v1 data and validates the resulting schema. (Open as separate issue.)
- Update CLAUDE.md or a release-checklist doc to require a pre-merge smoke install over the previous release before tagging.

## Communication plan after merge

- Tag v1.5.2, build, upload APK to the release.
- Update website download links to v1.5.2.
- Forum + X post calling out: v1.5.0 / v1.5.1 users must manually grab v1.5.2 once.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed app crash when upgrading from version 1.5.0 or earlier.
* Fixed in-app update notifications to detect new releases correctly.
* Users upgrading from v1.5.0 or v1.5.1 must manually install this release; subsequent updates will work automatically.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->