### PR TITLE
fix: coachmark position + recurring sync-mode default override

### DIFF
--- a/android/app/src/main/java/com/rjnr/pocketnode/data/wallet/WalletPreferences.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/wallet/WalletPreferences.kt
@@ -119,17 +119,34 @@ class WalletPreferences @Inject constructor(
 
     // --- Sync mode ---
 
-    fun getSyncMode(network: NetworkType? = null, walletId: String? = null): SyncMode {
+    /**
+     * Returns the explicitly-stored sync mode, or null if no value has ever
+     * been written for this wallet/network. Lets callers distinguish
+     * "user picked RECENT" from "nothing written yet" without re-reading
+     * raw prefs.
+     *
+     * Most call sites should prefer this over [getSyncMode] when handling
+     * the first-registration path, so a freshly-created wallet whose
+     * per-wallet key was set by `markFreshWalletSyncMode` is not silently
+     * overwritten by a network-default heuristic.
+     */
+    fun getSyncModeOrNull(network: NetworkType? = null, walletId: String? = null): SyncMode? {
         val net = network ?: getSelectedNetwork()
         val key = if (walletId != null) walletNetworkKey(walletId, net.name, KEY_SYNC_MODE)
                   else networkKey(KEY_SYNC_MODE, net)
-        val modeName = prefs.getString(key, SyncMode.RECENT.name)
-        return try {
-            SyncMode.valueOf(modeName ?: SyncMode.RECENT.name)
-        } catch (e: IllegalArgumentException) {
-            Log.w(TAG, "Unknown sync mode '$modeName', defaulting to RECENT", e)
-            SyncMode.RECENT
-        }
+        val modeName = prefs.getString(key, null) ?: return null
+        return runCatching { SyncMode.valueOf(modeName) }
+            .onFailure { Log.w(TAG, "Unknown sync mode '$modeName' in prefs", it) }
+            .getOrNull()
+    }
+
+    fun getSyncMode(network: NetworkType? = null, walletId: String? = null): SyncMode {
+        // Default to NEW_WALLET when nothing is explicitly stored. For a fresh
+        // wallet there is no past activity to find, and choosing RECENT here
+        // would silently kick off a 30-day re-scan that the user didn't ask for.
+        // Callers that need a network-aware first-time default should call
+        // [getSyncModeOrNull] and apply their own fallback.
+        return getSyncModeOrNull(network, walletId) ?: SyncMode.NEW_WALLET
     }
 
     fun setSyncMode(mode: SyncMode, network: NetworkType? = null, walletId: String? = null) {

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/education/coachmark/SyncCoachmark.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/education/coachmark/SyncCoachmark.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
@@ -58,7 +59,7 @@ fun SyncCoachmark(
     val cornerRadiusPx = with(density) { 16.dp.toPx() }
     val spotlightInsetPx = with(density) { 4.dp.toPx() }
 
-    Box(
+    BoxWithConstraints(
         modifier = Modifier
             .fillMaxSize()
             // Swallow taps so taps outside the tooltip don't hit underlying UI.
@@ -90,8 +91,26 @@ fun SyncCoachmark(
             drawPath(path = scrim, color = scrimColor)
         }
 
-        // Tooltip below the spotlight.
-        val tooltipTopDp = with(density) { rect.bottom.toDp() } + 16.dp
+        // Decide tooltip placement: prefer below the spotlight, but flip above
+        // when there isn't enough room. The bottom-nav bar eats roughly 80dp
+        // of the viewport on Home, and the tooltip itself needs ~140dp for
+        // the body + dismiss button + padding. If the spotlight sits low on
+        // the screen, "below" gets clipped (reported in v1.5.2 smoke).
+        val viewportHeightPx = with(density) { maxHeight.toPx() }
+        val tooltipMinHeightPx = with(density) { 180.dp.toPx() }
+        val showAbove = (viewportHeightPx - rect.bottom) < tooltipMinHeightPx
+
+        val tooltipPadding = if (showAbove) {
+            // Place the card so its BOTTOM edge sits 16dp above rect.top.
+            // Implement as a top padding equal to (rect.top - card_height - 16dp);
+            // Card with wrap_content will hug the spotlight from above.
+            val targetTopPx = (rect.top - tooltipMinHeightPx - with(density) { 16.dp.toPx() })
+                .coerceAtLeast(with(density) { 16.dp.toPx() })
+            with(density) { targetTopPx.toDp() }
+        } else {
+            with(density) { rect.bottom.toDp() } + 16.dp
+        }
+
         Card(
             shape = RoundedCornerShape(16.dp),
             colors = CardDefaults.cardColors(
@@ -100,7 +119,7 @@ fun SyncCoachmark(
             elevation = CardDefaults.cardElevation(defaultElevation = 6.dp),
             modifier = Modifier
                 .align(Alignment.TopStart)
-                .padding(start = 16.dp, end = 16.dp, top = tooltipTopDp)
+                .padding(start = 16.dp, end = 16.dp, top = tooltipPadding)
                 .fillMaxWidth(),
         ) {
             Column(

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/home/HomeViewModel.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/home/HomeViewModel.kt
@@ -323,12 +323,26 @@ class HomeViewModel @Inject constructor(
 
         _uiState.update { it.copy(currentSyncMode = savedSyncMode, savedCustomBlockHeight = savedCustomBlockHeight) }
 
-        // Use saved settings, or network-appropriate default for first-time users.
-        // Testnet defaults to NEW_WALLET (start from tip — testnet is small, no need for history).
-        // Mainnet defaults to RECENT (~30 days of history).
-        val firstTimeSyncMode = if (repository.currentNetwork == NetworkType.TESTNET)
+        // First-registration sync-mode resolution:
+        // 1. If the user has completed an initial sync before, respect their
+        //    last choice (savedSyncMode).
+        // 2. Otherwise, if a per-wallet sync mode has been EXPLICITLY written
+        //    (e.g. by WalletRepository.markFreshWalletSyncMode on createWallet,
+        //    or by the post-import sheet on importWallet), use that. This is
+        //    the path that was being silently overwritten in earlier releases:
+        //    a fresh wallet would get NEW_WALLET written, then a network-default
+        //    heuristic would replace it with RECENT in registerAccount.
+        // 3. Only when neither (1) nor (2) applies (legacy single-wallet
+        //    upgraders, etc.) do we fall back to the network-default heuristic.
+        val activeWid = walletPreferences.getActiveWalletId()?.takeIf { it.isNotBlank() }
+        val explicitSyncMode = walletPreferences.getSyncModeOrNull(walletId = activeWid)
+        val networkDefault = if (repository.currentNetwork == NetworkType.TESTNET)
             SyncMode.NEW_WALLET else SyncMode.RECENT
-        val syncMode = if (hasCompletedInitialSync) savedSyncMode else firstTimeSyncMode
+        val syncMode = when {
+            hasCompletedInitialSync -> savedSyncMode
+            explicitSyncMode != null -> explicitSyncMode
+            else -> networkDefault
+        }
         val customBlockHeight = if (syncMode == SyncMode.CUSTOM) savedCustomBlockHeight else null
 
         Log.d(TAG, "Registering account with sync mode: $syncMode")

--- a/android/app/src/test/java/com/rjnr/pocketnode/data/wallet/WalletPreferencesTest.kt
+++ b/android/app/src/test/java/com/rjnr/pocketnode/data/wallet/WalletPreferencesTest.kt
@@ -63,8 +63,24 @@ class WalletPreferencesTest {
     }
 
     @Test
-    fun `getSyncMode defaults to RECENT for a network with no stored value`() {
-        assertEquals(SyncMode.RECENT, newPrefs().getSyncMode(NetworkType.TESTNET))
+    fun `getSyncMode defaults to NEW_WALLET for a network with no stored value`() {
+        // Default flipped from RECENT to NEW_WALLET in v1.6.0: a fresh wallet
+        // has no past activity to find, so silently scanning the last 30 days
+        // (RECENT) was kicking off pointless re-syncs. Callers that need a
+        // network-aware first-time default should use getSyncModeOrNull.
+        assertEquals(SyncMode.NEW_WALLET, newPrefs().getSyncMode(NetworkType.TESTNET))
+    }
+
+    @Test
+    fun `getSyncModeOrNull returns null when nothing stored`() {
+        assertNull(newPrefs().getSyncModeOrNull(NetworkType.TESTNET))
+    }
+
+    @Test
+    fun `getSyncModeOrNull returns the explicitly stored value`() {
+        val prefs = newPrefs()
+        prefs.setSyncMode(SyncMode.FULL_HISTORY, NetworkType.MAINNET)
+        assertEquals(SyncMode.FULL_HISTORY, prefs.getSyncModeOrNull(NetworkType.MAINNET))
     }
 
     // --- Per-network isolation: custom block height ---

--- a/website/index.html
+++ b/website/index.html
@@ -1112,7 +1112,7 @@
             </p>
 
             <div class="hero-buttons">
-                <a href="https://github.com/RaheemJnr/pocket-node/releases/download/v1.5.1/PocketNode-v1.5.1.apk" class="btn btn--primary">
+                <a href="https://github.com/RaheemJnr/pocket-node/releases/download/v1.5.2/PocketNode-v1.5.2.apk" class="btn btn--primary">
                     <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 15v4a2 2 0 01-2 2H5a2 2 0 01-2-2v-4"/><polyline points="7,10 12,15 17,10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
                     Download APK
                 </a>
@@ -1413,7 +1413,7 @@
         <p class="section-desc animate-on-scroll">Join the growing community of Nervos users who verify everything locally. No trust required.</p>
 
         <div class="cta-buttons animate-on-scroll">
-            <a href="https://github.com/RaheemJnr/pocket-node/releases/download/v1.5.1/PocketNode-v1.5.1.apk" class="btn btn--primary">
+            <a href="https://github.com/RaheemJnr/pocket-node/releases/download/v1.5.2/PocketNode-v1.5.2.apk" class="btn btn--primary">
                 <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 15v4a2 2 0 01-2 2H5a2 2 0 01-2-2v-4"/><polyline points="7,10 12,15 17,10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
                 Download for Android
             </a>
@@ -1445,7 +1445,7 @@
                     <li><a href="#features">Features</a></li>
                     <li><a href="#security">Security</a></li>
                     <li><a href="#tech">Technical</a></li>
-                    <li><a href="https://github.com/RaheemJnr/pocket-node/releases/download/v1.5.1/PocketNode-v1.5.1.apk">Get App</a></li>
+                    <li><a href="https://github.com/RaheemJnr/pocket-node/releases/download/v1.5.2/PocketNode-v1.5.2.apk">Get App</a></li>
                 </ul>
             </div>
             <div class="footer-col">


### PR DESCRIPTION
Two fixes from v1.5.2 smoke + user reports. Queues for v1.6.0 (per the deferred-bumps plan).

## 1. Coachmark tooltip clipped at the bottom of Home

Reported by a user on Telegram: the "Got it" button on the sync coachmark gets cut off by the bottom nav bar on most phones because the sync card sits low on Home.

\`SyncCoachmark\` now uses \`BoxWithConstraints\` to measure viewport height and flips the tooltip ABOVE the spotlight when there is not enough room below. Otherwise keeps existing below-spotlight placement.

## 2. Recurring sync-mode default override

User report: "I set sync option to new wallet, so it's not needed to sync. That should be the default if a new wallet is created. I don't think I set it to something else before that."

This bug has been "fixed" multiple times. Each previous patch addressed a single write site. The actual root cause is at the registration layer:

1. \`WalletRepository.createWallet\` calls \`markFreshWalletSyncMode\` which writes \`NEW_WALLET\` to the per-wallet sync mode key.
2. \`HomeViewModel.registerAccount\` then computes \`firstTimeSyncMode\` based purely on the current network: mainnet → \`RECENT\`, testnet → \`NEW_WALLET\`. Whenever \`hasCompletedInitialSync\` is false (which it is for any fresh wallet), \`firstTimeSyncMode\` wins regardless of what \`markFreshWalletSyncMode\` just wrote.
3. \`registerAccount\` then writes that mainnet \`RECENT\` back into the per-wallet key with \`savePreference = true\`, silently overwriting the \`NEW_WALLET\` from step 1.

So fresh wallets on mainnet always end up at \`RECENT\` and start a 30-day re-scan the user did not ask for.

### Fix in two layers

**Layer 1 — WalletPreferences**

- New \`getSyncModeOrNull(network, walletId)\` that returns null when no value has been written for the wallet/network. Lets callers distinguish "user explicitly chose RECENT" from "nothing written yet".
- \`getSyncMode\` default flipped from \`RECENT\` to \`NEW_WALLET\`. RECENT was the wrong choice for a fresh wallet with no past activity to find. Callers that need a network-aware first-time default should use \`getSyncModeOrNull\` and apply their own fallback.
- Tests updated.

**Layer 2 — HomeViewModel**

Three-step resolution on first-registration:

1. If \`hasCompletedInitialSync\` is true, respect \`savedSyncMode\`.
2. Otherwise, if \`getSyncModeOrNull\` returns a value (i.e. \`markFreshWalletSyncMode\` or the post-import sheet wrote one), use it. **This is the path that was being silently overwritten.**
3. Only when neither (1) nor (2) applies (legacy upgraders whose per-wallet key was never written) do we fall back to the network-default heuristic.

## Test plan

- [x] \`assembleDebug\` succeeds.
- [x] \`testDebugUnitTest\` passes including new \`getSyncModeOrNull\` tests.
- [ ] Manual: create a fresh wallet on mainnet, verify it does NOT kick off a RECENT-mode sync. Should land at NEW_WALLET (sync completes near-instantly).
- [ ] Manual: import a wallet on mainnet, verify the post-import sheet still shows and the chosen sync mode is honored after registration.
- [ ] Manual: legacy single-wallet user upgrading from pre-M3 build should still get a sensible default (network heuristic kicks in).
- [ ] Manual: trigger the coachmark on a small phone (Pixel 4a-class), verify the tooltip renders above the spotlight without clipping.