### PR TITLE
revert: remove leaked neg-control throw from initializeNode

### DIFF
--- a/android/app/src/main/java/com/rjnr/pocketnode/data/gateway/GatewayRepository.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/gateway/GatewayRepository.kt
@@ -400,7 +400,6 @@ class GatewayRepository @Inject constructor(
         try {
             _nodeReady.value = null // Reset for re-initialization
             Log.d(TAG, "Initializing embedded node for ${targetNetwork.name}...")
-            throw IllegalStateException("upgrade-smoke negative control")
 
             val configName = "${targetNetwork.name.lowercase()}.toml"
             val configFile = File(context.filesDir, configName)


### PR DESCRIPTION
**Hotfix.** A \`throw IllegalStateException(\"upgrade-smoke negative control\")\` slipped into main via #162's squash. The line came from the throwaway #159 branch whose history was folded into the smoke-script-file PR during a rebase.

The throw aborts every wallet init: upgrading users from v1.5.2 would crash on first launch with no recovery short of reinstall. Remove it.

The harness's positive smoke run passed despite this because \`assertHomeAfterUpgrade\` only walks AuthScreen → PIN → Home; the init failure manifests further downstream and was masked.

Merge ASAP.