### PR TITLE
chore(website): point download to v1.5.2

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -1112,7 +1112,7 @@
             </p>
 
             <div class="hero-buttons">
-                <a href="https://github.com/RaheemJnr/pocket-node/releases/download/v1.5.1/PocketNode-v1.5.1.apk" class="btn btn--primary">
+                <a href="https://github.com/RaheemJnr/pocket-node/releases/download/v1.5.2/PocketNode-v1.5.2.apk" class="btn btn--primary">
                     <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 15v4a2 2 0 01-2 2H5a2 2 0 01-2-2v-4"/><polyline points="7,10 12,15 17,10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
                     Download APK
                 </a>
@@ -1413,7 +1413,7 @@
         <p class="section-desc animate-on-scroll">Join the growing community of Nervos users who verify everything locally. No trust required.</p>
 
         <div class="cta-buttons animate-on-scroll">
-            <a href="https://github.com/RaheemJnr/pocket-node/releases/download/v1.5.1/PocketNode-v1.5.1.apk" class="btn btn--primary">
+            <a href="https://github.com/RaheemJnr/pocket-node/releases/download/v1.5.2/PocketNode-v1.5.2.apk" class="btn btn--primary">
                 <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 15v4a2 2 0 01-2 2H5a2 2 0 01-2-2v-4"/><polyline points="7,10 12,15 17,10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
                 Download for Android
             </a>
@@ -1445,7 +1445,7 @@
                     <li><a href="#features">Features</a></li>
                     <li><a href="#security">Security</a></li>
                     <li><a href="#tech">Technical</a></li>
-                    <li><a href="https://github.com/RaheemJnr/pocket-node/releases/download/v1.5.1/PocketNode-v1.5.1.apk">Get App</a></li>
+                    <li><a href="https://github.com/RaheemJnr/pocket-node/releases/download/v1.5.2/PocketNode-v1.5.2.apk">Get App</a></li>
                 </ul>
             </div>
             <div class="footer-col">


### PR DESCRIPTION
Bumps the three v1.5.1 APK links in `website/index.html` to v1.5.2 so the website download lands on the v1.5.2 hotfix release.

Pairs with the v1.5.2 GitHub release: https://github.com/RaheemJnr/pocket-node/releases/tag/v1.5.2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Android application download links to version 1.5.2 across website sections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->