### PR TITLE
feat(settings): debug build pill + git SHA in version row

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -32,6 +32,17 @@ android {
             "\"https://api.github.com/repos/RaheemJnr/pocket-node/releases/latest\""
         )
 
+        // Short git SHA injected at build time so debug APKs can be traced
+        // back to the exact commit they were built from. Surfaced in the
+        // Settings → Version row as part of the [DEBUG • abc1234] pill.
+        // Falls back to "unknown" on shallow clones or when git is absent.
+        val gitSha = runCatching {
+            providers.exec {
+                commandLine("git", "rev-parse", "--short", "HEAD")
+            }.standardOutput.asText.get().trim()
+        }.getOrDefault("unknown")
+        buildConfigField("String", "GIT_SHA", "\"$gitSha\"")
+
         // Only include ARM ABIs — x86_64 is emulator-only and adds ~29 MB.
         // CI's upgrade-smoke harness opts in via BUILD_X86_64=1 (matched in
         // external/ckb-light-client/build-android-jni.sh).

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/settings/SettingsScreen.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/settings/SettingsScreen.kt
@@ -12,6 +12,7 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -522,7 +523,10 @@ private fun SettingsScreenUI(
                     icon = Lucide.Info,
                     title = "Version",
                     value = BuildConfig.VERSION_NAME,
-                    onClick = null
+                    onClick = null,
+                    trailing = if (BuildConfig.DEBUG) {
+                        { DebugBuildPill(gitSha = BuildConfig.GIT_SHA) }
+                    } else null
                 )
             }
 
@@ -662,7 +666,8 @@ fun SettingsValueRow(
     title: String,
     value: String,
     onClick: (() -> Unit)?,
-    valueColor: Color = MaterialTheme.colorScheme.primary
+    valueColor: Color = MaterialTheme.colorScheme.primary,
+    trailing: (@Composable RowScope.() -> Unit)? = null
 ) {
     Row(
         modifier = Modifier
@@ -689,14 +694,41 @@ fun SettingsValueRow(
                 fontWeight = FontWeight.Medium
             )
         }
-        Text(
-            value,
-            color = valueColor,
-            fontSize = 14.sp,
-            fontWeight = FontWeight.Medium
-        )
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Text(
+                value,
+                color = valueColor,
+                fontSize = 14.sp,
+                fontWeight = FontWeight.Medium
+            )
+            if (trailing != null) {
+                Spacer(modifier = Modifier.width(8.dp))
+                trailing()
+            }
+        }
     }
     HorizontalDivider(color = MaterialTheme.colorScheme.surfaceVariant, thickness = 1.dp)
+}
+
+/**
+ * Pill rendered in the Settings → Version row of debug builds only. Shows
+ * "DEBUG • <short SHA>" so testers can report exactly which commit they're
+ * running. Hidden in release per `BuildConfig.DEBUG`.
+ */
+@Composable
+fun DebugBuildPill(gitSha: String) {
+    Surface(
+        color = MaterialTheme.colorScheme.errorContainer,
+        shape = RoundedCornerShape(100.dp)
+    ) {
+        Text(
+            text = "DEBUG • $gitSha",
+            modifier = Modifier.padding(horizontal = 10.dp, vertical = 2.dp),
+            color = MaterialTheme.colorScheme.onErrorContainer,
+            fontSize = 11.sp,
+            fontWeight = FontWeight.Bold
+        )
+    }
 }
 
 @Composable


### PR DESCRIPTION
## Summary
- Adds a `[DEBUG • <short SHA>]` pill next to the version string in Settings → About → Version, rendered only when `BuildConfig.DEBUG == true`. Release builds show the unchanged row.
- Short git SHA injected at configuration time via a new `BuildConfig.GIT_SHA` buildConfigField. Falls back to `"unknown"` on shallow clones or when git is absent.
- `SettingsValueRow` grows an optional `trailing: (@Composable RowScope.() -> Unit)?` slot to host the pill without duplicating row layout.
- `DebugBuildPill` styled with `errorContainer`/`onErrorContainer` so it reads as a non-release affordance.

## Why
Testers reporting bugs on debug APKs couldn't tell us exactly which commit they were running. With the SHA pinned in the version row, repros are one screenshot away from a precise commit ref.

## Test plan
- [x] `./gradlew :app:compileDebugKotlin` clean
- [x] `./gradlew testDebugUnitTest` passes
- [x] Generated `BuildConfig.GIT_SHA` populated to the current short SHA at build time
- [ ] Manual: install debug APK, open Settings, confirm `[DEBUG • <sha>]` pill renders next to version
- [ ] Manual: install release APK, open Settings, confirm no pill (just the version string)