### PR TITLE
chore(release): v1.6.0 changelog + versionCode 9

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -15,8 +15,8 @@ android {
         applicationId = "com.rjnr.pocketnode"
         minSdk = 26
         targetSdk = 35
-        versionCode = 8
-        versionName = "1.5.2"
+        versionCode = 9
+        versionName = "1.6.0"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 

--- a/fastlane/metadata/android/en-US/changelogs/9.txt
+++ b/fastlane/metadata/android/en-US/changelogs/9.txt
@@ -1,4 +1,6 @@
 v1.6.0:
-- External links (block explorer, GitHub) now open in an in-app browser tab. Returning to the wallet keeps you in the same task, so your phone's lock or face unlock doesn't re-engage on the way back.
+- External links (block explorer, GitHub) now open in an in-app browser tab. Returning to the wallet keeps you in the same task, so your phone's lock or face unlock does not re-engage on the way back.
 - Fixes a bug where your sync mode choice on first wallet registration could be silently overwritten back to the default.
-- Sync mode tooltip on Home now flips above the icon when there's not enough room below, so it stays readable on shorter screens.
+- Sync mode tooltip on Home now flips above the icon when there is not enough room below, so it stays readable on shorter screens.
+- Peers connected indicator on Home is now tappable and opens Node Status directly, no more navigating through Settings.
+- Removed the repeating "Protect your funds" pop-up. The home banner still surfaces backup and PIN setup.

--- a/fastlane/metadata/android/en-US/changelogs/9.txt
+++ b/fastlane/metadata/android/en-US/changelogs/9.txt
@@ -1,0 +1,4 @@
+v1.6.0:
+- External links (block explorer, GitHub) now open in an in-app browser tab. Returning to the wallet keeps you in the same task, so your phone's lock or face unlock doesn't re-engage on the way back.
+- Fixes a bug where your sync mode choice on first wallet registration could be silently overwritten back to the default.
+- Sync mode tooltip on Home now flips above the icon when there's not enough room below, so it stays readable on shorter screens.


### PR DESCRIPTION
## Summary
Release-prep for v1.6.0. Bumps `versionCode` 8 → 9 and `versionName` 1.5.2 → 1.6.0, and lands the Play Store changelog at `fastlane/metadata/android/en-US/changelogs/9.txt`.

## v1.6.0 user-facing changes (in the changelog)
- External links (block explorer, GitHub) open in Chrome Custom Tabs (#148).
- Fixes sync mode silently reverting to default on first registration (#146).
- Sync coachmark flips above icon on short screens (#146).
- Peers connected indicator on Home is tappable, opens Node Status directly (#131).
- Removed the recurring "Protect your funds" pop-up on home (#151).

## Internal changes, intentionally not in user notes
- #142B auto-update URL moved to `BuildConfig` with self-check unit test.
- #147 walking-migration test (replaces in-memory builder pattern).
- #152-#167 upgrade-smoke harness + flake fixes.
- #172 debug-build pill with git SHA in Settings → Version (debug variant only).

## Test plan
- [x] `./gradlew :app:assembleDebug` clean
- [ ] Smoke-install v1.6.0 APK over v1.5.2 install on a real device before tagging (per project memory: every recent release has shipped upgrade-path bugs because of fresh-install-only testing)
- [ ] Confirm in-app version row reads "1.6.0"
- [ ] Confirm Fastlane changelog renders cleanly when previewed