### PR TITLE
feat(update): source releases URL from BuildConfig + self-check (#142B)

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -20,6 +20,18 @@ android {
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 
+        // GitHub Releases API URL for auto-update. Sourced from BuildConfig so
+        // the canonical repo identity is reviewed alongside versionCode/
+        // versionName at release time, not buried in a Kotlin constant. v1.5.0
+        // + v1.5.1 shipped with a stale fork URL — this guard makes that class
+        // of regression visible in build.gradle.kts diffs and pairs with a
+        // unit test that asserts the URL shape (#142B).
+        buildConfigField(
+            "String",
+            "RELEASES_API_URL",
+            "\"https://api.github.com/repos/RaheemJnr/pocket-node/releases/latest\""
+        )
+
         // Only include ARM ABIs — x86_64 is emulator-only and adds ~29 MB.
         // CI's upgrade-smoke harness opts in via BUILD_X86_64=1 (matched in
         // external/ckb-light-client/build-android-jni.sh).

--- a/android/app/src/main/java/com/rjnr/pocketnode/data/update/UpdateRepository.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/update/UpdateRepository.kt
@@ -1,6 +1,7 @@
 package com.rjnr.pocketnode.data.update
 
 import android.util.Log
+import com.rjnr.pocketnode.BuildConfig
 import io.ktor.client.HttpClient
 import io.ktor.client.request.get
 import io.ktor.client.request.header
@@ -16,8 +17,9 @@ private const val TAG = "UpdateRepository"
 // stale fork URL (`AgustaRC/ckb-wallet-gateway`) that 404s, so the in-app
 // "new version available" notification never fired. Users on those releases
 // must manually grab v1.5.2 once; auto-update works from v1.5.2 onward.
-private const val GITHUB_API_URL =
-    "https://api.github.com/repos/RaheemJnr/pocket-node/releases/latest"
+// Now sourced from BuildConfig (#142B) so the canonical repo identity is
+// reviewed alongside versionCode/versionName.
+private val GITHUB_API_URL: String = BuildConfig.RELEASES_API_URL
 
 @Serializable
 internal data class GitHubReleaseAsset(

--- a/android/app/src/test/java/com/rjnr/pocketnode/data/update/UpdateRepositoryTest.kt
+++ b/android/app/src/test/java/com/rjnr/pocketnode/data/update/UpdateRepositoryTest.kt
@@ -1,5 +1,6 @@
 package com.rjnr.pocketnode.data.update
 
+import com.rjnr.pocketnode.BuildConfig
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
@@ -67,5 +68,31 @@ class UpdateRepositoryTest {
     fun `findApkAsset returns null for empty list`() {
         val result = UpdateRepository.findApkAsset(emptyList())
         assertNull(result)
+    }
+
+    // --- BuildConfig.RELEASES_API_URL self-check (#142B) ---
+    // Guards against a future typo or rebase mishap reintroducing the
+    // v1.5.0/v1.5.1 regression where the auto-update poll targeted the wrong
+    // GitHub repo. Build-time string lives in app/build.gradle.kts; if either
+    // diverges, this test fails.
+
+    @Test
+    fun `RELEASES_API_URL targets the canonical project repo`() {
+        assertEquals(
+            "https://api.github.com/repos/RaheemJnr/pocket-node/releases/latest",
+            BuildConfig.RELEASES_API_URL
+        )
+    }
+
+    @Test
+    fun `RELEASES_API_URL is a GitHub releases-latest endpoint`() {
+        assertTrue(
+            "RELEASES_API_URL must point at GitHub's releases-latest endpoint",
+            BuildConfig.RELEASES_API_URL.startsWith("https://api.github.com/repos/")
+        )
+        assertTrue(
+            "RELEASES_API_URL must end with /releases/latest",
+            BuildConfig.RELEASES_API_URL.endsWith("/releases/latest")
+        )
     }
 }


### PR DESCRIPTION
## Summary
- Move the GitHub releases URL out of `UpdateRepository.kt` and into a `buildConfigField` in `app/build.gradle.kts`, so the canonical repo identity is reviewed at release prep alongside `versionCode` / `versionName`.
- `UpdateRepository.GITHUB_API_URL` now reads `BuildConfig.RELEASES_API_URL`.
- Add two unit tests asserting the URL points at `RaheemJnr/pocket-node/releases/latest` and is a `/releases/latest` endpoint — guards against the v1.5.0/v1.5.1 fork-URL regression resurfacing.

## Test plan
- [x] `./gradlew testDebugUnitTest --tests "com.rjnr.pocketnode.data.update.UpdateRepositoryTest"` passes
- [x] Manual: invert the URL in `build.gradle.kts`, confirm both new tests fail.

Part of #142 (B). Closes the auto-update URL portion of #142; schema-export portion remains blocked on #149.