### PR TITLE
feat(home): peers indicator → NodeStatus shortcut (#131)

### DIFF
--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/MainScreen.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/MainScreen.kt
@@ -92,6 +92,7 @@ fun MainScreen(
                     onNavigateToBackup = onNavigateToBackup,
                     onNavigateToSecurityChecklist = onNavigateToSecurityChecklist,
                     onNavigateToWalletManager = onNavigateToWalletManager,
+                    onNavigateToNodeStatus = onNavigateToNodeStatus,
                     onNavigateToDao = {
                         innerNav.navigate(BottomTab.DAO.route) {
                             popUpTo(innerNav.graph.findStartDestination().id) {

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/home/Components.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/home/Components.kt
@@ -63,7 +63,8 @@ fun WalletBalanceCard(
     peerCount: Int,
     isBalanceHidden: Boolean = false,
     onToggleVisibility: () -> Unit = {},
-    onCopyAddress: () -> Unit
+    onCopyAddress: () -> Unit,
+    onPeersClick: () -> Unit = {}
 ) {
     Surface(
         color = MaterialTheme.colorScheme.surface,
@@ -145,19 +146,33 @@ fun WalletBalanceCard(
                         )
                     }
                 }
-                Row(verticalAlignment = Alignment.CenterVertically) {
-                    Icon(
-                        Lucide.Users,
-                        contentDescription = null,
-                        tint = if (peerCount > 0) MaterialTheme.colorScheme.primary else PendingAmber,
-                        modifier = Modifier.size(14.dp)
-                    )
-                    Spacer(modifier = Modifier.width(8.dp))
-                    Text(
-                        text = "$peerCount peers connected",
-                        style = MaterialTheme.typography.bodySmall,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant
-                    )
+                // Tappable shortcut to NodeStatus — same affordance shape as
+                // the address copy chip so the row reads as two parallel
+                // actions (#131).
+                Surface(
+                    color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.05f),
+                    shape = RoundedCornerShape(12.dp)
+                ) {
+                    Row(
+                        modifier = Modifier
+                            .clickable(onClick = onPeersClick)
+                            .padding(horizontal = 12.dp, vertical = 8.dp)
+                            .uaTestTag("home-peers-shortcut"),
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        Icon(
+                            Lucide.Users,
+                            contentDescription = null,
+                            tint = if (peerCount > 0) MaterialTheme.colorScheme.primary else PendingAmber,
+                            modifier = Modifier.size(14.dp)
+                        )
+                        Spacer(modifier = Modifier.width(8.dp))
+                        Text(
+                            text = "$peerCount peers connected",
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                    }
                 }
             }
         }

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/home/HomeScreen.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/home/HomeScreen.kt
@@ -123,6 +123,7 @@ fun HomeScreen(
     onNavigateToWalletManager: () -> Unit = {},
     onNavigateToSecurityChecklist: () -> Unit = {},
     onNavigateToFaq: (anchor: String?) -> Unit = {},
+    onNavigateToNodeStatus: () -> Unit = {},
     viewModel: HomeViewModel = hiltViewModel()
 ) {
     val uiState by viewModel.uiState.collectAsState()
@@ -486,6 +487,7 @@ fun HomeScreen(
                     onNavigateToDao = onNavigateToDao,
                     onNavigateToActivity = onNavigateToActivity,
                     onNavigateToSecurityChecklist = onNavigateToSecurityChecklist,
+                    onNavigateToNodeStatus = onNavigateToNodeStatus,
                     dismissBackupReminder = { viewModel.dismissBackupReminder() },
                     onToggleBalanceVisibility = { viewModel.toggleBalanceVisibility() },
                     clipboardManager = clipboardManager,
@@ -552,6 +554,7 @@ fun HomeScreenUI(
     onNavigateToDao: () -> Unit = {},
     onNavigateToActivity: () -> Unit = {},
     onNavigateToSecurityChecklist: () -> Unit = {},
+    onNavigateToNodeStatus: () -> Unit = {},
     dismissBackupReminder: () -> Unit,
     onToggleBalanceVisibility: () -> Unit,
     clipboardManager: androidx.compose.ui.platform.ClipboardManager,
@@ -609,6 +612,7 @@ fun HomeScreenUI(
                     peerCount = uiState.peerCount,
                     isBalanceHidden = uiState.isBalanceHidden,
                     onToggleVisibility = onToggleBalanceVisibility,
+                    onPeersClick = onNavigateToNodeStatus,
                     onCopyAddress = {
                         clipboardManager.setText(AnnotatedString(uiState.address))
                         scope.launch {


### PR DESCRIPTION
## Summary
- The Users icon + "N peers connected" row on the home wallet card is now a tappable shortcut to the NodeStatus screen.
- Mirrors the address-copy chip styling so the row reads as two parallel actions.
- New `onPeersClick` param on `WalletBalanceCard` and `onNavigateToNodeStatus` param threaded through `HomeScreen` → `HomeScreenUI`, hooked up in `MainScreen` to the existing nav callback that Settings already uses.

## Test plan
- [x] `./gradlew :app:compileDebugKotlin` clean
- [x] `./gradlew testDebugUnitTest` passes
- [ ] Manual: tap peers row on home, lands on NodeStatus; back button returns to home

Closes #131

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The peers indicator on your wallet balance card is now fully interactive and clickable. Tap it to quickly navigate to detailed node status information. The indicator has been redesigned as a convenient shortcut element, styled to match other quick-action features on the card for a cohesive experience.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/RaheemJnr/pocket-node/pull/171?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->