### PR TITLE
fix(ci): use nttld/setup-ndk for full NDK install

### DIFF
--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -81,10 +81,19 @@ jobs:
         uses: android-actions/setup-android@v3
 
       - name: Setup Android NDK
-        # NDK r27.0.12077973 — matches AGP 8.13.2 default. Bump in lockstep with AGP.
-        run: |
-          sdkmanager --install "ndk;27.0.12077973" >/dev/null
-          echo "ANDROID_NDK_HOME=$ANDROID_HOME/ndk/27.0.12077973" >> $GITHUB_ENV
+        # NDK r27c (27.0.12077973) — matches AGP 8.13.2 default. Bump in
+        # lockstep with AGP. nttld/setup-ndk handles license + full extraction;
+        # sdkmanager produced partial installs missing the llvm toolchain
+        # ("clang not found in NDK").
+        id: setup-ndk
+        uses: nttld/setup-ndk@v1
+        with:
+          ndk-version: r27c
+          add-to-path: false
+      - name: Export ANDROID_NDK_HOME
+        env:
+          NDK_PATH: ${{ steps.setup-ndk.outputs.ndk-path }}
+        run: echo "ANDROID_NDK_HOME=$NDK_PATH" >> $GITHUB_ENV
 
       - name: Set up Rust (stable + Android targets)
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/upgrade-smoke.yml
+++ b/.github/workflows/upgrade-smoke.yml
@@ -31,10 +31,19 @@ jobs:
         uses: android-actions/setup-android@v3
 
       - name: Setup Android NDK
-        # NDK r27.0.12077973 — matches AGP 8.13.2 default. Bump in lockstep with AGP.
-        run: |
-          sdkmanager --install "ndk;27.0.12077973" >/dev/null
-          echo "ANDROID_NDK_HOME=$ANDROID_HOME/ndk/27.0.12077973" >> $GITHUB_ENV
+        # NDK r27c (27.0.12077973) — matches AGP 8.13.2 default. Bump in
+        # lockstep with AGP. nttld/setup-ndk handles license + full extraction;
+        # sdkmanager produced partial installs missing the llvm toolchain
+        # ("clang not found in NDK").
+        id: setup-ndk
+        uses: nttld/setup-ndk@v1
+        with:
+          ndk-version: r27c
+          add-to-path: false
+      - name: Export ANDROID_NDK_HOME
+        env:
+          NDK_PATH: ${{ steps.setup-ndk.outputs.ndk-path }}
+        run: echo "ANDROID_NDK_HOME=$NDK_PATH" >> $GITHUB_ENV
 
       - name: Set up Rust (stable + Android targets)
         uses: dtolnay/rust-toolchain@stable


### PR DESCRIPTION
Follow-up to #152.

Post-merge run 26045445025's `prev-jni-build` job failed with `clang not found in NDK`. The sdkmanager-based NDK install was producing a partial install on ubuntu-latest runners — the `27.0.12077973` directory existed but the `toolchains/llvm/` subtree was missing.

Switch both `prev-jni-build` (android-ci.yml) and `smoke` (upgrade-smoke.yml) to `nttld/setup-ndk@v1` which handles license acceptance and full extraction, then exports the path via step output.

After this lands on main, the next `android-ci.yml` run will produce the first `pocketnode-prev-jni-debug` artifact that the smoke harness needs.