### PR TITLE
DO NOT MERGE: smoke negative control

### DIFF
--- a/android/app/src/main/java/com/rjnr/pocketnode/data/gateway/GatewayRepository.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/gateway/GatewayRepository.kt
@@ -397,6 +397,9 @@ class GatewayRepository @Inject constructor(
     }
 
     private suspend fun initializeNode(targetNetwork: NetworkType) {
+        // DO NOT MERGE — upgrade-smoke harness negative-control injection.
+        // Validates that the harness fails on regressions in node init.
+        throw IllegalStateException("upgrade-smoke negative control")
         try {
             _nodeReady.value = null // Reset for re-initialization
             Log.d(TAG, "Initializing embedded node for ${targetNetwork.name}...")


### PR DESCRIPTION
Phase 6.3 validation. Injects `throw IllegalStateException` in `GatewayRepository.initializeNode()`. Upgrade-smoke must fail with logcat FATAL + assertHomeAfterUpgrade UA failure. Close without merging once harness fails as expected.