### PR TITLE
feat: upgrade-smoke harness (#144 Phase 2)

### DIFF
--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -70,8 +70,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-        with:
-          submodules: recursive
 
       - name: Set up JDK 17
         uses: actions/setup-java@v4
@@ -83,6 +81,7 @@ jobs:
         uses: android-actions/setup-android@v3
 
       - name: Setup Android NDK
+        # NDK r27.0.12077973 — matches AGP 8.13.2 default. Bump in lockstep with AGP.
         run: |
           sdkmanager --install "ndk;27.0.12077973" >/dev/null
           echo "ANDROID_NDK_HOME=$ANDROID_HOME/ndk/27.0.12077973" >> $GITHUB_ENV
@@ -106,6 +105,7 @@ jobs:
         with:
           path: |
             ~/.cargo/registry
+            ~/.cargo/git
             external/ckb-light-client/target
           key: cargo-${{ hashFiles('external/ckb-light-client/Cargo.lock') }}
           restore-keys: cargo-

--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -61,3 +61,74 @@ jobs:
           name: test-results
           path: android/app/build/reports/tests/
           retention-days: 7
+
+  prev-jni-build:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    needs: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: Setup Android SDK
+        uses: android-actions/setup-android@v3
+
+      - name: Setup Android NDK
+        run: |
+          sdkmanager --install "ndk;27.0.12077973" >/dev/null
+          echo "ANDROID_NDK_HOME=$ANDROID_HOME/ndk/27.0.12077973" >> $GITHUB_ENV
+
+      - name: Set up Rust (stable + Android targets)
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: aarch64-linux-android,armv7-linux-androideabi,x86_64-linux-android
+
+      - name: Cache Gradle
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: gradle-jni-${{ hashFiles('android/**/*.gradle.kts', 'android/gradle/libs.versions.toml') }}
+          restore-keys: gradle-jni-
+
+      - name: Cache Cargo target
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            external/ckb-light-client/target
+          key: cargo-${{ hashFiles('external/ckb-light-client/Cargo.lock') }}
+          restore-keys: cargo-
+
+      - name: Create dummy google-services.json
+        run: |
+          cat > android/app/google-services.json << 'GSEOF'
+          {
+            "project_info": { "project_number": "0", "project_id": "dummy", "storage_bucket": "dummy.appspot.com" },
+            "client": [{ "client_info": { "mobilesdk_app_id": "1:0:android:0", "android_client_info": { "package_name": "com.rjnr.pocketnode" } }, "api_key": [{ "current_key": "dummy" }] }],
+            "configuration_version": "1"
+          }
+          GSEOF
+
+      - name: Build debug APK with JNI + x86_64
+        working-directory: android
+        env:
+          BUILD_X86_64: "1"
+        run: ./gradlew assembleDebug
+
+      - name: Upload prev-jni APK
+        uses: actions/upload-artifact@v4
+        with:
+          name: pocketnode-prev-jni-debug
+          path: android/app/build/outputs/apk/debug/app-debug.apk
+          retention-days: 14

--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -50,10 +50,6 @@ jobs:
           }
           GSEOF
 
-      - name: Build debug APK
-        working-directory: android
-        run: ./gradlew assembleDebug -x cargoBuild
-
       - name: Run unit tests
         working-directory: android
         run: ./gradlew test -x cargoBuild

--- a/.github/workflows/upgrade-smoke.yml
+++ b/.github/workflows/upgrade-smoke.yml
@@ -1,0 +1,181 @@
+name: Upgrade Smoke
+
+on:
+  pull_request:
+    branches: [main]
+  workflow_dispatch:        # remove before final merge of harness PR
+
+concurrency:
+  group: upgrade-smoke-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  smoke:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: Setup Android SDK
+        uses: android-actions/setup-android@v3
+
+      - name: Setup Android NDK
+        # NDK r27.0.12077973 — matches AGP 8.13.2 default. Bump in lockstep with AGP.
+        run: |
+          sdkmanager --install "ndk;27.0.12077973" >/dev/null
+          echo "ANDROID_NDK_HOME=$ANDROID_HOME/ndk/27.0.12077973" >> $GITHUB_ENV
+
+      - name: Set up Rust (stable + Android targets)
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: aarch64-linux-android,armv7-linux-androideabi,x86_64-linux-android
+
+      - name: Cache Gradle
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: gradle-jni-${{ hashFiles('android/**/*.gradle.kts', 'android/gradle/libs.versions.toml') }}
+          restore-keys: gradle-jni-
+
+      - name: Cache Cargo target
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            external/ckb-light-client/target
+          key: cargo-${{ hashFiles('external/ckb-light-client/Cargo.lock') }}
+          restore-keys: cargo-
+
+      - name: Download prev main APK
+        id: prev_apk
+        uses: dawidd6/action-download-artifact@v6
+        with:
+          workflow: android-ci.yml
+          branch: main
+          name: pocketnode-prev-jni-debug
+          path: prev/
+          if_no_artifact_found: warn
+
+      - name: Skip job if no prev artifact
+        if: steps.prev_apk.outputs.found_artifact != 'true'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: '⚠️ upgrade-smoke skipped: no `pocketnode-prev-jni-debug` artifact on main yet. Run android-ci.yml on main first, then re-run this job.'
+            });
+            core.notice('Skipping upgrade-smoke: no prev artifact');
+            process.exit(0);
+
+      - name: Create dummy google-services.json
+        run: |
+          cat > android/app/google-services.json << 'GSEOF'
+          {
+            "project_info": { "project_number": "0", "project_id": "dummy", "storage_bucket": "dummy.appspot.com" },
+            "client": [{ "client_info": { "mobilesdk_app_id": "1:0:android:0", "android_client_info": { "package_name": "com.rjnr.pocketnode" } }, "api_key": [{ "current_key": "dummy" }] }],
+            "configuration_version": "1"
+          }
+          GSEOF
+
+      - name: Build PR APK + androidTest APK
+        working-directory: android
+        env:
+          BUILD_X86_64: "1"
+        run: ./gradlew assembleDebug assembleDebugAndroidTest
+
+      - name: Enable KVM
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+
+      - name: Run upgrade-smoke on emulator
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: 34
+          arch: x86_64
+          target: default
+          force-avd-creation: false
+          emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
+          disable-animations: true
+          script: |
+            set -euo pipefail
+            adb wait-for-device
+            adb shell input keyevent 82 || true
+
+            echo "::group::Install prev APK"
+            adb install -r prev/app-debug.apk
+            echo "::endgroup::"
+
+            echo "::group::Install androidTest APK"
+            adb install -r -t android/app/build/outputs/apk/androidTest/debug/app-debug-androidTest.apk
+            echo "::endgroup::"
+
+            echo "::group::Seed wallet on prev APK"
+            adb shell am instrument -w \
+              -e class com.rjnr.pocketnode.UpgradeSmokeTest#seedFreshWallet \
+              com.rjnr.pocketnode.test/androidx.test.runner.AndroidJUnitRunner | tee seed.log
+            grep -q 'OK (1 test)' seed.log || { echo "Prev APK seed failed; main is broken, not this PR"; exit 1; }
+            echo "::endgroup::"
+
+            echo "::group::Install PR APK over prev (data preserved)"
+            adb install -r android/app/build/outputs/apk/debug/app-debug.apk
+            echo "::endgroup::"
+
+            adb logcat -c
+
+            echo "::group::Assert Home renders post-upgrade"
+            adb shell am instrument -w \
+              -e class com.rjnr.pocketnode.UpgradeSmokeTest#assertHomeAfterUpgrade \
+              com.rjnr.pocketnode.test/androidx.test.runner.AndroidJUnitRunner | tee post.log
+            grep -q 'OK (1 test)' post.log || { echo "Post-upgrade Home assertion failed"; exit 1; }
+            echo "::endgroup::"
+
+            echo "::group::Logcat scan"
+            adb logcat -d > logcat-post.txt
+            if grep -qE 'FATAL EXCEPTION|AndroidRuntime.*FATAL' logcat-post.txt; then
+              echo "FATAL detected in logcat:"
+              grep -E 'FATAL EXCEPTION|AndroidRuntime.*FATAL' logcat-post.txt
+              exit 1
+            fi
+            echo "::endgroup::"
+
+            echo "::group::Process liveness"
+            pid=$(adb shell pidof com.rjnr.pocketnode | tr -d '\r' || true)
+            if [ -z "$pid" ]; then
+              echo "com.rjnr.pocketnode not running after smoke"
+              exit 1
+            fi
+            echo "pid=$pid"
+            echo "::endgroup::"
+
+            echo "::group::Final screenshot"
+            adb shell screencap -p /sdcard/post.png
+            adb pull /sdcard/post.png post.png
+            echo "::endgroup::"
+
+      - name: Upload smoke artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: upgrade-smoke-artifacts
+          path: |
+            seed.log
+            post.log
+            logcat-post.txt
+            post.png
+          if-no-files-found: warn
+          retention-days: 7

--- a/.github/workflows/upgrade-smoke.yml
+++ b/.github/workflows/upgrade-smoke.yml
@@ -9,6 +9,11 @@ concurrency:
   group: upgrade-smoke-${{ github.ref }}
   cancel-in-progress: true
 
+# Skip-path posts a comment on the PR when no prev artifact exists.
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   smoke:
     runs-on: ubuntu-latest
@@ -74,13 +79,19 @@ jobs:
             core.notice('Skipping upgrade-smoke: no prev artifact');
             // Only post a PR comment when triggered by a pull_request.
             // workflow_dispatch runs have no issue context — would 404.
+            // Soft-fail the API call so a missing pull-requests:write
+            // permission doesn't turn the skip-path into a job failure.
             if (context.eventName === 'pull_request' && context.issue && context.issue.number) {
-              await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: context.issue.number,
-                body: '⚠️ upgrade-smoke skipped: no `pocketnode-prev-jni-debug` artifact on main yet. Run android-ci.yml on main first, then re-run this job.'
-              });
+              try {
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: context.issue.number,
+                  body: '⚠️ upgrade-smoke skipped: no `pocketnode-prev-jni-debug` artifact on main yet. Run android-ci.yml on main first, then re-run this job.'
+                });
+              } catch (e) {
+                core.warning(`Could not post skip comment: ${e.message}`);
+              }
             }
 
       - name: Create dummy google-services.json

--- a/.github/workflows/upgrade-smoke.yml
+++ b/.github/workflows/upgrade-smoke.yml
@@ -3,7 +3,6 @@ name: Upgrade Smoke
 on:
   pull_request:
     branches: [main]
-  workflow_dispatch:        # remove before final merge of harness PR
 
 concurrency:
   group: upgrade-smoke-${{ github.ref }}

--- a/.github/workflows/upgrade-smoke.yml
+++ b/.github/workflows/upgrade-smoke.yml
@@ -71,13 +71,17 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            await github.rest.issues.createComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number,
-              body: '⚠️ upgrade-smoke skipped: no `pocketnode-prev-jni-debug` artifact on main yet. Run android-ci.yml on main first, then re-run this job.'
-            });
             core.notice('Skipping upgrade-smoke: no prev artifact');
+            // Only post a PR comment when triggered by a pull_request.
+            // workflow_dispatch runs have no issue context — would 404.
+            if (context.eventName === 'pull_request' && context.issue && context.issue.number) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body: '⚠️ upgrade-smoke skipped: no `pocketnode-prev-jni-debug` artifact on main yet. Run android-ci.yml on main first, then re-run this job.'
+              });
+            }
 
       - name: Create dummy google-services.json
         if: steps.prev_apk.outputs.found_artifact == 'true'

--- a/.github/workflows/upgrade-smoke.yml
+++ b/.github/workflows/upgrade-smoke.yml
@@ -78,9 +78,9 @@ jobs:
               body: '⚠️ upgrade-smoke skipped: no `pocketnode-prev-jni-debug` artifact on main yet. Run android-ci.yml on main first, then re-run this job.'
             });
             core.notice('Skipping upgrade-smoke: no prev artifact');
-            process.exit(0);
 
       - name: Create dummy google-services.json
+        if: steps.prev_apk.outputs.found_artifact == 'true'
         run: |
           cat > android/app/google-services.json << 'GSEOF'
           {
@@ -91,18 +91,21 @@ jobs:
           GSEOF
 
       - name: Build PR APK + androidTest APK
+        if: steps.prev_apk.outputs.found_artifact == 'true'
         working-directory: android
         env:
           BUILD_X86_64: "1"
         run: ./gradlew assembleDebug assembleDebugAndroidTest
 
       - name: Enable KVM
+        if: steps.prev_apk.outputs.found_artifact == 'true'
         run: |
           echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
           sudo udevadm control --reload-rules
           sudo udevadm trigger --name-match=kvm
 
       - name: Run upgrade-smoke on emulator
+        if: steps.prev_apk.outputs.found_artifact == 'true'
         uses: reactivecircus/android-emulator-runner@v2
         with:
           api-level: 34
@@ -132,10 +135,10 @@ jobs:
             echo "::endgroup::"
 
             echo "::group::Install PR APK over prev (data preserved)"
+            adb shell am force-stop com.rjnr.pocketnode
+            adb logcat -c   # Cover Room migration during the first post-upgrade launch.
             adb install -r android/app/build/outputs/apk/debug/app-debug.apk
             echo "::endgroup::"
-
-            adb logcat -c
 
             echo "::group::Assert Home renders post-upgrade"
             adb shell am instrument -w \
@@ -154,7 +157,7 @@ jobs:
             echo "::endgroup::"
 
             echo "::group::Process liveness"
-            pid=$(adb shell pidof com.rjnr.pocketnode | tr -d '\r' || true)
+            pid=$(adb shell pidof com.rjnr.pocketnode 2>/dev/null | tr -d '\r' || true)
             if [ -z "$pid" ]; then
               echo "com.rjnr.pocketnode not running after smoke"
               exit 1

--- a/.gitignore
+++ b/.gitignore
@@ -187,6 +187,11 @@ docs/
 .plans/
 
 # ===================
+# Git worktrees (local only)
+# ===================
+.worktrees/
+
+# ===================
 # Release / Play Store (local only)
 # ===================
 android/app/release/

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -20,9 +20,14 @@ android {
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 
-        // Only include ARM ABIs — x86_64 is emulator-only and adds ~29 MB
+        // Only include ARM ABIs — x86_64 is emulator-only and adds ~29 MB.
+        // CI's upgrade-smoke harness opts in via BUILD_X86_64=1 (matched in
+        // external/ckb-light-client/build-android-jni.sh).
         ndk {
             abiFilters += listOf("arm64-v8a", "armeabi-v7a")
+            if (System.getenv("BUILD_X86_64") == "1") {
+                abiFilters += "x86_64"
+            }
         }
 
         // ksp { arg("room.schemaLocation", "$projectDir/schemas") } is

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -212,6 +212,12 @@ dependencies {
     testImplementation("androidx.test:core:1.6.1")
     testImplementation(libs.mockk)
     testImplementation(libs.kotlinx.coroutines.test)
+
+    // Instrumented tests
+    androidTestImplementation("androidx.test.ext:junit:1.2.1")
+    androidTestImplementation("androidx.test:runner:1.6.2")
+    androidTestImplementation("androidx.test:rules:1.6.1")
+    androidTestImplementation("androidx.test.uiautomator:uiautomator:2.3.0")
 }
 
 tasks.register<Exec>("cargoBuild") {

--- a/android/app/src/androidTest/java/com/rjnr/pocketnode/UpgradeSmokeTest.kt
+++ b/android/app/src/androidTest/java/com/rjnr/pocketnode/UpgradeSmokeTest.kt
@@ -61,13 +61,21 @@ class UpgradeSmokeTest {
 
         // Two passes (SETUP + CONFIRM). Each pass enters six 1s; the screen
         // auto-submits on the 6th digit and advances to the next phase.
-        repeat(2) {
-            repeat(6) {
+        // Per-iteration wait covers the SETUP→CONFIRM recompose between passes.
+        repeat(2) { pass ->
+            if (pass == 1) {
+                // Defensive: let SETUP→CONFIRM recomposition settle.
+                device.waitForIdle(2_000L)
+            }
+            repeat(6) { i ->
                 val digit = device.wait(
                     Until.findObject(By.res(PKG, "pin-keypad-1")),
-                    5_000L
+                    8_000L
                 )
-                assertNotNull("PIN digit '1' not visible (resource-id pin-keypad-1)", digit)
+                assertNotNull(
+                    "PIN digit '1' not visible at pass=$pass digit=$i (resource-id pin-keypad-1)",
+                    digit
+                )
                 digit.click()
             }
         }
@@ -101,11 +109,12 @@ class UpgradeSmokeTest {
     private fun launchApp() {
         device.pressHome()
         val launcherPkg = device.launcherPackageName
-        assertNotNull(launcherPkg)
+        assertNotNull("UiDevice.launcherPackageName is null — emulator image broken?", launcherPkg)
         device.wait(Until.hasObject(By.pkg(launcherPkg).depth(0)), LAUNCH_TIMEOUT_MS)
 
+        device.executeShellCommand("am force-stop $PKG")
         val intent = ctx.packageManager.getLaunchIntentForPackage(PKG)!!.apply {
-            addFlags(android.content.Intent.FLAG_ACTIVITY_CLEAR_TASK)
+            addFlags(android.content.Intent.FLAG_ACTIVITY_NEW_TASK or android.content.Intent.FLAG_ACTIVITY_CLEAR_TASK)
         }
         ctx.startActivity(intent)
         assertTrue(

--- a/android/app/src/androidTest/java/com/rjnr/pocketnode/UpgradeSmokeTest.kt
+++ b/android/app/src/androidTest/java/com/rjnr/pocketnode/UpgradeSmokeTest.kt
@@ -1,5 +1,7 @@
 package com.rjnr.pocketnode
 
+import android.content.ClipData
+import android.content.ClipboardManager
 import android.content.Context
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
@@ -18,6 +20,11 @@ private const val LAUNCH_TIMEOUT_MS = 10_000L
 private const val ONBOARDING_TIMEOUT_MS = 15_000L
 private const val POST_UPGRADE_HOME_TIMEOUT_MS = 30_000L
 
+// Standard BIP39 dev mnemonic. 11×"abandon" + "about" is a valid checksum.
+// Hardcoded so the seed is deterministic across runs.
+private const val TEST_MNEMONIC =
+    "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about"
+
 @RunWith(AndroidJUnit4::class)
 class UpgradeSmokeTest {
 
@@ -32,56 +39,68 @@ class UpgradeSmokeTest {
 
     /**
      * Run against the previous-main APK before the upgrade install.
-     * Walks onboarding (Create New Wallet → PIN intro → setup PIN → confirm PIN)
-     * and asserts the home-balance-row resource-id is visible. That means real
-     * key material was written and Room/EncryptedSharedPrefs hold prior-version
-     * state for the upgrade migration to chew on.
+     * Walks Recover-from-Seed-Phrase with a hardcoded BIP39 dev mnemonic so the
+     * seed is deterministic and the test can skip the random-mnemonic verify
+     * step of the create-new flow. After import + PIN setup the home-balance-row
+     * resource-id must be visible — that means real key material was written
+     * and Room/EncryptedSharedPrefs hold prior-version state for the upgrade
+     * migration to chew on.
      */
     @Test
     fun seedFreshWallet() {
+        // Seed clipboard before launching so the Paste button on the import
+        // screen sees TEST_MNEMONIC.
+        val cm = ctx.getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
+        cm.setPrimaryClip(ClipData.newPlainText("upgrade-smoke", TEST_MNEMONIC))
+
         launchApp()
 
-        val createTile = device.wait(
-            Until.findObject(By.res(PKG, "onboarding-create-new")),
-            ONBOARDING_TIMEOUT_MS
+        assertTrue(
+            "Onboarding recover tile not found — prev APK is broken, not this PR",
+            clickByRes("onboarding-recover", ONBOARDING_TIMEOUT_MS)
         )
-        assertNotNull(
-            "Onboarding create-new tile not found — prev APK is broken, not this PR",
-            createTile
-        )
-        createTile.click()
 
-        // After wallet creation completes the app shows the PIN intro.
-        val pinIntro = device.wait(
-            Until.findObject(By.res(PKG, "pin-intro-continue")),
-            ONBOARDING_TIMEOUT_MS
+        assertTrue(
+            "Import paste button not found",
+            clickByRes("import-paste", ONBOARDING_TIMEOUT_MS)
         )
-        assertNotNull("PIN intro continue button not found", pinIntro)
-        pinIntro.click()
+
+        // Let the 12 fields populate from the clipboard paste.
+        device.waitForIdle(1_500L)
+
+        assertTrue(
+            "Import submit button not found",
+            clickByRes("import-submit", ONBOARDING_TIMEOUT_MS)
+        )
+
+        // Import → on mainnet the SyncOptionsSheet pops up with default mode
+        // RECENT pre-selected. Apply it to dismiss + trigger nav. On testnet
+        // it doesn't appear; clickByRes returns false and we fall through.
+        clickByRes("sync-sheet-apply", ONBOARDING_TIMEOUT_MS)
+
+        // After import + sync-selection the app shows the PIN intro.
+        assertTrue(
+            "PIN intro continue button not found",
+            clickByRes("pin-intro-continue", ONBOARDING_TIMEOUT_MS)
+        )
 
         // Two passes (SETUP + CONFIRM). Each pass enters six 1s; the screen
         // auto-submits on the 6th digit and advances to the next phase.
-        // Per-iteration wait covers the SETUP→CONFIRM recompose between passes.
         repeat(2) { pass ->
             if (pass == 1) {
                 // Defensive: let SETUP→CONFIRM recomposition settle.
                 device.waitForIdle(2_000L)
             }
             repeat(6) { i ->
-                val digit = device.wait(
-                    Until.findObject(By.res(PKG, "pin-keypad-1")),
-                    8_000L
+                assertTrue(
+                    "PIN digit '1' not clickable at pass=$pass digit=$i",
+                    clickByRes("pin-keypad-1")
                 )
-                assertNotNull(
-                    "PIN digit '1' not visible at pass=$pass digit=$i (resource-id pin-keypad-1)",
-                    digit
-                )
-                digit.click()
             }
         }
 
         val balanceRow = device.wait(
-            Until.findObject(By.res(PKG, "home-balance-row")),
+            Until.findObject(By.res("home-balance-row")),
             ONBOARDING_TIMEOUT_MS
         )
         assertNotNull("Home balance row not found after onboarding", balanceRow)
@@ -96,8 +115,23 @@ class UpgradeSmokeTest {
     fun assertHomeAfterUpgrade() {
         launchApp()
 
+        // Post-upgrade the wallet is PIN-locked behind AuthScreen, which shows
+        // a biometric prompt + "Use PIN" fallback. On a non-enrolled emulator
+        // only "Use PIN" appears; tap it to reach the keypad.
+        clickByRes("auth-use-pin", 10_000L)
+
+        // PIN entry (1×6, auto-submits on the 6th digit).
+        if (device.wait(Until.hasObject(By.res("pin-keypad-1")), 10_000L)) {
+            repeat(6) {
+                assertTrue(
+                    "PIN digit '1' not clickable on post-upgrade unlock",
+                    clickByRes("pin-keypad-1")
+                )
+            }
+        }
+
         val balanceRow = device.wait(
-            Until.findObject(By.res(PKG, "home-balance-row")),
+            Until.findObject(By.res("home-balance-row")),
             POST_UPGRADE_HOME_TIMEOUT_MS
         )
         assertNotNull(
@@ -106,13 +140,35 @@ class UpgradeSmokeTest {
         )
     }
 
+    /**
+     * Click a node by resource-id, retrying on StaleObjectException. Compose
+     * recompositions during animations / state changes invalidate UiObject2
+     * references between `findObject` and `.click()`; retrying with a fresh
+     * lookup handles this without forcing slow `waitForIdle` everywhere.
+     */
+    private fun clickByRes(res: String, timeoutMs: Long = 8_000L, attempts: Int = 6): Boolean {
+        if (!device.wait(Until.hasObject(By.res(res)), timeoutMs)) return false
+        repeat(attempts) {
+            try {
+                val node = device.findObject(By.res(res)) ?: return@repeat
+                node.click()
+                return true
+            } catch (_: androidx.test.uiautomator.StaleObjectException) {
+                device.waitForIdle(300L)
+            }
+        }
+        return false
+    }
+
     private fun launchApp() {
         device.pressHome()
         val launcherPkg = device.launcherPackageName
         assertNotNull("UiDevice.launcherPackageName is null — emulator image broken?", launcherPkg)
         device.wait(Until.hasObject(By.pkg(launcherPkg).depth(0)), LAUNCH_TIMEOUT_MS)
 
-        device.executeShellCommand("am force-stop $PKG")
+        // NB: don't `am force-stop $PKG` here — instrumentation runs inside the
+        // target app's process, so force-stopping it kills the test itself.
+        // The workflow handles cold-start between instrument calls externally.
         val intent = ctx.packageManager.getLaunchIntentForPackage(PKG)!!.apply {
             addFlags(android.content.Intent.FLAG_ACTIVITY_NEW_TASK or android.content.Intent.FLAG_ACTIVITY_CLEAR_TASK)
         }

--- a/android/app/src/androidTest/java/com/rjnr/pocketnode/UpgradeSmokeTest.kt
+++ b/android/app/src/androidTest/java/com/rjnr/pocketnode/UpgradeSmokeTest.kt
@@ -1,0 +1,116 @@
+package com.rjnr.pocketnode
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import androidx.test.uiautomator.By
+import androidx.test.uiautomator.UiDevice
+import androidx.test.uiautomator.Until
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+
+private const val PKG = "com.rjnr.pocketnode"
+private const val LAUNCH_TIMEOUT_MS = 10_000L
+private const val ONBOARDING_TIMEOUT_MS = 15_000L
+private const val POST_UPGRADE_HOME_TIMEOUT_MS = 30_000L
+
+@RunWith(AndroidJUnit4::class)
+class UpgradeSmokeTest {
+
+    private lateinit var device: UiDevice
+    private lateinit var ctx: Context
+
+    @Before
+    fun setUp() {
+        device = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())
+        ctx = ApplicationProvider.getApplicationContext()
+    }
+
+    /**
+     * Run against the previous-main APK before the upgrade install.
+     * Walks onboarding (Create New Wallet → PIN intro → setup PIN → confirm PIN)
+     * and asserts the home-balance-row resource-id is visible. That means real
+     * key material was written and Room/EncryptedSharedPrefs hold prior-version
+     * state for the upgrade migration to chew on.
+     */
+    @Test
+    fun seedFreshWallet() {
+        launchApp()
+
+        val createTile = device.wait(
+            Until.findObject(By.res(PKG, "onboarding-create-new")),
+            ONBOARDING_TIMEOUT_MS
+        )
+        assertNotNull(
+            "Onboarding create-new tile not found — prev APK is broken, not this PR",
+            createTile
+        )
+        createTile.click()
+
+        // After wallet creation completes the app shows the PIN intro.
+        val pinIntro = device.wait(
+            Until.findObject(By.res(PKG, "pin-intro-continue")),
+            ONBOARDING_TIMEOUT_MS
+        )
+        assertNotNull("PIN intro continue button not found", pinIntro)
+        pinIntro.click()
+
+        // Two passes (SETUP + CONFIRM). Each pass enters six 1s; the screen
+        // auto-submits on the 6th digit and advances to the next phase.
+        repeat(2) {
+            repeat(6) {
+                val digit = device.wait(
+                    Until.findObject(By.res(PKG, "pin-keypad-1")),
+                    5_000L
+                )
+                assertNotNull("PIN digit '1' not visible (resource-id pin-keypad-1)", digit)
+                digit.click()
+            }
+        }
+
+        val balanceRow = device.wait(
+            Until.findObject(By.res(PKG, "home-balance-row")),
+            ONBOARDING_TIMEOUT_MS
+        )
+        assertNotNull("Home balance row not found after onboarding", balanceRow)
+    }
+
+    /**
+     * Run against the PR-head APK after the install -r upgrade.
+     * Just asserts Home renders. If migration crashes or JNI init fails,
+     * the row never appears.
+     */
+    @Test
+    fun assertHomeAfterUpgrade() {
+        launchApp()
+
+        val balanceRow = device.wait(
+            Until.findObject(By.res(PKG, "home-balance-row")),
+            POST_UPGRADE_HOME_TIMEOUT_MS
+        )
+        assertNotNull(
+            "Home balance row not visible within ${POST_UPGRADE_HOME_TIMEOUT_MS}ms after upgrade",
+            balanceRow
+        )
+    }
+
+    private fun launchApp() {
+        device.pressHome()
+        val launcherPkg = device.launcherPackageName
+        assertNotNull(launcherPkg)
+        device.wait(Until.hasObject(By.pkg(launcherPkg).depth(0)), LAUNCH_TIMEOUT_MS)
+
+        val intent = ctx.packageManager.getLaunchIntentForPackage(PKG)!!.apply {
+            addFlags(android.content.Intent.FLAG_ACTIVITY_CLEAR_TASK)
+        }
+        ctx.startActivity(intent)
+        assertTrue(
+            "App package $PKG didn't appear within $LAUNCH_TIMEOUT_MS ms",
+            device.wait(Until.hasObject(By.pkg(PKG).depth(0)), LAUNCH_TIMEOUT_MS)
+        )
+    }
+}

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/components/SyncOptionsSheet.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/components/SyncOptionsSheet.kt
@@ -1,6 +1,7 @@
 package com.rjnr.pocketnode.ui.components
 
 import androidx.compose.foundation.clickable
+import com.rjnr.pocketnode.ui.util.uaTestTag
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
@@ -202,6 +203,7 @@ internal fun SyncOptionsSheet(
                     },
                     enabled = selectedMode != SyncMode.CUSTOM ||
                         (parsedHeight != null && parsedHeight > 0 && withinTip),
+                    modifier = Modifier.uaTestTag("sync-sheet-apply"),
                 ) {
                     Text(stringResource(R.string.common_apply))
                 }

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/auth/AuthScreen.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/auth/AuthScreen.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import com.composables.icons.lucide.*
+import com.rjnr.pocketnode.ui.util.uaTestTag
 import androidx.compose.material3.Button
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
@@ -134,7 +135,7 @@ fun AuthScreen(
             if (uiState.showPinFallback) {
                 OutlinedButton(
                     onClick = onNavigateToPinVerify,
-                    modifier = Modifier.fillMaxWidth()
+                    modifier = Modifier.fillMaxWidth().uaTestTag("auth-use-pin")
                 ) {
                     Text("Use PIN")
                 }

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/auth/InitialPinSetupScreen.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/auth/InitialPinSetupScreen.kt
@@ -33,6 +33,7 @@ import androidx.compose.ui.unit.dp
 import com.composables.icons.lucide.KeyRound
 import com.composables.icons.lucide.Lucide
 import androidx.compose.material3.Icon
+import com.rjnr.pocketnode.ui.util.uaTestTag
 
 private enum class Phase { INTRO, SETUP, CONFIRM }
 
@@ -150,7 +151,7 @@ private fun IntroBody(
 
         Button(
             onClick = onContinue,
-            modifier = Modifier.fillMaxWidth(),
+            modifier = Modifier.fillMaxWidth().uaTestTag("pin-intro-continue"),
             colors = ButtonDefaults.buttonColors()
         ) {
             Text("Create PIN")

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/auth/PinEntryScreen.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/auth/PinEntryScreen.kt
@@ -39,6 +39,7 @@ import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.rjnr.pocketnode.data.auth.PinManager
+import com.rjnr.pocketnode.ui.util.uaTestTag
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -200,7 +201,7 @@ fun PinEntryScreen(
                             else -> {
                                 FilledTonalButton(
                                     onClick = { viewModel.onDigitEntered(key[0]) },
-                                    modifier = Modifier.size(72.dp),
+                                    modifier = Modifier.size(72.dp).uaTestTag("pin-keypad-$key"),
                                     shape = CircleShape,
                                     enabled = buttonsEnabled
                                 ) {

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/home/Components.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/home/Components.kt
@@ -51,6 +51,7 @@ import com.rjnr.pocketnode.data.gateway.models.TransactionRecord
 import com.rjnr.pocketnode.ui.theme.ErrorRed
 import com.rjnr.pocketnode.ui.theme.PendingAmber
 import com.rjnr.pocketnode.ui.theme.SuccessGreen
+import com.rjnr.pocketnode.ui.util.uaTestTag
 import com.rjnr.pocketnode.util.formatBlockTimestamp
 import java.util.Locale
 
@@ -67,7 +68,8 @@ fun WalletBalanceCard(
     Surface(
         color = MaterialTheme.colorScheme.surface,
         shape = RoundedCornerShape(24.dp),
-        border = BorderStroke(1.dp, MaterialTheme.colorScheme.outlineVariant)
+        border = BorderStroke(1.dp, MaterialTheme.colorScheme.outlineVariant),
+        modifier = Modifier.uaTestTag("home-balance-row")
     ) {
         Column(modifier = Modifier.padding(20.dp)) {
             Row(

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/onboarding/MnemonicImportScreen.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/onboarding/MnemonicImportScreen.kt
@@ -10,6 +10,7 @@ import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalClipboardManager
+import com.rjnr.pocketnode.ui.util.uaTestTag
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -286,7 +287,7 @@ fun MnemonicImportScreen(
                         viewModel.pasteMnemonic(text)
                     }
                 },
-                modifier = Modifier.fillMaxWidth()
+                modifier = Modifier.fillMaxWidth().uaTestTag("import-paste")
             ) {
                 Icon(Lucide.ClipboardPaste, contentDescription = null, modifier = Modifier.size(18.dp))
                 Spacer(Modifier.width(8.dp))
@@ -324,7 +325,7 @@ fun MnemonicImportScreen(
             // Import button
             Button(
                 onClick = { viewModel.importMnemonic() },
-                modifier = Modifier.fillMaxWidth(),
+                modifier = Modifier.fillMaxWidth().uaTestTag("import-submit"),
                 enabled = !uiState.isImporting && uiState.words.all { it.isNotBlank() }
             ) {
                 if (uiState.isImporting) {

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/onboarding/OnboardingScreen.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/onboarding/OnboardingScreen.kt
@@ -14,6 +14,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
+import com.rjnr.pocketnode.ui.util.uaTestTag
 
 @Composable
 fun OnboardingScreen(
@@ -104,7 +105,8 @@ fun OnboardingScreen(
                 description = "Generate a new wallet with a 12-word recovery phrase.",
                 icon = Lucide.Plus,
                 onClick = { viewModel.createNewWallet() },
-                isLoading = uiState.isLoading
+                isLoading = uiState.isLoading,
+                modifier = Modifier.uaTestTag("onboarding-create-new")
             )
 
             Spacer(modifier = Modifier.height(16.dp))
@@ -136,12 +138,13 @@ private fun OnboardingOption(
     description: String,
     icon: ImageVector,
     onClick: () -> Unit,
-    isLoading: Boolean
+    isLoading: Boolean,
+    modifier: Modifier = Modifier
 ) {
     Card(
         onClick = onClick,
         enabled = !isLoading,
-        modifier = Modifier.fillMaxWidth(),
+        modifier = modifier.fillMaxWidth(),
         colors = CardDefaults.cardColors(
             containerColor = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f)
         ),

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/onboarding/OnboardingScreen.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/onboarding/OnboardingScreen.kt
@@ -116,7 +116,8 @@ fun OnboardingScreen(
                 description = "Import wallet using your 12-word recovery phrase.",
                 icon = Lucide.KeyRound,
                 onClick = onNavigateToImport,
-                isLoading = uiState.isLoading
+                isLoading = uiState.isLoading,
+                modifier = Modifier.uaTestTag("onboarding-recover")
             )
 
             Spacer(modifier = Modifier.height(32.dp))

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/util/TestTagModifier.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/util/TestTagModifier.kt
@@ -1,0 +1,17 @@
+package com.rjnr.pocketnode.ui.util
+
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.testTagsAsResourceId
+
+/**
+ * Adds a stable testTag and exposes it to UI Automator as a resource-id.
+ * Compose's plain `testTag` only shows up in the semantics tree; UA reads
+ * the View tree, so it needs `testTagsAsResourceId = true` as well.
+ */
+@OptIn(androidx.compose.ui.ExperimentalComposeUiApi::class)
+fun Modifier.uaTestTag(tag: String): Modifier =
+    this
+        .semantics { testTagsAsResourceId = true }
+        .testTag(tag)

--- a/external/ckb-light-client/build-android-jni.sh
+++ b/external/ckb-light-client/build-android-jni.sh
@@ -56,6 +56,11 @@ echo "NDK Host: $NDK_HOST"
 # Multi-ABI setup (arm64 + armv7 only — x86_64 is emulator-only and excluded from APK)
 RUST_TARGETS=("aarch64-linux-android" "armv7-linux-androideabi")
 ANDROID_ARCHS=("arm64-v8a" "armeabi-v7a")
+if [ "${BUILD_X86_64:-0}" = "1" ]; then
+    RUST_TARGETS+=("x86_64-linux-android")
+    ANDROID_ARCHS+=("x86_64")
+    echo "BUILD_X86_64=1 → also building x86_64-linux-android"
+fi
 
 # Environment common flags
 ROCKSDB_DISABLE_FLAGS="-DROCKSDB_NO_DYNAMIC_EXTENSION -DROCKSDB_LITE"


### PR DESCRIPTION
Implements #144 Phase 2 — install-over-install smoke harness that catches Room migration / JNI init regressions on the upgrade path.

## What lands

- `BUILD_X86_64=1` opt-in env for Cargo + abiFilters (CI emulator is x86_64-KVM; default ARM-only builds untouched).
- `Modifier.uaTestTag()` helper + 9 testTag sites across onboarding, import, PIN, sync sheet, auth screen, and Home balance row.
- `UpgradeSmokeTest` (UI Automator) with two `@Test` methods: `seedFreshWallet` (Recover-from-Seed with a deterministic BIP39 dev mnemonic) and `assertHomeAfterUpgrade` (re-enters PIN, asserts Home renders).
- `android-ci.yml`: drops the PR-time JNI-less debug APK build; new main-only `prev-jni-build` job uploads `pocketnode-prev-jni-debug` (14d retention).
- `.github/workflows/upgrade-smoke.yml`: full pipeline — download prev artifact, build PR APK, boot x86_64 API-34 emulator, seed → install -r → assert.

Plan + design under `docs/superpowers/{plans,specs}/` (gitignored, local).

## Pre-merge validation

- [x] 6.1 Local UA dry-run on arm64-v8a emulator — both tests green (seed 35s, post-upgrade 31s) against a degenerate prev=PR baseline. Smoke wiring proven; real prev/PR comparison only possible post-merge once main produces the first artifact.
- [ ] 6.2 Manual workflow_dispatch on this branch (or covered automatically by 6.5 below).
- [ ] 6.3 Negative-control PR (inject `throw IllegalStateException` in `GatewayRepository.initNode`; expect harness to fail).
- [ ] 6.4 Positive-control PR (no-op whitespace; expect green).
- [ ] 6.5 First-run skip-path: this PR's own upgrade-smoke run should warn + comment + exit 0 (no prev artifact on main yet).
- [ ] 7.1 Drop `workflow_dispatch:` trigger from `upgrade-smoke.yml` before final merge.

## Notes

- Skip-comment posts only on `pull_request` events to avoid 404 on workflow_dispatch (no PR context).
- DB is v9 on both sides of upgrade right now, so MIGRATION_8_9 doesn't fire. The harness still catches JNI-init + DAO / first-render regressions; once a v9→v10 migration lands the harness covers it automatically.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated upgrade scenario testing to verify seamless app transitions between versions.

* **Tests**
  * Enhanced test infrastructure with improved UI element identification for better test coverage and reliability.
  * Expanded architecture support for testing environments.

* **Chores**
  * Updated CI/CD workflows and build configuration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/RaheemJnr/pocket-node/pull/152?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->