### PR TITLE
feat(home): remove "protect your funds" post-deposit dialog (#151)

### DIFF
--- a/android/app/src/main/java/com/rjnr/pocketnode/data/wallet/WalletPreferences.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/wallet/WalletPreferences.kt
@@ -209,31 +209,6 @@ class WalletPreferences @Inject constructor(
         prefs.edit().putBoolean(KEY_BACKGROUND_SYNC, enabled).commit()
     }
 
-    // --- Post-deposit "Protect your funds" dialog (per-wallet, #116 follow-up) ---
-    //
-    // The dialog is intended to fire once when a wallet first receives funds
-    // and is not fully secured (no PIN/biometrics OR no recovery-phrase backup).
-    // The trigger lives in HomeViewModel and watches `previousBalanceWasZero`,
-    // a field that resets to true on every VM init — so on every reopen of
-    // a funded-but-unsecured wallet the first balance emission (already > 0
-    // from the cached/synced state) re-trips the condition and the dialog
-    // returns.
-    //
-    // Persisting "already shown" per-wallet means each wallet sees the dialog
-    // exactly once. If the user secures the wallet later, the regular trigger
-    // condition (`!hasPin || !hasBackup`) would be false anyway.
-
-    fun isPostDepositReminderShown(walletId: String): Boolean {
-        return prefs.getBoolean(postDepositReminderKey(walletId), false)
-    }
-
-    fun setPostDepositReminderShown(walletId: String) {
-        prefs.edit().putBoolean(postDepositReminderKey(walletId), true).apply()
-    }
-
-    private fun postDepositReminderKey(walletId: String): String =
-        "${KEY_POST_DEPOSIT_REMINDER_SHOWN_PREFIX}$walletId"
-
     // --- Database maintenance ---
 
     fun getLastVacuumAt(): Long = prefs.getLong(KEY_LAST_VACUUM_AT, 0L)
@@ -337,7 +312,6 @@ class WalletPreferences @Inject constructor(
         private const val KEY_SYNC_STRATEGY = "sync_strategy"
         private const val KEY_THEME_MODE = "theme_mode"
         private const val KEY_BACKGROUND_SYNC = "background_sync_enabled"
-        private const val KEY_POST_DEPOSIT_REMINDER_SHOWN_PREFIX = "post_deposit_reminder_shown_"
         private const val KEY_LAST_VACUUM_AT = "last_vacuum_at"
         private const val KEY_SYNC_PROGRESS_MIGRATED = "sync_progress_migrated_to_room_v7"
         private const val KEY_SYNC_COACHMARK_SEEN = "sync_coachmark_seen"

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/home/HomeScreen.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/home/HomeScreen.kt
@@ -292,31 +292,6 @@ fun HomeScreen(
         )
     }
 
-    // Post-deposit security reminder
-    if (uiState.showPostDepositReminder) {
-        AlertDialog(
-            onDismissRequest = { viewModel.dismissPostDepositReminder() },
-            title = { Text("Protect your funds") },
-            text = {
-                Text(
-                    "You now have funds in this wallet. Set up a PIN and write down " +
-                        "your recovery phrase to protect them."
-                )
-            },
-            confirmButton = {
-                Button(onClick = {
-                    viewModel.dismissPostDepositReminder()
-                    onNavigateToSecurityChecklist()
-                }) { Text("Secure now") }
-            },
-            dismissButton = {
-                TextButton(onClick = { viewModel.dismissPostDepositReminder() }) {
-                    Text("Later")
-                }
-            }
-        )
-    }
-
     LaunchedEffect(uiState.error) {
         uiState.error?.let { error ->
             snackbarHostState.showSnackbar(error)

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/home/HomeViewModel.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/home/HomeViewModel.kt
@@ -110,8 +110,6 @@ class HomeViewModel @Inject constructor(
     private val _navEvents = Channel<HomeNavEvent>(Channel.BUFFERED)
     val navEvents = _navEvents.receiveAsFlow()
 
-    private var previousBalanceWasZero = true
-
     // Tracks the last successful CKB/USD fetch so we can throttle
     // refresh-on-foreground and the 5-min ticker (#117 deferred items).
     private var lastPriceFetchAt: Long = 0L
@@ -179,25 +177,6 @@ class HomeViewModel @Inject constructor(
                         fiatBalance = fiat ?: current.fiatBalance
                     )
                 }
-                // Post-deposit reminder: trigger when balance goes from zero to
-                // non-zero and the wallet is not fully secured. Per-wallet
-                // "already shown" flag prevents the dialog from re-appearing on
-                // every VM init for an already-funded unsecured wallet — the
-                // `previousBalanceWasZero` field always starts true on init, so
-                // without persistence the cached/synced balance emission re-trips
-                // the condition every reopen. (#116)
-                val hasPin = _uiState.value.hasPinOrBiometrics
-                val hasBackup = _uiState.value.hasMnemonicBackup
-                val activeId = _uiState.value.wallets.find { it.isActive }?.walletId.orEmpty()
-                val alreadyShown = activeId.isNotEmpty()
-                    && walletPreferences.isPostDepositReminderShown(activeId)
-                if (previousBalanceWasZero && ckb > 0.0 && (!hasPin || !hasBackup) && !alreadyShown) {
-                    if (activeId.isNotEmpty()) {
-                        walletPreferences.setPostDepositReminderShown(activeId)
-                    }
-                    _uiState.update { it.copy(showPostDepositReminder = true) }
-                }
-                previousBalanceWasZero = (ckb == 0.0)
             }
         }
 
@@ -626,10 +605,6 @@ class HomeViewModel @Inject constructor(
         _uiState.update { it.copy(showBackupReminder = false) }
     }
 
-    fun dismissPostDepositReminder() {
-        _uiState.update { it.copy(showPostDepositReminder = false) }
-    }
-
     fun toggleBalanceVisibility() {
         _uiState.update { it.copy(isBalanceHidden = !it.isBalanceHidden) }
     }
@@ -897,7 +872,6 @@ data class HomeUiState(
     val showInstallPermissionNeeded: Boolean = false,
     val hasPinOrBiometrics: Boolean = false,
     val hasMnemonicBackup: Boolean = false,
-    val showPostDepositReminder: Boolean = false,
     val isSwitchingWallet: Boolean = false,
     val savedCustomBlockHeight: Long? = null,
     val walletBalances: Map<String, String> = emptyMap(),


### PR DESCRIPTION
## Summary
- Drop the post-deposit "Protect your funds" `AlertDialog` from the home screen.
- Remove the trigger logic + `previousBalanceWasZero` field in `HomeViewModel`, the per-wallet "already shown" persistence in `WalletPreferences`, and the `showPostDepositReminder` UI state field.
- Banner on the home card and the existing security checklist flow remain — those are the persistent backup-reminder surface.

## Test plan
- [x] `./gradlew :app:compileDebugKotlin` clean
- [x] `./gradlew testDebugUnitTest` passes
- [ ] Manual smoke: send funds to a fresh unsecured wallet, verify no dialog appears, banner still surfaces backup CTA

Closes #151