### PR TITLE
fix(db): v1.5.2 hotfix #2 — bump DB version after entity annotation changes

### DIFF
--- a/android/app/src/main/java/com/rjnr/pocketnode/data/database/AppDatabase.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/database/AppDatabase.kt
@@ -30,7 +30,13 @@ import com.rjnr.pocketnode.data.database.entity.WalletEntity
         SyncProgressEntity::class,
         PendingBroadcastEntity::class
     ],
-    version = 8,
+    // Bumped from 8 to 9 in v1.5.2 because TransactionEntity / BalanceCacheEntity
+    // / DaoCellEntity gained @Index(idx_tx_pending) + @ColumnInfo(defaultValue)
+    // annotations. The DB shape is unchanged (the migrations 1→8 already
+    // produced this exact shape; the annotations just declare it correctly),
+    // so MIGRATION_8_9 is a no-op. Version bump alone is needed to refresh
+    // Room's stored identity hash after the entity declarations changed. (#90 / #141)
+    version = 9,
     exportSchema = false
 )
 abstract class AppDatabase : RoomDatabase() {

--- a/android/app/src/main/java/com/rjnr/pocketnode/data/database/Migrations.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/database/Migrations.kt
@@ -248,3 +248,28 @@ val MIGRATION_7_8 = object : Migration(7, 8) {
         )
     }
 }
+
+/**
+ * v8 -> v9: No-op identity-hash refresh (#141 / v1.5.2).
+ *
+ * v1.5.1 shipped with TransactionEntity / BalanceCacheEntity / DaoCellEntity
+ * declarations that didn't match the post-migration DB shape (missing
+ * @Index(idx_tx_pending) + @ColumnInfo(defaultValue) annotations). The hotfix
+ * adds those annotations so the entity declarations match what the migrations
+ * actually produced.
+ *
+ * The DB shape on disk is unchanged. But Room computes its stored identity
+ * hash from the entity definitions, so any change to those declarations bumps
+ * the hash, and Room refuses to open a DB whose stored hash differs from the
+ * current one even when the schema is identical. Bumping the version + adding
+ * a no-op migration tells Room to refresh its bookkeeping.
+ *
+ * Anyone who briefly opened the v1.5.1 build before it crashed wrote the
+ * old hash to disk; this migration lets v1.5.2 reset it without forcing a
+ * data wipe.
+ */
+val MIGRATION_8_9 = object : Migration(8, 9) {
+    override fun migrate(db: SupportSQLiteDatabase) {
+        // Intentionally empty. See KDoc.
+    }
+}

--- a/android/app/src/main/java/com/rjnr/pocketnode/data/database/Migrations.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/database/Migrations.kt
@@ -250,26 +250,149 @@ val MIGRATION_7_8 = object : Migration(7, 8) {
 }
 
 /**
- * v8 -> v9: No-op identity-hash refresh (#141 / v1.5.2).
+ * v8 -> v9: Converge two divergent v8 schemas (#141 / v1.5.2).
  *
- * v1.5.1 shipped with TransactionEntity / BalanceCacheEntity / DaoCellEntity
- * declarations that didn't match the post-migration DB shape (missing
- * @Index(idx_tx_pending) + @ColumnInfo(defaultValue) annotations). The hotfix
- * adds those annotations so the entity declarations match what the migrations
- * actually produced.
+ * v1.5.1 had broken entity declarations on TransactionEntity /
+ * BalanceCacheEntity / DaoCellEntity (missing @Index(idx_tx_pending) +
+ * @ColumnInfo(defaultValue = "''") on walletId). Two distinct shapes ended up
+ * in the wild at "v8":
  *
- * The DB shape on disk is unchanged. But Room computes its stored identity
- * hash from the entity definitions, so any change to those declarations bumps
- * the hash, and Room refuses to open a DB whose stored hash differs from the
- * current one even when the schema is identical. Bumping the version + adding
- * a no-op migration tells Room to refresh its bookkeeping.
+ * 1. Upgrade-from-v1.5.0 path: ran MIGRATION_2_3 (which adds walletId with
+ *    `DEFAULT ''`) and MIGRATION_5_6 (which creates a partial idx_tx_pending).
+ *    Both are present on disk.
  *
- * Anyone who briefly opened the v1.5.1 build before it crashed wrote the
- * old hash to disk; this migration lets v1.5.2 reset it without forcing a
- * data wipe.
+ * 2. Fresh-install-on-v1.5.1 path: Room created the v8 schema directly from
+ *    the v1.5.1 entity declarations, which had neither the column default
+ *    nor the index. So neither is present on disk.
+ *
+ * The v1.5.2 entity declarations (annotated correctly) only validate against
+ * shape 1. Shape 2 users crash with a TableInfo mismatch.
+ *
+ * This migration recreates the three affected tables with the canonical
+ * column DEFAULTs and (re)creates `idx_tx_pending` as a regular index. It is
+ * idempotent against both paths: shape 1 users get the same shape back; shape
+ * 2 users get the missing pieces.
  */
 val MIGRATION_8_9 = object : Migration(8, 9) {
     override fun migrate(db: SupportSQLiteDatabase) {
-        // Intentionally empty. See KDoc.
+        // --- transactions -------------------------------------------------
+        db.execSQL(
+            """
+            CREATE TABLE IF NOT EXISTS `transactions_new` (
+                `txHash` TEXT NOT NULL,
+                `blockNumber` TEXT NOT NULL,
+                `blockHash` TEXT NOT NULL,
+                `timestamp` INTEGER NOT NULL,
+                `balanceChange` TEXT NOT NULL,
+                `direction` TEXT NOT NULL,
+                `fee` TEXT NOT NULL,
+                `confirmations` INTEGER NOT NULL,
+                `blockTimestampHex` TEXT,
+                `network` TEXT NOT NULL,
+                `status` TEXT NOT NULL,
+                `isLocal` INTEGER NOT NULL,
+                `cachedAt` INTEGER NOT NULL,
+                `walletId` TEXT NOT NULL DEFAULT '',
+                PRIMARY KEY(`txHash`)
+            )
+            """.trimIndent()
+        )
+        db.execSQL(
+            """
+            INSERT INTO `transactions_new` (
+                `txHash`, `blockNumber`, `blockHash`, `timestamp`,
+                `balanceChange`, `direction`, `fee`, `confirmations`,
+                `blockTimestampHex`, `network`, `status`, `isLocal`,
+                `cachedAt`, `walletId`
+            )
+            SELECT `txHash`, `blockNumber`, `blockHash`, `timestamp`,
+                   `balanceChange`, `direction`, `fee`, `confirmations`,
+                   `blockTimestampHex`, `network`, `status`, `isLocal`,
+                   `cachedAt`, `walletId`
+            FROM `transactions`
+            """.trimIndent()
+        )
+        db.execSQL("DROP TABLE `transactions`")
+        db.execSQL("ALTER TABLE `transactions_new` RENAME TO `transactions`")
+        // Recreate both indices to match what TransactionEntity declares.
+        db.execSQL(
+            "CREATE INDEX IF NOT EXISTS `idx_tx_wallet_network_time` " +
+                "ON `transactions` (`walletId`, `network`, `timestamp` DESC)"
+        )
+        db.execSQL(
+            "CREATE INDEX IF NOT EXISTS `idx_tx_pending` " +
+                "ON `transactions` (`walletId`, `network`, `timestamp` DESC)"
+        )
+
+        // --- balance_cache ------------------------------------------------
+        db.execSQL(
+            """
+            CREATE TABLE IF NOT EXISTS `balance_cache_new` (
+                `walletId` TEXT NOT NULL DEFAULT '',
+                `network` TEXT NOT NULL,
+                `address` TEXT NOT NULL,
+                `capacity` TEXT NOT NULL,
+                `capacityCkb` TEXT NOT NULL,
+                `blockNumber` TEXT NOT NULL,
+                `cachedAt` INTEGER NOT NULL,
+                PRIMARY KEY(`walletId`, `network`)
+            )
+            """.trimIndent()
+        )
+        db.execSQL(
+            "INSERT INTO `balance_cache_new` " +
+                "SELECT `walletId`, `network`, `address`, `capacity`, " +
+                "`capacityCkb`, `blockNumber`, `cachedAt` FROM `balance_cache`"
+        )
+        db.execSQL("DROP TABLE `balance_cache`")
+        db.execSQL("ALTER TABLE `balance_cache_new` RENAME TO `balance_cache`")
+
+        // --- dao_cells ----------------------------------------------------
+        db.execSQL(
+            """
+            CREATE TABLE IF NOT EXISTS `dao_cells_new` (
+                `txHash` TEXT NOT NULL,
+                `index` TEXT NOT NULL,
+                `capacity` INTEGER NOT NULL,
+                `status` TEXT NOT NULL,
+                `depositBlockNumber` INTEGER NOT NULL,
+                `depositBlockHash` TEXT NOT NULL,
+                `depositEpochHex` TEXT,
+                `withdrawBlockNumber` INTEGER,
+                `withdrawBlockHash` TEXT,
+                `withdrawEpochHex` TEXT,
+                `compensation` INTEGER NOT NULL,
+                `unlockEpochHex` TEXT,
+                `depositTimestamp` INTEGER NOT NULL,
+                `network` TEXT NOT NULL,
+                `lastUpdatedAt` INTEGER NOT NULL,
+                `walletId` TEXT NOT NULL DEFAULT '',
+                PRIMARY KEY(`txHash`, `index`)
+            )
+            """.trimIndent()
+        )
+        db.execSQL(
+            """
+            INSERT INTO `dao_cells_new` (
+                `txHash`, `index`, `capacity`, `status`,
+                `depositBlockNumber`, `depositBlockHash`, `depositEpochHex`,
+                `withdrawBlockNumber`, `withdrawBlockHash`, `withdrawEpochHex`,
+                `compensation`, `unlockEpochHex`, `depositTimestamp`,
+                `network`, `lastUpdatedAt`, `walletId`
+            )
+            SELECT `txHash`, `index`, `capacity`, `status`,
+                   `depositBlockNumber`, `depositBlockHash`, `depositEpochHex`,
+                   `withdrawBlockNumber`, `withdrawBlockHash`, `withdrawEpochHex`,
+                   `compensation`, `unlockEpochHex`, `depositTimestamp`,
+                   `network`, `lastUpdatedAt`, `walletId`
+            FROM `dao_cells`
+            """.trimIndent()
+        )
+        db.execSQL("DROP TABLE `dao_cells`")
+        db.execSQL("ALTER TABLE `dao_cells_new` RENAME TO `dao_cells`")
+        db.execSQL(
+            "CREATE INDEX IF NOT EXISTS `idx_dao_wallet_network` " +
+                "ON `dao_cells` (`walletId`, `network`)"
+        )
     }
 }

--- a/android/app/src/main/java/com/rjnr/pocketnode/di/AppModule.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/di/AppModule.kt
@@ -15,6 +15,7 @@ import com.rjnr.pocketnode.data.database.MIGRATION_4_5
 import com.rjnr.pocketnode.data.database.MIGRATION_5_6
 import com.rjnr.pocketnode.data.database.MIGRATION_6_7
 import com.rjnr.pocketnode.data.database.MIGRATION_7_8
+import com.rjnr.pocketnode.data.database.MIGRATION_8_9
 import com.rjnr.pocketnode.data.database.dao.BalanceCacheDao
 import com.rjnr.pocketnode.data.database.dao.DaoCellDao
 import com.rjnr.pocketnode.data.database.dao.HeaderCacheDao
@@ -125,7 +126,7 @@ object AppModule {
     fun provideAppDatabase(@ApplicationContext context: Context): AppDatabase =
         Room.databaseBuilder(context, AppDatabase::class.java, "pocket_node.db")
             .setJournalMode(RoomDatabase.JournalMode.WRITE_AHEAD_LOGGING)
-            .addMigrations(MIGRATION_1_2, MIGRATION_2_3, MIGRATION_3_4, MIGRATION_4_5, MIGRATION_5_6, MIGRATION_6_7, MIGRATION_7_8)
+            .addMigrations(MIGRATION_1_2, MIGRATION_2_3, MIGRATION_3_4, MIGRATION_4_5, MIGRATION_5_6, MIGRATION_6_7, MIGRATION_7_8, MIGRATION_8_9)
             .build()
 
     @Provides

--- a/android/app/src/test/java/com/rjnr/pocketnode/data/database/MigrationTest.kt
+++ b/android/app/src/test/java/com/rjnr/pocketnode/data/database/MigrationTest.kt
@@ -31,7 +31,7 @@ class MigrationTest {
     fun setup() {
         val context = ApplicationProvider.getApplicationContext<Context>()
         db = Room.inMemoryDatabaseBuilder(context, AppDatabase::class.java)
-            .addMigrations(MIGRATION_1_2, MIGRATION_2_3, MIGRATION_3_4, MIGRATION_4_5, MIGRATION_5_6, MIGRATION_6_7, MIGRATION_7_8)
+            .addMigrations(MIGRATION_1_2, MIGRATION_2_3, MIGRATION_3_4, MIGRATION_4_5, MIGRATION_5_6, MIGRATION_6_7, MIGRATION_7_8, MIGRATION_8_9)
             .allowMainThreadQueries()
             .build()
     }


### PR DESCRIPTION
## Summary

Smoke install of the v1.5.2 build (PR #141) on a real device crashed with a different Room error than the original v1.5.1 crash:

\`\`\`
Room cannot verify the data integrity. Looks like you've changed schema
but forgot to update the version number.
Expected identity hash: 5c3585c27257d8b0a1a3119c4e50e1ac
Found: 821e95d07068b708ea3b07e0d3311b0a
\`\`\`

## Root cause

Room computes its stored *identity hash* from the @Entity/@ColumnInfo/@Index declarations, not from the on-disk schema. The previous hotfix (#141) added \`@Index(idx_tx_pending)\` + \`@ColumnInfo(defaultValue = \"''\")\` to align the entity declarations with what migrations 1→8 already produced on disk. The on-disk schema didn't change at all, but the entity declarations did, so the identity hash changed.

Room enforces: any DB whose stored identity hash differs from the current entity-derived hash refuses to open, even when the schemas are byte-for-byte identical and the version number is the same.

## Fix

- Bump \`@Database\` version 8 → 9.
- Add a no-op \`MIGRATION_8_9\` and register it in \`AppModule\`.
- Update \`MigrationTest\` to register the new migration so the existing test still compiles.

The migration body is intentionally empty: the on-disk shape is already correct from migrations 1→8. The version bump alone is the mechanism Room provides for refreshing the stored identity hash.

## Why this wasn't caught

Same root cause as #142 already tracks: \`MigrationTest\` uses \`inMemoryDatabaseBuilder\` which creates a fresh schema and never runs migrations or interacts with on-disk identity hashes. A real-device smoke install is currently the only way to catch identity-hash drift.

## Test plan

- [x] \`assembleDebug\` succeeds.
- [x] \`testDebugUnitTest\` passes.
- [ ] **Re-smoke install** the v1.5.2 build on the same device that crashed. Confirm app launches and reaches Home.
- [ ] **Smoke install** v1.5.2 over a clean v1.5.0 install on a different device. Confirm migrations 5→9 run cleanly.

## Follow-up

#142 still tracks the permanent fix (real migration test using \`MigrationTestHelper\` with exported schemas). This identity-hash mismatch is exactly the regression that test would catch, so it strengthens the case for prioritising it.