### PR TITLE
fix(smoke): drop set -o pipefail (dash on ubuntu)

### DIFF
--- a/.github/workflows/upgrade-smoke.yml
+++ b/.github/workflows/upgrade-smoke.yml
@@ -138,7 +138,11 @@ jobs:
           emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           disable-animations: true
           script: |
-            set -euo pipefail
+            # reactivecircus/android-emulator-runner runs this under /bin/sh
+            # (dash on ubuntu-latest), which lacks `set -o pipefail`. Drop it.
+            # The `tee … | grep` patterns below survive without pipefail
+            # because each grep is on a separate line and checks file content.
+            set -eu
             adb wait-for-device
             adb shell input keyevent 82 || true
 
@@ -151,9 +155,7 @@ jobs:
             echo "::endgroup::"
 
             echo "::group::Seed wallet on prev APK"
-            adb shell am instrument -w \
-              -e class com.rjnr.pocketnode.UpgradeSmokeTest#seedFreshWallet \
-              com.rjnr.pocketnode.test/androidx.test.runner.AndroidJUnitRunner | tee seed.log
+            adb shell am instrument -w -e class com.rjnr.pocketnode.UpgradeSmokeTest#seedFreshWallet com.rjnr.pocketnode.test/androidx.test.runner.AndroidJUnitRunner | tee seed.log
             grep -q 'OK (1 test)' seed.log || { echo "Prev APK seed failed; main is broken, not this PR"; exit 1; }
             echo "::endgroup::"
 
@@ -164,9 +166,7 @@ jobs:
             echo "::endgroup::"
 
             echo "::group::Assert Home renders post-upgrade"
-            adb shell am instrument -w \
-              -e class com.rjnr.pocketnode.UpgradeSmokeTest#assertHomeAfterUpgrade \
-              com.rjnr.pocketnode.test/androidx.test.runner.AndroidJUnitRunner | tee post.log
+            adb shell am instrument -w -e class com.rjnr.pocketnode.UpgradeSmokeTest#assertHomeAfterUpgrade com.rjnr.pocketnode.test/androidx.test.runner.AndroidJUnitRunner | tee post.log
             grep -q 'OK (1 test)' post.log || { echo "Post-upgrade Home assertion failed"; exit 1; }
             echo "::endgroup::"
 


### PR DESCRIPTION
Follow-up to #154.

Both control runs (#155 neg-control, #156 pos-control) failed at line 1 of the emulator script with `Illegal option -o pipefail`. `reactivecircus/android-emulator-runner` runs `script:` via `/usr/bin/sh`, which on ubuntu-latest is dash. Dash supports `-eu` but not `-o pipefail`.

Drop pipefail. Comment notes why the `tee | grep` patterns are safe without it (each grep reads a file on the next line, not from a pipe).

After this lands, re-run #155 and #156 to actually validate the harness logic.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated test workflow configuration to ensure compatibility with the shell environment used during execution and improved documentation of testing procedures.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/RaheemJnr/pocket-node/pull/157?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->