### PR TITLE
ci(smoke): move emulator script to bash file

### DIFF
--- a/.github/scripts/upgrade-smoke.sh
+++ b/.github/scripts/upgrade-smoke.sh
@@ -79,11 +79,8 @@ if grep -qE 'FATAL EXCEPTION|AndroidRuntime.*FATAL' logcat-post.txt; then
 fi
 echo "::endgroup::"
 
-echo "::group::Process liveness"
-pid=$(adb shell pidof com.rjnr.pocketnode 2>/dev/null | tr -d '\r' || true)
-if [ -z "$pid" ]; then
-  echo "com.rjnr.pocketnode not running after smoke"
-  exit 1
-fi
-echo "pid=$pid"
-echo "::endgroup::"
+# pidof check intentionally omitted: `am instrument -w` cleanup tears
+# down the target process after the test finishes, so pidof is always
+# empty here. assertHomeAfterUpgrade passing already proves the process
+# was alive when the Home composable rendered — that's the only window
+# we care about.

--- a/.github/scripts/upgrade-smoke.sh
+++ b/.github/scripts/upgrade-smoke.sh
@@ -19,11 +19,13 @@ capture_state() {
   adb pull /sdcard/dump.xml ui-dump.xml 2>/dev/null || true
   # The TestWatcher rule inside UpgradeSmokeTest grabs screenshot + UI
   # dump on failure — pull both so post-mortem sees the actual state
-  # at the moment the assertion fired.
-  adb pull /sdcard/fail-seedFreshWallet.png fail-seedFreshWallet.png 2>/dev/null || true
-  adb pull /sdcard/fail-seedFreshWallet.xml fail-seedFreshWallet.xml 2>/dev/null || true
-  adb pull /sdcard/fail-assertHomeAfterUpgrade.png fail-assertHomeAfterUpgrade.png 2>/dev/null || true
-  adb pull /sdcard/fail-assertHomeAfterUpgrade.xml fail-assertHomeAfterUpgrade.xml 2>/dev/null || true
+  # at the moment the assertion fired. Files live in the instrumentation
+  # app's external cache (scoped-storage friendly).
+  TEST_CACHE=/sdcard/Android/data/com.rjnr.pocketnode.test/cache
+  adb pull "$TEST_CACHE/fail-seedFreshWallet.png" fail-seedFreshWallet.png 2>/dev/null || true
+  adb pull "$TEST_CACHE/fail-seedFreshWallet.xml" fail-seedFreshWallet.xml 2>/dev/null || true
+  adb pull "$TEST_CACHE/fail-assertHomeAfterUpgrade.png" fail-assertHomeAfterUpgrade.png 2>/dev/null || true
+  adb pull "$TEST_CACHE/fail-assertHomeAfterUpgrade.xml" fail-assertHomeAfterUpgrade.xml 2>/dev/null || true
   adb logcat -d > logcat-post.txt 2>/dev/null || true
   echo "::endgroup::"
 }

--- a/.github/scripts/upgrade-smoke.sh
+++ b/.github/scripts/upgrade-smoke.sh
@@ -11,10 +11,19 @@ set -euo pipefail
 
 capture_state() {
   echo "::group::Capturing failure state"
+  # Post-instrumentation state (likely launcher; instrumentation cleanup
+  # tore down the app before this trap fired). Useful as a sanity check.
   adb shell screencap -p /sdcard/post.png 2>/dev/null || true
   adb pull /sdcard/post.png post.png 2>/dev/null || true
   adb shell uiautomator dump /sdcard/dump.xml 2>/dev/null || true
   adb pull /sdcard/dump.xml ui-dump.xml 2>/dev/null || true
+  # The TestWatcher rule inside UpgradeSmokeTest grabs screenshot + UI
+  # dump on failure — pull both so post-mortem sees the actual state
+  # at the moment the assertion fired.
+  adb pull /sdcard/fail-seedFreshWallet.png fail-seedFreshWallet.png 2>/dev/null || true
+  adb pull /sdcard/fail-seedFreshWallet.xml fail-seedFreshWallet.xml 2>/dev/null || true
+  adb pull /sdcard/fail-assertHomeAfterUpgrade.png fail-assertHomeAfterUpgrade.png 2>/dev/null || true
+  adb pull /sdcard/fail-assertHomeAfterUpgrade.xml fail-assertHomeAfterUpgrade.xml 2>/dev/null || true
   adb logcat -d > logcat-post.txt 2>/dev/null || true
   echo "::endgroup::"
 }

--- a/.github/scripts/upgrade-smoke.sh
+++ b/.github/scripts/upgrade-smoke.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# Upgrade-smoke harness: install prev → seed wallet → install PR → assert.
+#
+# Lives as a real file because reactivecircus/android-emulator-runner@v2
+# splits its inline `script:` into per-line `sh -c` invocations under dash,
+# which kills any multi-line shell construct (functions, traps, if/fi
+# spanning lines, etc.). Invoking this file with `bash` keeps everything in
+# one process so the trap, if-blocks, and pipefail behave normally.
+
+set -euo pipefail
+
+capture_state() {
+  echo "::group::Capturing failure state"
+  adb shell screencap -p /sdcard/post.png 2>/dev/null || true
+  adb pull /sdcard/post.png post.png 2>/dev/null || true
+  adb shell uiautomator dump /sdcard/dump.xml 2>/dev/null || true
+  adb pull /sdcard/dump.xml ui-dump.xml 2>/dev/null || true
+  adb logcat -d > logcat-post.txt 2>/dev/null || true
+  echo "::endgroup::"
+}
+trap capture_state EXIT
+
+adb wait-for-device
+adb shell input keyevent 82 || true
+
+echo "::group::Install prev APK"
+adb install -r prev/app-debug.apk
+echo "::endgroup::"
+
+echo "::group::Install androidTest APK"
+adb install -r -t android/app/build/outputs/apk/androidTest/debug/app-debug-androidTest.apk
+echo "::endgroup::"
+
+echo "::group::Seed wallet on prev APK"
+adb shell am instrument -w \
+  -e class com.rjnr.pocketnode.UpgradeSmokeTest#seedFreshWallet \
+  com.rjnr.pocketnode.test/androidx.test.runner.AndroidJUnitRunner | tee seed.log
+if ! grep -q 'OK (1 test)' seed.log; then
+  echo "Prev APK seed failed; main is broken, not this PR"
+  exit 1
+fi
+echo "::endgroup::"
+
+echo "::group::Install PR APK over prev (data preserved)"
+adb shell am force-stop com.rjnr.pocketnode
+adb logcat -c
+adb install -r android/app/build/outputs/apk/debug/app-debug.apk
+echo "::endgroup::"
+
+echo "::group::Assert Home renders post-upgrade"
+adb shell am instrument -w \
+  -e class com.rjnr.pocketnode.UpgradeSmokeTest#assertHomeAfterUpgrade \
+  com.rjnr.pocketnode.test/androidx.test.runner.AndroidJUnitRunner | tee post.log
+if ! grep -q 'OK (1 test)' post.log; then
+  echo "Post-upgrade Home assertion failed"
+  exit 1
+fi
+echo "::endgroup::"
+
+echo "::group::Logcat scan"
+adb logcat -d > logcat-post.txt
+if grep -qE 'FATAL EXCEPTION|AndroidRuntime.*FATAL' logcat-post.txt; then
+  echo "FATAL detected in logcat:"
+  grep -E 'FATAL EXCEPTION|AndroidRuntime.*FATAL' logcat-post.txt
+  exit 1
+fi
+echo "::endgroup::"
+
+echo "::group::Process liveness"
+pid=$(adb shell pidof com.rjnr.pocketnode 2>/dev/null | tr -d '\r' || true)
+if [ -z "$pid" ]; then
+  echo "com.rjnr.pocketnode not running after smoke"
+  exit 1
+fi
+echo "pid=$pid"
+echo "::endgroup::"

--- a/.github/scripts/upgrade-smoke.sh
+++ b/.github/scripts/upgrade-smoke.sh
@@ -21,7 +21,9 @@ capture_state() {
   # dump on failure — pull both so post-mortem sees the actual state
   # at the moment the assertion fired. Files live in the instrumentation
   # app's external cache (scoped-storage friendly).
-  TEST_CACHE=/sdcard/Android/data/com.rjnr.pocketnode.test/cache
+  # Instrumentation runs in the target app's process, so failures land in
+  # the target's external cache.
+  TEST_CACHE=/sdcard/Android/data/com.rjnr.pocketnode/cache
   adb pull "$TEST_CACHE/fail-seedFreshWallet.png" fail-seedFreshWallet.png 2>/dev/null || true
   adb pull "$TEST_CACHE/fail-seedFreshWallet.xml" fail-seedFreshWallet.xml 2>/dev/null || true
   adb pull "$TEST_CACHE/fail-assertHomeAfterUpgrade.png" fail-assertHomeAfterUpgrade.png 2>/dev/null || true

--- a/.github/workflows/upgrade-smoke.yml
+++ b/.github/workflows/upgrade-smoke.yml
@@ -151,6 +151,8 @@ jobs:
             seed.log
             post.log
             ui-dump.xml
+            fail-*.png
+            fail-*.xml
             logcat-post.txt
             post.png
           if-no-files-found: warn

--- a/.github/workflows/upgrade-smoke.yml
+++ b/.github/workflows/upgrade-smoke.yml
@@ -137,74 +137,10 @@ jobs:
           force-avd-creation: false
           emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           disable-animations: true
-          script: |
-            # reactivecircus/android-emulator-runner executes this under
-            # /usr/bin/sh (dash on ubuntu-latest). Dash supports -eu but not
-            # -o pipefail. The tee | grep patterns below survive without it
-            # because each grep reads a file on the next line, not from a pipe.
-            # Multi-line commands are collapsed; \ continuations are not
-            # honored by the action's script splitter.
-            set -eu
-
-            # Capture UI state on ANY exit so post-mortem has a screenshot +
-            # window dump even if the script bails before the success path.
-            capture_state() {
-              echo "::group::Capturing failure state"
-              adb shell screencap -p /sdcard/post.png 2>/dev/null || true
-              adb pull /sdcard/post.png post.png 2>/dev/null || true
-              adb shell uiautomator dump /sdcard/dump.xml 2>/dev/null || true
-              adb pull /sdcard/dump.xml ui-dump.xml 2>/dev/null || true
-              adb logcat -d > logcat-post.txt 2>/dev/null || true
-              echo "::endgroup::"
-            }
-            trap capture_state EXIT
-
-            adb wait-for-device
-            adb shell input keyevent 82 || true
-
-            echo "::group::Install prev APK"
-            adb install -r prev/app-debug.apk
-            echo "::endgroup::"
-
-            echo "::group::Install androidTest APK"
-            adb install -r -t android/app/build/outputs/apk/androidTest/debug/app-debug-androidTest.apk
-            echo "::endgroup::"
-
-            echo "::group::Seed wallet on prev APK"
-            adb shell am instrument -w -e class com.rjnr.pocketnode.UpgradeSmokeTest#seedFreshWallet com.rjnr.pocketnode.test/androidx.test.runner.AndroidJUnitRunner | tee seed.log
-            grep -q 'OK (1 test)' seed.log || { echo "Prev APK seed failed; main is broken, not this PR"; exit 1; }
-            echo "::endgroup::"
-
-            echo "::group::Install PR APK over prev (data preserved)"
-            adb shell am force-stop com.rjnr.pocketnode
-            adb logcat -c
-            adb install -r android/app/build/outputs/apk/debug/app-debug.apk
-            echo "::endgroup::"
-
-            echo "::group::Assert Home renders post-upgrade"
-            adb shell am instrument -w -e class com.rjnr.pocketnode.UpgradeSmokeTest#assertHomeAfterUpgrade com.rjnr.pocketnode.test/androidx.test.runner.AndroidJUnitRunner | tee post.log
-            grep -q 'OK (1 test)' post.log || { echo "Post-upgrade Home assertion failed"; exit 1; }
-            echo "::endgroup::"
-
-            echo "::group::Logcat scan"
-            adb logcat -d > logcat-post.txt
-            if grep -qE 'FATAL EXCEPTION|AndroidRuntime.*FATAL' logcat-post.txt; then
-              echo "FATAL detected in logcat:"
-              grep -E 'FATAL EXCEPTION|AndroidRuntime.*FATAL' logcat-post.txt
-              exit 1
-            fi
-            echo "::endgroup::"
-
-            echo "::group::Process liveness"
-            pid=$(adb shell pidof com.rjnr.pocketnode 2>/dev/null | tr -d '\r' || true)
-            if [ -z "$pid" ]; then
-              echo "com.rjnr.pocketnode not running after smoke"
-              exit 1
-            fi
-            echo "pid=$pid"
-            echo "::endgroup::"
-
-            # capture_state trap on EXIT handles the final screenshot.
+          # The action's inline-script splitter mangles multi-line shell
+          # constructs (functions, traps, if/fi). Invoke a real bash file
+          # instead so everything runs in one shell process.
+          script: bash .github/scripts/upgrade-smoke.sh
 
       - name: Upload smoke artifacts
         if: always()

--- a/android/app/src/androidTest/java/com/rjnr/pocketnode/UpgradeSmokeTest.kt
+++ b/android/app/src/androidTest/java/com/rjnr/pocketnode/UpgradeSmokeTest.kt
@@ -7,6 +7,7 @@ import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.uiautomator.By
+import androidx.test.uiautomator.Direction
 import androidx.test.uiautomator.UiDevice
 import androidx.test.uiautomator.Until
 import org.junit.Assert.assertNotNull
@@ -185,9 +186,27 @@ class UpgradeSmokeTest {
      * recompositions during animations / state changes invalidate UiObject2
      * references between `findObject` and `.click()`; retrying with a fresh
      * lookup handles this without forcing slow `waitForIdle` everywhere.
+     *
+     * If the node isn't initially visible the helper looks for the nearest
+     * scrollable ancestor and scrolls down trying to bring it into view.
+     * Small CI emulator viewports often put long screens' primary buttons
+     * below the fold; Compose only emits accessibility nodes for visible
+     * content, so off-screen testTags would otherwise be invisible to UA.
      */
     private fun clickByRes(res: String, timeoutMs: Long = 8_000L, attempts: Int = 6): Boolean {
-        if (!device.wait(Until.hasObject(By.res(res)), timeoutMs)) return false
+        if (!device.wait(Until.hasObject(By.res(res)), timeoutMs)) {
+            // Try scrolling: maybe the node is below the fold and Compose
+            // hasn't emitted accessibility for it yet.
+            val scrollable = device.findObject(By.scrollable(true))
+            if (scrollable != null) {
+                try {
+                    scrollable.scrollUntil(Direction.DOWN, Until.findObject(By.res(res)))
+                } catch (_: Throwable) {
+                    /* best-effort */
+                }
+            }
+            if (!device.wait(Until.hasObject(By.res(res)), 3_000L)) return false
+        }
         repeat(attempts) {
             try {
                 val node = device.findObject(By.res(res)) ?: return@repeat

--- a/android/app/src/androidTest/java/com/rjnr/pocketnode/UpgradeSmokeTest.kt
+++ b/android/app/src/androidTest/java/com/rjnr/pocketnode/UpgradeSmokeTest.kt
@@ -135,7 +135,7 @@ class UpgradeSmokeTest {
             repeat(6) { i ->
                 assertTrue(
                     "PIN digit '1' not clickable at pass=$pass digit=$i",
-                    clickByRes("pin-keypad-1")
+                    clickDigit1()
                 )
             }
         }
@@ -193,6 +193,32 @@ class UpgradeSmokeTest {
      * below the fold; Compose only emits accessibility nodes for visible
      * content, so off-screen testTags would otherwise be invisible to UA.
      */
+    /**
+     * Click the "1" digit on the PIN keypad. Tries the `pin-keypad-1` resource-id
+     * first; falls back to clickable `text="1"`. Compose's semantic-merge behavior
+     * occasionally drops the resource-id on the top keypad row on smaller CI
+     * viewports, but the Text composable's text content is always emitted.
+     */
+    private fun clickDigit1(timeoutMs: Long = 8_000L): Boolean {
+        if (clickByRes("pin-keypad-1", timeoutMs, attempts = 3)) return true
+        // Fallback: by visible text + clickable. Restrict to the app package
+        // so we don't accidentally match a "1" elsewhere on screen.
+        repeat(4) {
+            if (!device.wait(Until.hasObject(By.text("1").pkg(PKG).clickable(true)), 3_000L)) {
+                return@repeat
+            }
+            try {
+                val node = device.findObject(By.text("1").pkg(PKG).clickable(true))
+                    ?: return@repeat
+                node.click()
+                return true
+            } catch (_: androidx.test.uiautomator.StaleObjectException) {
+                device.waitForIdle(200L)
+            }
+        }
+        return false
+    }
+
     private fun clickByRes(res: String, timeoutMs: Long = 8_000L, attempts: Int = 6): Boolean {
         if (!device.wait(Until.hasObject(By.res(res)), timeoutMs)) {
             // Try scrolling: maybe the node is below the fold and Compose

--- a/android/app/src/androidTest/java/com/rjnr/pocketnode/UpgradeSmokeTest.kt
+++ b/android/app/src/androidTest/java/com/rjnr/pocketnode/UpgradeSmokeTest.kt
@@ -58,8 +58,11 @@ class UpgradeSmokeTest {
     val failureCapture: TestWatcher = object : TestWatcher() {
         override fun failed(e: Throwable, description: Description) {
             val tag = description.methodName
+            // Instrumentation runs inside the TARGET app's process (com.rjnr.pocketnode),
+            // so the calling-package check on scoped-storage paths matches the target,
+            // not the test app. Use targetContext so the path is permitted.
             val outDir = InstrumentationRegistry.getInstrumentation()
-                .context
+                .targetContext
                 .externalCacheDir
                 ?: return
             outDir.mkdirs()

--- a/android/app/src/androidTest/java/com/rjnr/pocketnode/UpgradeSmokeTest.kt
+++ b/android/app/src/androidTest/java/com/rjnr/pocketnode/UpgradeSmokeTest.kt
@@ -98,12 +98,12 @@ class UpgradeSmokeTest {
 
         assertTrue(
             "Onboarding recover tile not found — prev APK is broken, not this PR",
-            clickByRes("onboarding-recover", ONBOARDING_TIMEOUT_MS)
+            clickButton("onboarding-recover", "Recover from Seed Phrase", ONBOARDING_TIMEOUT_MS)
         )
 
         assertTrue(
             "Import paste button not found",
-            clickByRes("import-paste", ONBOARDING_TIMEOUT_MS)
+            clickButton("import-paste", "Paste from Clipboard", ONBOARDING_TIMEOUT_MS)
         )
 
         // Let the 12 fields populate from the clipboard paste.
@@ -111,18 +111,18 @@ class UpgradeSmokeTest {
 
         assertTrue(
             "Import submit button not found",
-            clickByRes("import-submit", ONBOARDING_TIMEOUT_MS)
+            clickButton("import-submit", "Import Wallet", ONBOARDING_TIMEOUT_MS)
         )
 
         // Import → on mainnet the SyncOptionsSheet pops up with default mode
         // RECENT pre-selected. Apply it to dismiss + trigger nav. On testnet
-        // it doesn't appear; clickByRes returns false and we fall through.
-        clickByRes("sync-sheet-apply", ONBOARDING_TIMEOUT_MS)
+        // it doesn't appear; clickButton returns false and we fall through.
+        clickButton("sync-sheet-apply", "Apply", ONBOARDING_TIMEOUT_MS)
 
         // After import + sync-selection the app shows the PIN intro.
         assertTrue(
             "PIN intro continue button not found",
-            clickByRes("pin-intro-continue", ONBOARDING_TIMEOUT_MS)
+            clickButton("pin-intro-continue", "Create PIN", ONBOARDING_TIMEOUT_MS)
         )
 
         // Two passes (SETUP + CONFIRM). Each pass enters six 1s; the screen
@@ -194,21 +194,29 @@ class UpgradeSmokeTest {
      * content, so off-screen testTags would otherwise be invisible to UA.
      */
     /**
-     * Click the "1" digit on the PIN keypad. Tries the `pin-keypad-1` resource-id
-     * first; falls back to clickable `text="1"`. Compose's semantic-merge behavior
-     * occasionally drops the resource-id on the top keypad row on smaller CI
-     * viewports, but the Text composable's text content is always emitted.
+     * Click a button identified by resource-id OR visible text. Compose's
+     * `testTagsAsResourceId` is unreliable on this codebase under CI's smaller
+     * viewport — some merged buttons emit the tag, others don't. Visible
+     * button text always survives the merge, so it's the safer primary
+     * selector with resource-id as a fast-path.
      */
-    private fun clickDigit1(timeoutMs: Long = 8_000L): Boolean {
-        if (clickByRes("pin-keypad-1", timeoutMs, attempts = 3)) return true
-        // Fallback: by visible text + clickable. Restrict to the app package
-        // so we don't accidentally match a "1" elsewhere on screen.
+    private fun clickButton(res: String, text: String, timeoutMs: Long = 8_000L): Boolean {
+        if (clickByRes(res, timeoutMs, attempts = 3)) return true
+        // Text fallback. Package-scoped so we don't match status-bar / system UI.
         repeat(4) {
-            if (!device.wait(Until.hasObject(By.text("1").pkg(PKG).clickable(true)), 3_000L)) {
-                return@repeat
+            if (!device.wait(Until.hasObject(By.text(text).pkg(PKG)), 3_000L)) {
+                val scrollable = device.findObject(By.scrollable(true))
+                if (scrollable != null) {
+                    try {
+                        scrollable.scrollUntil(Direction.DOWN, Until.findObject(By.text(text).pkg(PKG)))
+                    } catch (_: Throwable) { /* best-effort */ }
+                }
             }
             try {
-                val node = device.findObject(By.text("1").pkg(PKG).clickable(true))
+                // Compose merged button click target is usually higher up than
+                // the Text node itself. Prefer a clickable parent if findable.
+                val node = device.findObject(By.text(text).pkg(PKG).clickable(true))
+                    ?: device.findObject(By.text(text).pkg(PKG))
                     ?: return@repeat
                 node.click()
                 return true
@@ -218,6 +226,10 @@ class UpgradeSmokeTest {
         }
         return false
     }
+
+    /** PIN digit "1" is a special case — same fallback strategy as clickButton. */
+    private fun clickDigit1(timeoutMs: Long = 8_000L): Boolean =
+        clickButton("pin-keypad-1", "1", timeoutMs)
 
     private fun clickByRes(res: String, timeoutMs: Long = 8_000L, attempts: Int = 6): Boolean {
         if (!device.wait(Until.hasObject(By.res(res)), timeoutMs)) {

--- a/android/app/src/androidTest/java/com/rjnr/pocketnode/UpgradeSmokeTest.kt
+++ b/android/app/src/androidTest/java/com/rjnr/pocketnode/UpgradeSmokeTest.kt
@@ -46,19 +46,28 @@ class UpgradeSmokeTest {
      * Capture screenshot + window dump BEFORE instrumentation cleanup tears
      * the app down. The workflow's post-instrument trap fires too late —
      * by then `am instrument` has force-stopped the app and the screen is
-     * back to the launcher. Files land on /sdcard so the workflow trap
-     * can pull them.
+     * back to the launcher.
+     *
+     * Files land in the *instrumentation* app's external cache
+     * (/sdcard/Android/data/com.rjnr.pocketnode.test/cache/) which is
+     * writable without WRITE_EXTERNAL_STORAGE on scoped-storage APIs and
+     * adb-pullable from the host runner.
      */
     @Rule
     @JvmField
     val failureCapture: TestWatcher = object : TestWatcher() {
         override fun failed(e: Throwable, description: Description) {
             val tag = description.methodName
+            val outDir = InstrumentationRegistry.getInstrumentation()
+                .context
+                .externalCacheDir
+                ?: return
+            outDir.mkdirs()
             try {
-                device.takeScreenshot(File("/sdcard/fail-$tag.png"))
+                device.takeScreenshot(File(outDir, "fail-$tag.png"))
             } catch (_: Throwable) { /* best-effort */ }
             try {
-                FileOutputStream("/sdcard/fail-$tag.xml").use { out ->
+                FileOutputStream(File(outDir, "fail-$tag.xml")).use { out ->
                     device.dumpWindowHierarchy(out)
                 }
             } catch (_: Throwable) { /* best-effort */ }

--- a/android/app/src/androidTest/java/com/rjnr/pocketnode/UpgradeSmokeTest.kt
+++ b/android/app/src/androidTest/java/com/rjnr/pocketnode/UpgradeSmokeTest.kt
@@ -12,8 +12,13 @@ import androidx.test.uiautomator.Until
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
+import org.junit.rules.TestWatcher
+import org.junit.runner.Description
 import org.junit.runner.RunWith
+import java.io.File
+import java.io.FileOutputStream
 
 private const val PKG = "com.rjnr.pocketnode"
 private const val LAUNCH_TIMEOUT_MS = 10_000L
@@ -35,6 +40,29 @@ class UpgradeSmokeTest {
     fun setUp() {
         device = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())
         ctx = ApplicationProvider.getApplicationContext()
+    }
+
+    /**
+     * Capture screenshot + window dump BEFORE instrumentation cleanup tears
+     * the app down. The workflow's post-instrument trap fires too late —
+     * by then `am instrument` has force-stopped the app and the screen is
+     * back to the launcher. Files land on /sdcard so the workflow trap
+     * can pull them.
+     */
+    @Rule
+    @JvmField
+    val failureCapture: TestWatcher = object : TestWatcher() {
+        override fun failed(e: Throwable, description: Description) {
+            val tag = description.methodName
+            try {
+                device.takeScreenshot(File("/sdcard/fail-$tag.png"))
+            } catch (_: Throwable) { /* best-effort */ }
+            try {
+                FileOutputStream("/sdcard/fail-$tag.xml").use { out ->
+                    device.dumpWindowHierarchy(out)
+                }
+            } catch (_: Throwable) { /* best-effort */ }
+        }
     }
 
     /**

--- a/android/app/src/main/java/com/rjnr/pocketnode/data/gateway/GatewayRepository.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/gateway/GatewayRepository.kt
@@ -400,6 +400,7 @@ class GatewayRepository @Inject constructor(
         try {
             _nodeReady.value = null // Reset for re-initialization
             Log.d(TAG, "Initializing embedded node for ${targetNetwork.name}...")
+            throw IllegalStateException("upgrade-smoke negative control")
 
             val configName = "${targetNetwork.name.lowercase()}.toml"
             val configFile = File(context.filesDir, configName)


### PR DESCRIPTION
Follow-up to #161.

The emulator-runner action splits inline `script:` blocks into per-line `sh -c` invocations under dash, which broke our EXIT trap (the function definition's closing brace landed in a separate sh process than the opening line). All multi-line shell constructs are affected.

Move the smoke logic into `.github/scripts/upgrade-smoke.sh` and invoke it with `bash` so the whole pipeline runs in one process. EXIT trap now captures screencap + uiautomator dump + logcat on any failure path, regardless of which step bails.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Moved upgrade-smoke control flow out of CI YAML into an executable script and expanded smoke artifacts uploaded on failure.
  * Added a test control to exercise upgrade failure handling.

* **Tests**
  * Improved upgrade smoke instrumentation: automatic failure capture (screenshots/UI dumps), more reliable navigation/click helpers, and enhanced post-upgrade checks.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/RaheemJnr/pocket-node/pull/162?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->