### PR TITLE
fix(update): Telegram-style banner + Ktor downloader + permission resume

### DIFF
--- a/android/app/src/main/java/com/rjnr/pocketnode/data/update/UpdateDownloader.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/update/UpdateDownloader.kt
@@ -1,120 +1,215 @@
 package com.rjnr.pocketnode.data.update
 
-import android.app.DownloadManager
-import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
-import android.content.IntentFilter
 import android.net.Uri
-import android.os.Build
 import android.os.Environment
 import android.provider.Settings
 import android.util.Log
 import androidx.core.content.FileProvider
 import dagger.hilt.android.qualifiers.ApplicationContext
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.android.Android
+import io.ktor.client.plugins.HttpRequestTimeoutException
+import io.ktor.client.plugins.HttpTimeout
+import io.ktor.client.plugins.onDownload
+import io.ktor.client.request.prepareGet
+import io.ktor.client.statement.bodyAsChannel
+import io.ktor.utils.io.ByteReadChannel
+import io.ktor.utils.io.readAvailable
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
 import java.io.File
 import javax.inject.Inject
 import javax.inject.Singleton
 
 private const val TAG = "UpdateDownloader"
 private const val APK_FILE_NAME = "pocket-node-update.apk"
+private const val DOWNLOAD_BUFFER_BYTES = 16 * 1024
+
+/**
+ * Visible states for the auto-update download flow. HomeScreen + the
+ * persistent banner above the bottom nav observe this StateFlow and render
+ * Telegram-style progress in place of the previous silent-system-download
+ * experience.
+ */
+sealed class DownloadState {
+    data object Idle : DownloadState()
+    data class Downloading(val bytesDownloaded: Long, val totalBytes: Long) : DownloadState()
+
+    /**
+     * Download finished and the APK is on disk. Install has NOT been
+     * triggered yet — the user has to tap the banner. This is the Telegram
+     * pattern: download silently, surface an "Update" CTA, only fire the
+     * system installer on explicit tap.
+     */
+    data object ReadyToInstall : DownloadState()
+
+    /** Brief state right after the user taps install while the package installer foregrounds. */
+    data object Installing : DownloadState()
+
+    data class Failed(val reason: String) : DownloadState()
+}
 
 @Singleton
 class UpdateDownloader @Inject constructor(
     @ApplicationContext private val context: Context
 ) {
-    private var downloadId: Long = -1L
-    private var receiver: BroadcastReceiver? = null
+    // Standalone scope, not tied to a single ViewModel. A download started
+    // from HomeScreen needs to keep running while the user navigates around.
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+    private var downloadJob: Job? = null
 
     /**
-     * Whether the user has granted permission to install from unknown sources.
+     * Dedicated client with a generous socket timeout. The shared HttpClient
+     * provided by AppModule uses 10s read/socket timeouts which are fine for
+     * tiny JSON polls but trip on a 39 MB APK over GitHub → S3 redirects.
+     * This client lives for the app lifetime; we install only the timeout
+     * plugin and nothing else (no JSON, no content negotiation).
      */
-    fun canInstallPackages(): Boolean {
-        return context.packageManager.canRequestPackageInstalls()
+    private val httpClient: HttpClient by lazy {
+        HttpClient(Android) {
+            install(HttpTimeout) {
+                connectTimeoutMillis = 15_000
+                requestTimeoutMillis = 10 * 60_000  // 10 min total budget
+                socketTimeoutMillis = 60_000        // 1 min of idle is OK
+            }
+            followRedirects = true
+            expectSuccess = false
+        }
+    }
+
+    private val _state = MutableStateFlow<DownloadState>(DownloadState.Idle)
+    val state: StateFlow<DownloadState> = _state.asStateFlow()
+
+    init {
+        // Reclaim disk on process start. After a successful install the new
+        // app process boots, this init runs, and the stale ~39 MB APK we left
+        // in externalFilesDir gets dropped. Failed/cancelled installs that
+        // happened in the previous process are also collected here.
+        cleanupStaleApk()
+    }
+
+    /** True if the user has granted "install from unknown sources" for Pocket Node. */
+    fun canInstallPackages(): Boolean = context.packageManager.canRequestPackageInstalls()
+
+    /** Settings intent that opens the install-from-unknown-sources screen for this app. */
+    fun getInstallPermissionIntent(): Intent = Intent(
+        Settings.ACTION_MANAGE_UNKNOWN_APP_SOURCES,
+        Uri.parse("package:${context.packageName}")
+    )
+
+    fun resetState() {
+        _state.value = DownloadState.Idle
     }
 
     /**
-     * Returns an intent that opens the system settings for allowing installs from this app.
+     * Stream an APK from [apkUrl] using Ktor. Emits [DownloadState.Downloading]
+     * on every read tick so the banner can update in lockstep. Does not auto-
+     * launch the installer: when bytes are fully on disk we transition to
+     * [DownloadState.ReadyToInstall] and wait for the user to tap the banner.
+     *
+     * Replaces the prior DownloadManager-based implementation that froze at
+     * ~87-95% on emulator + real handsets and gave no programmatic visibility
+     * into why. Ktor streams chunk-by-chunk on our scope; cancellation is
+     * trivial via Job.cancel.
      */
-    fun getInstallPermissionIntent(): Intent {
-        return Intent(
-            Settings.ACTION_MANAGE_UNKNOWN_APP_SOURCES,
-            Uri.parse("package:${context.packageName}")
-        )
-    }
-
-    /**
-     * Downloads the APK from [apkUrl] using DownloadManager and installs it when complete.
-     */
-    fun downloadAndInstall(apkUrl: String) {
+    fun downloadAndInstall(apkUrl: String, totalBytesHint: Long = -1L) {
         cleanup()
+        _state.value = DownloadState.Downloading(0L, totalBytesHint.coerceAtLeast(0L))
 
-        val downloadManager = context.getSystemService(Context.DOWNLOAD_SERVICE) as DownloadManager
+        downloadJob = scope.launch {
+            val apkFile = File(
+                context.getExternalFilesDir(Environment.DIRECTORY_DOWNLOADS),
+                APK_FILE_NAME
+            )
+            apkFile.parentFile?.mkdirs()
+            // Wipe any partial file from a prior aborted attempt.
+            if (apkFile.exists()) apkFile.delete()
 
-        val request = DownloadManager.Request(Uri.parse(apkUrl))
-            .setTitle("Pocket Node Update")
-            .setDescription("Downloading latest version...")
-            .setNotificationVisibility(DownloadManager.Request.VISIBILITY_VISIBLE_NOTIFY_COMPLETED)
-            .setDestinationInExternalFilesDir(context, Environment.DIRECTORY_DOWNLOADS, APK_FILE_NAME)
-
-        downloadId = downloadManager.enqueue(request)
-        Log.d(TAG, "Download enqueued: id=$downloadId")
-
-        receiver = object : BroadcastReceiver() {
-            override fun onReceive(ctx: Context, intent: Intent) {
-                val id = intent.getLongExtra(DownloadManager.EXTRA_DOWNLOAD_ID, -1)
-                if (id != downloadId) return
-
-                try {
-                    val query = DownloadManager.Query().setFilterById(downloadId)
-                    downloadManager.query(query).use { cursor ->
-                        if (cursor.moveToFirst()) {
-                            val statusIndex = cursor.getColumnIndex(DownloadManager.COLUMN_STATUS)
-                            val status = cursor.getInt(statusIndex)
-                            if (status == DownloadManager.STATUS_SUCCESSFUL) {
-                                Log.d(TAG, "Download complete, installing APK")
-                                installApk()
-                            } else {
-                                Log.w(TAG, "Download finished with status: $status")
-                            }
+            try {
+                httpClient.prepareGet(apkUrl) {
+                    // onDownload fires on every chunk Ktor reads from the
+                    // network. contentLength may be null for chunked
+                    // transfer-encoded responses; in that case we keep
+                    // showing an indeterminate bar and just count bytes.
+                    onDownload { bytesSoFar, contentLength ->
+                        val total = contentLength ?: totalBytesHint
+                        _state.value = DownloadState.Downloading(
+                            bytesDownloaded = bytesSoFar,
+                            totalBytes = total.coerceAtLeast(0L),
+                        )
+                    }
+                }.execute { response ->
+                    val channel: ByteReadChannel = response.bodyAsChannel()
+                    apkFile.outputStream().use { out ->
+                        val buf = ByteArray(DOWNLOAD_BUFFER_BYTES)
+                        while (!channel.isClosedForRead) {
+                            val read = channel.readAvailable(buf, 0, buf.size)
+                            if (read <= 0) break
+                            out.write(buf, 0, read)
                         }
+                        out.flush()
                     }
-                } finally {
-                    try {
-                        context.unregisterReceiver(this)
-                    } catch (e: IllegalArgumentException) {
-                        // Already unregistered
-                    }
-                    receiver = null
                 }
+                Log.d(TAG, "Download complete: ${apkFile.length()} bytes")
+                _state.value = DownloadState.ReadyToInstall
+            } catch (e: CancellationException) {
+                Log.d(TAG, "Download cancelled")
+                if (apkFile.exists()) apkFile.delete()
+                _state.value = DownloadState.Idle
+                throw e
+            } catch (e: HttpRequestTimeoutException) {
+                Log.w(TAG, "Download timed out", e)
+                if (apkFile.exists()) apkFile.delete()
+                _state.value = DownloadState.Failed("Download timed out. Tap retry.")
+            } catch (e: Exception) {
+                Log.w(TAG, "Download failed", e)
+                if (apkFile.exists()) apkFile.delete()
+                _state.value = DownloadState.Failed(e.message ?: "Download failed")
             }
         }
-
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-            context.registerReceiver(
-                receiver,
-                IntentFilter(DownloadManager.ACTION_DOWNLOAD_COMPLETE),
-                Context.RECEIVER_NOT_EXPORTED
-            )
-        } else {
-            @Suppress("UnspecifiedRegisterReceiverFlag")
-            context.registerReceiver(
-                receiver,
-                IntentFilter(DownloadManager.ACTION_DOWNLOAD_COMPLETE)
-            )
-        }
     }
 
     /**
-     * Installs the downloaded APK via a FileProvider content URI.
+     * Called from the banner when the user taps Update on a finished
+     * download. Launches the system package installer.
      */
-    private fun installApk() {
+    fun installNow() {
+        if (_state.value !is DownloadState.ReadyToInstall) return
+        _state.value = DownloadState.Installing
+        launchSystemInstaller()
+    }
+
+    /**
+     * Cancel an in-progress download. Removes any partial APK file.
+     */
+    fun cancel() {
+        downloadJob?.cancel()
+        downloadJob = null
+        val apkFile = File(
+            context.getExternalFilesDir(Environment.DIRECTORY_DOWNLOADS),
+            APK_FILE_NAME
+        )
+        if (apkFile.exists()) apkFile.delete()
+        _state.value = DownloadState.Idle
+    }
+
+    private fun launchSystemInstaller() {
         val apkFile = File(
             context.getExternalFilesDir(Environment.DIRECTORY_DOWNLOADS),
             APK_FILE_NAME
         )
         if (!apkFile.exists()) {
             Log.e(TAG, "APK file not found at ${apkFile.absolutePath}")
+            _state.value = DownloadState.Failed("APK file not found after download")
             return
         }
 
@@ -123,7 +218,6 @@ class UpdateDownloader @Inject constructor(
             "${context.packageName}.fileprovider",
             apkFile
         )
-
         val installIntent = Intent(Intent.ACTION_VIEW).apply {
             setDataAndType(apkUri, "application/vnd.android.package-archive")
             addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
@@ -133,27 +227,37 @@ class UpdateDownloader @Inject constructor(
     }
 
     /**
-     * Cleans up any previous download artifacts and unregisters the receiver.
+     * Drop any in-progress job and partial APK without changing the public
+     * state. Called before a fresh [downloadAndInstall] to keep the
+     * singleton's invariants clean across retries.
      */
     fun cleanup() {
-        // Unregister any pending receiver
-        receiver?.let {
-            try {
-                context.unregisterReceiver(it)
-            } catch (e: IllegalArgumentException) {
-                // Already unregistered
-            }
-            receiver = null
-        }
+        downloadJob?.cancel()
+        downloadJob = null
+        cleanupStaleApk()
+    }
 
-        // Delete any existing APK file
+    /**
+     * Called when the activity resumes after we sent the user to the
+     * system installer. If the state is still [DownloadState.Installing]
+     * the user has come back without completing install (cancelled or
+     * fatal error like the signing-mismatch screen). Clear state and
+     * delete the on-disk APK so we are not holding ~39 MB indefinitely.
+     */
+    fun onInstallerReturned() {
+        if (_state.value !is DownloadState.Installing) return
+        _state.value = DownloadState.Idle
+        cleanupStaleApk()
+    }
+
+    private fun cleanupStaleApk() {
         val apkFile = File(
             context.getExternalFilesDir(Environment.DIRECTORY_DOWNLOADS),
             APK_FILE_NAME
         )
         if (apkFile.exists()) {
             val deleted = apkFile.delete()
-            Log.d(TAG, "Cleaned up previous APK: deleted=$deleted")
+            Log.d(TAG, "cleanupStaleApk: deleted=$deleted size=${apkFile.length()}")
         }
     }
 }

--- a/android/app/src/main/java/com/rjnr/pocketnode/data/update/UpdateDownloader.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/update/UpdateDownloader.kt
@@ -22,11 +22,13 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import java.io.File
+import java.io.IOException
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -89,6 +91,12 @@ class UpdateDownloader @Inject constructor(
     private val _state = MutableStateFlow<DownloadState>(DownloadState.Idle)
     val state: StateFlow<DownloadState> = _state.asStateFlow()
 
+    // Cached download arguments so a Failed → Retry tap can restart the
+    // same download without forcing the user back through the version
+    // dialog. Cleared after a successful queue and on resetState.
+    private var lastApkUrl: String? = null
+    private var lastTotalBytesHint: Long = -1L
+
     init {
         // Reclaim disk on process start. After a successful install the new
         // app process boots, this init runs, and the stale ~39 MB APK we left
@@ -108,6 +116,18 @@ class UpdateDownloader @Inject constructor(
 
     fun resetState() {
         _state.value = DownloadState.Idle
+        lastApkUrl = null
+        lastTotalBytesHint = -1L
+    }
+
+    /**
+     * Re-run the last attempted download. Called from the banner's "Tap
+     * to retry" affordance on the Failed state. Bails silently if no
+     * download has ever been queued (no URL cached).
+     */
+    fun retry() {
+        val url = lastApkUrl ?: return
+        downloadAndInstall(apkUrl = url, totalBytesHint = lastTotalBytesHint)
     }
 
     /**
@@ -122,17 +142,27 @@ class UpdateDownloader @Inject constructor(
      * trivial via Job.cancel.
      */
     fun downloadAndInstall(apkUrl: String, totalBytesHint: Long = -1L) {
-        cleanup()
-        _state.value = DownloadState.Downloading(0L, totalBytesHint.coerceAtLeast(0L))
+        // Remember args for Retry. Set before the launch so a quick
+        // Failed→Retry cycle finds the URL even if the job's catch block
+        // has not run yet.
+        lastApkUrl = apkUrl
+        lastTotalBytesHint = totalBytesHint
 
-        downloadJob = scope.launch {
+        // Capture and replace the previous job atomically. The new job
+        // awaits the old one's cancellation before touching the APK path,
+        // so the old coroutine's CancellationException handler cannot
+        // delete the file the new run wrote (race noted in PR #175 review).
+        val previousJob = downloadJob
+        val newJob = scope.launch {
+            previousJob?.cancelAndJoin()
+            cleanupStaleApk()
+            _state.value = DownloadState.Downloading(0L, totalBytesHint.coerceAtLeast(0L))
+
             val apkFile = File(
                 context.getExternalFilesDir(Environment.DIRECTORY_DOWNLOADS),
                 APK_FILE_NAME
             )
             apkFile.parentFile?.mkdirs()
-            // Wipe any partial file from a prior aborted attempt.
-            if (apkFile.exists()) apkFile.delete()
 
             try {
                 httpClient.prepareGet(apkUrl) {
@@ -148,6 +178,15 @@ class UpdateDownloader @Inject constructor(
                         )
                     }
                 }.execute { response ->
+                    // expectSuccess = false on this client, so non-2xx
+                    // responses arrive here as plain HttpResponse. Without
+                    // this check, a 404/403 HTML error page would be
+                    // written to apkFile and we would mark it ReadyToInstall
+                    // — surfacing a malformed APK to the system installer.
+                    val status = response.status.value
+                    if (status !in 200..299) {
+                        throw IOException("Update download failed with HTTP $status")
+                    }
                     val channel: ByteReadChannel = response.bodyAsChannel()
                     apkFile.outputStream().use { out ->
                         val buf = ByteArray(DOWNLOAD_BUFFER_BYTES)
@@ -164,7 +203,10 @@ class UpdateDownloader @Inject constructor(
             } catch (e: CancellationException) {
                 Log.d(TAG, "Download cancelled")
                 if (apkFile.exists()) apkFile.delete()
-                _state.value = DownloadState.Idle
+                // Do not touch _state here. If a newer download has already
+                // started, it owns the state; resetting to Idle would clear
+                // the replacement banner. The fresh job sets Downloading at
+                // its start, overwriting any stale Idle anyway.
                 throw e
             } catch (e: HttpRequestTimeoutException) {
                 Log.w(TAG, "Download timed out", e)
@@ -176,6 +218,7 @@ class UpdateDownloader @Inject constructor(
                 _state.value = DownloadState.Failed(e.message ?: "Download failed")
             }
         }
+        downloadJob = newJob
     }
 
     /**
@@ -194,6 +237,8 @@ class UpdateDownloader @Inject constructor(
     fun cancel() {
         downloadJob?.cancel()
         downloadJob = null
+        lastApkUrl = null
+        lastTotalBytesHint = -1L
         val apkFile = File(
             context.getExternalFilesDir(Environment.DIRECTORY_DOWNLOADS),
             APK_FILE_NAME

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/MainScreen.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/MainScreen.kt
@@ -1,5 +1,6 @@
 package com.rjnr.pocketnode.ui
 
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
@@ -8,6 +9,8 @@ import androidx.compose.material3.NavigationBarItem
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
@@ -23,6 +26,7 @@ import com.composables.icons.lucide.Lock
 import com.composables.icons.lucide.Lucide
 import com.composables.icons.lucide.Settings
 import com.composables.icons.lucide.Wallet
+import com.rjnr.pocketnode.ui.components.UpdateProgressBanner
 import com.rjnr.pocketnode.ui.navigation.BottomTab
 import com.rjnr.pocketnode.ui.screens.activity.ActivityScreen
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -30,6 +34,7 @@ import com.rjnr.pocketnode.ui.screens.dao.DaoScreen
 import com.rjnr.pocketnode.ui.screens.home.HomeScreen
 import com.rjnr.pocketnode.ui.screens.settings.SettingsScreen
 import com.rjnr.pocketnode.ui.theme.CkbWalletTheme
+import com.rjnr.pocketnode.ui.update.UpdateBannerViewModel
 
 @Composable
 fun MainScreen(
@@ -49,32 +54,63 @@ fun MainScreen(
     val navBackStackEntry by innerNav.currentBackStackEntryAsState()
     val currentRoute = navBackStackEntry?.destination?.route
 
+    // Auto-update banner sits above the bottom navigation and reflects the
+    // singleton UpdateDownloader's state. Hilt scopes the VM to this
+    // composable; the underlying StateFlow is shared so the banner persists
+    // across tab switches.
+    val updateBannerVm: UpdateBannerViewModel = hiltViewModel()
+    val updateDownloadState by updateBannerVm.state.collectAsState()
+
+    // Clear "Installing…" state when the user returns from the system
+    // installer (cancelled, signing conflict, success, anything). The
+    // downloader also drops the on-disk APK here so we are not holding
+    // ~40 MB indefinitely between updates.
+    val lifecycleOwner = androidx.lifecycle.compose.LocalLifecycleOwner.current
+    DisposableEffect(lifecycleOwner) {
+        val observer = androidx.lifecycle.LifecycleEventObserver { _, event ->
+            if (event == androidx.lifecycle.Lifecycle.Event.ON_RESUME) {
+                updateBannerVm.onActivityResumed()
+            }
+        }
+        lifecycleOwner.lifecycle.addObserver(observer)
+        onDispose { lifecycleOwner.lifecycle.removeObserver(observer) }
+    }
+
     Scaffold(
         bottomBar = {
-            NavigationBar(
-                containerColor = MaterialTheme.colorScheme.surface
-            ) {
-                BottomTab.entries.forEach { tab ->
-                    val selected = currentRoute == tab.route
-                    NavigationBarItem(
-                        selected = selected,
-                        onClick = {
-                            innerNav.navigate(tab.route) {
-                                popUpTo(innerNav.graph.findStartDestination().id) {
-                                    saveState = true
+            Column {
+                UpdateProgressBanner(
+                    state = updateDownloadState,
+                    onInstallClick = { updateBannerVm.installNow() },
+                    onCancelClick = { updateBannerVm.cancel() },
+                    onRetryClick = { updateBannerVm.dismiss() },
+                    onDismissClick = { updateBannerVm.dismiss() },
+                )
+                NavigationBar(
+                    containerColor = MaterialTheme.colorScheme.surface
+                ) {
+                    BottomTab.entries.forEach { tab ->
+                        val selected = currentRoute == tab.route
+                        NavigationBarItem(
+                            selected = selected,
+                            onClick = {
+                                innerNav.navigate(tab.route) {
+                                    popUpTo(innerNav.graph.findStartDestination().id) {
+                                        saveState = true
+                                    }
+                                    launchSingleTop = true
+                                    restoreState = true
                                 }
-                                launchSingleTop = true
-                                restoreState = true
-                            }
-                        },
-                        icon = {
-                            Icon(
-                                imageVector = tabIcon(tab, selected),
-                                contentDescription = tab.label
-                            )
-                        },
-                        label = { Text(tab.label) }
-                    )
+                            },
+                            icon = {
+                                Icon(
+                                    imageVector = tabIcon(tab, selected),
+                                    contentDescription = tab.label
+                                )
+                            },
+                            label = { Text(tab.label) }
+                        )
+                    }
                 }
             }
         }

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/MainScreen.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/MainScreen.kt
@@ -83,7 +83,7 @@ fun MainScreen(
                     state = updateDownloadState,
                     onInstallClick = { updateBannerVm.installNow() },
                     onCancelClick = { updateBannerVm.cancel() },
-                    onRetryClick = { updateBannerVm.dismiss() },
+                    onRetryClick = { updateBannerVm.retry() },
                     onDismissClick = { updateBannerVm.dismiss() },
                 )
                 NavigationBar(

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/components/UpdateDialog.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/components/UpdateDialog.kt
@@ -68,7 +68,8 @@ fun InstallPermissionDialog(
         text = {
             Text(
                 "Android needs your permission to install updates for Pocket Node. " +
-                    "Open settings, toggle \"Allow from this source\" on, then come back and tap Update again."
+                    "Open settings, toggle \"Allow from this source\" on, then return to Pocket Node. " +
+                    "The update will resume automatically."
             )
         },
         confirmButton = {

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/components/UpdateDialog.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/components/UpdateDialog.kt
@@ -9,11 +9,17 @@ import androidx.compose.ui.res.stringResource
 import com.rjnr.pocketnode.R
 import com.rjnr.pocketnode.data.update.UpdateInfo
 
+/**
+ * One-shot confirmation dialog telling the user a new version is available.
+ * When the user taps Update Now, this dialog closes and download begins
+ * silently in the background — the [com.rjnr.pocketnode.ui.components.UpdateProgressBanner]
+ * sitting above the bottom navigation surfaces progress and the install CTA.
+ */
 @Composable
 fun UpdateDialog(
     updateInfo: UpdateInfo,
     onUpdate: () -> Unit,
-    onDismiss: () -> Unit
+    onDismiss: () -> Unit,
 ) {
     val sizeText = if (updateInfo.fileSize > 0) {
         val sizeMb = updateInfo.fileSize / (1024.0 * 1024.0)
@@ -42,5 +48,38 @@ fun UpdateDialog(
                 Text(stringResource(R.string.update_dialog_action_later))
             }
         }
+    )
+}
+
+/**
+ * Dialog shown when the user taps Update but has not granted the
+ * "install from unknown sources" permission. Previously this state set a
+ * flag in the ViewModel but no dialog was rendered for it, so tapping
+ * Update silently did nothing.
+ */
+@Composable
+fun InstallPermissionDialog(
+    onGrant: () -> Unit,
+    onDismiss: () -> Unit,
+) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text("Permission needed") },
+        text = {
+            Text(
+                "Android needs your permission to install updates for Pocket Node. " +
+                    "Open settings, toggle \"Allow from this source\" on, then come back and tap Update again."
+            )
+        },
+        confirmButton = {
+            Button(onClick = onGrant) {
+                Text("Open settings")
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text("Not now")
+            }
+        },
     )
 }

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/components/UpdateProgressBanner.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/components/UpdateProgressBanner.kt
@@ -1,0 +1,175 @@
+package com.rjnr.pocketnode.ui.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import com.rjnr.pocketnode.data.update.DownloadState
+
+/**
+ * Telegram-style update banner that sits right above the bottom navigation.
+ * Three visible states:
+ *
+ *   - [DownloadState.Downloading]: progress bar + "Downloading update… 23%"
+ *   - [DownloadState.ReadyToInstall]: solid bar with "Tap to install" CTA
+ *   - [DownloadState.Failed]: brief failure message with Retry / Dismiss
+ *
+ * Idle and Installing render nothing (Installing is short-lived; the system
+ * package installer is foreground).
+ */
+@Composable
+fun UpdateProgressBanner(
+    state: DownloadState,
+    onInstallClick: () -> Unit,
+    onCancelClick: () -> Unit,
+    onRetryClick: () -> Unit,
+    onDismissClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    when (state) {
+        DownloadState.Idle, DownloadState.Installing -> Unit
+        is DownloadState.Downloading -> DownloadingRow(
+            bytesDownloaded = state.bytesDownloaded,
+            totalBytes = state.totalBytes,
+            onCancelClick = onCancelClick,
+            modifier = modifier,
+        )
+        DownloadState.ReadyToInstall -> ReadyRow(
+            onInstallClick = onInstallClick,
+            onDismissClick = onDismissClick,
+            modifier = modifier,
+        )
+        is DownloadState.Failed -> FailedRow(
+            reason = state.reason,
+            onRetryClick = onRetryClick,
+            onDismissClick = onDismissClick,
+            modifier = modifier,
+        )
+    }
+}
+
+@Composable
+private fun DownloadingRow(
+    bytesDownloaded: Long,
+    totalBytes: Long,
+    onCancelClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val fraction: Float? = if (totalBytes > 0L) {
+        (bytesDownloaded.toFloat() / totalBytes.toFloat()).coerceIn(0f, 1f)
+    } else null
+    val pct = fraction?.let { (it * 100f).toInt() }
+
+    // Compact Telegram-style row. Long-press to cancel — the X icon is
+    // intentionally subtle so the banner stays scan-and-forget.
+    Box(
+        modifier = modifier
+            .fillMaxWidth()
+            .background(MaterialTheme.colorScheme.primaryContainer)
+            .clickable(onClick = onCancelClick),
+    ) {
+        if (fraction != null) {
+            LinearProgressIndicator(
+                progress = { fraction },
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(2.dp),
+                color = MaterialTheme.colorScheme.primary,
+                trackColor = Color.Transparent,
+            )
+        } else {
+            LinearProgressIndicator(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(2.dp),
+                color = MaterialTheme.colorScheme.primary,
+                trackColor = Color.Transparent,
+            )
+        }
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp, vertical = 6.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Text(
+                text = if (pct != null) "Downloading update  $pct%" else "Downloading update…",
+                color = MaterialTheme.colorScheme.onPrimaryContainer,
+                style = MaterialTheme.typography.labelMedium,
+                fontWeight = FontWeight.Medium,
+            )
+        }
+    }
+}
+
+@Composable
+private fun ReadyRow(
+    onInstallClick: () -> Unit,
+    onDismissClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .background(MaterialTheme.colorScheme.primary)
+            .clickable(onClick = onInstallClick)
+            .padding(horizontal = 16.dp, vertical = 8.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Text(
+            text = "Update ready  ·  Tap to install",
+            color = MaterialTheme.colorScheme.onPrimary,
+            style = MaterialTheme.typography.labelMedium,
+            fontWeight = FontWeight.SemiBold,
+        )
+    }
+}
+
+@Composable
+private fun FailedRow(
+    reason: String,
+    onRetryClick: () -> Unit,
+    onDismissClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .background(MaterialTheme.colorScheme.errorContainer)
+            .clickable(onClick = onRetryClick)
+            .padding(horizontal = 16.dp, vertical = 6.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Text(
+            text = "Update download failed  ·  Tap to retry",
+            color = MaterialTheme.colorScheme.onErrorContainer,
+            style = MaterialTheme.typography.labelMedium,
+            fontWeight = FontWeight.Medium,
+            modifier = Modifier.weight(1f),
+        )
+        TextButton(onClick = onDismissClick, contentPadding = androidx.compose.foundation.layout.PaddingValues(horizontal = 8.dp, vertical = 0.dp)) {
+            Text(
+                "Dismiss",
+                color = MaterialTheme.colorScheme.onErrorContainer,
+                style = MaterialTheme.typography.labelSmall,
+            )
+        }
+    }
+}

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/home/HomeScreen.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/home/HomeScreen.kt
@@ -164,6 +164,10 @@ fun HomeScreen(
             if (event == androidx.lifecycle.Lifecycle.Event.ON_RESUME) {
                 viewModel.refreshSecurityState()
                 viewModel.refreshPriceIfStale()
+                // If we sent the user to Android settings to grant install
+                // permission, resume the download automatically when they
+                // come back instead of making them re-tap Update.
+                viewModel.retryPendingUpdateIfPermissionGranted()
             }
         }
         lifecycleOwner.lifecycle.addObserver(observer)
@@ -284,12 +288,29 @@ fun HomeScreen(
         )
     }
 
-    // Update dialog
+    // Confirmation dialog announcing a new version. After the user taps
+    // Update Now this closes, the download proceeds in the background, and
+    // the persistent banner above the bottom navigation surfaces progress
+    // and the install CTA.
     if (uiState.showUpdateDialog && uiState.updateInfo != null) {
         UpdateDialog(
             updateInfo = uiState.updateInfo!!,
             onUpdate = { viewModel.startUpdate() },
-            onDismiss = { viewModel.dismissUpdate() }
+            onDismiss = { viewModel.dismissUpdate() },
+        )
+    }
+
+    // Install-from-unknown-sources permission prompt. Previously the
+    // ViewModel raised this flag with no UI bound to it, so users who
+    // hadn't granted the permission tapped Update and got nothing.
+    if (uiState.showInstallPermissionNeeded) {
+        com.rjnr.pocketnode.ui.components.InstallPermissionDialog(
+            onGrant = {
+                viewModel.openInstallPermissionSettings { intent ->
+                    context.startActivity(intent)
+                }
+            },
+            onDismiss = { viewModel.dismissInstallPermission() },
         )
     }
 

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/home/HomeViewModel.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/home/HomeViewModel.kt
@@ -110,6 +110,13 @@ class HomeViewModel @Inject constructor(
     private val _navEvents = Channel<HomeNavEvent>(Channel.BUFFERED)
     val navEvents = _navEvents.receiveAsFlow()
 
+    // Captures a pending APK download URL + size when the user is sent to
+    // Android settings to grant install-from-unknown-sources. On ON_RESUME
+    // we check `canInstallPackages()` and start the download automatically
+    // so the user does not have to wait for the next launch / re-tap Update.
+    private var pendingUpdateApkUrl: String? = null
+    private var pendingUpdateApkSize: Long = 0L
+
     // Tracks the last successful CKB/USD fetch so we can throttle
     // refresh-on-foreground and the 5-min ticker (#117 deferred items).
     private var lastPriceFetchAt: Long = 0L
@@ -779,16 +786,76 @@ class HomeViewModel @Inject constructor(
 
     fun startUpdate() {
         val info = _uiState.value.updateInfo ?: return
-        _uiState.update { it.copy(showUpdateDialog = false) }
 
-        if (info.apkDownloadUrl != null && updateDownloader.canInstallPackages()) {
-            updateDownloader.downloadAndInstall(info.apkDownloadUrl)
-        } else if (info.apkDownloadUrl != null) {
-            _uiState.update { it.copy(showInstallPermissionNeeded = true) }
-        } else {
-            // No APK asset — open the GitHub release page in browser
+        if (info.apkDownloadUrl == null) {
+            // No APK asset attached to this release. Nothing safe to do
+            // without surprising the user with a browser jump; just close.
             _uiState.update { it.copy(showUpdateDialog = false) }
+            return
         }
+
+        if (!updateDownloader.canInstallPackages()) {
+            // Cannot proceed until the user grants "install from unknown
+            // sources" for this app. Hide the update dialog and show the
+            // permission prompt instead. Previously this flag was set but
+            // never rendered, so tapping Update did nothing.
+            _uiState.update {
+                it.copy(
+                    showUpdateDialog = false,
+                    showInstallPermissionNeeded = true,
+                )
+            }
+            return
+        }
+
+        // Close the dialog. The UpdateProgressBanner at MainScreen scope
+        // takes over and surfaces progress + install CTA.
+        _uiState.update { it.copy(showUpdateDialog = false) }
+        updateDownloader.downloadAndInstall(
+            apkUrl = info.apkDownloadUrl,
+            totalBytesHint = info.fileSize,
+        )
+    }
+
+    /**
+     * Dismiss the install-from-unknown-sources prompt without opening
+     * settings. The user can re-trigger the update flow from the dialog
+     * later when they are ready.
+     */
+    fun dismissInstallPermission() {
+        _uiState.update { it.copy(showInstallPermissionNeeded = false) }
+        pendingUpdateApkUrl = null
+        pendingUpdateApkSize = 0L
+    }
+
+    /**
+     * Open the system settings screen that lets the user grant install
+     * permission for this app. Captures the pending download details so
+     * [retryPendingUpdateIfPermissionGranted] can resume automatically on
+     * ON_RESUME once the user returns with permission granted.
+     */
+    fun openInstallPermissionSettings(launch: (android.content.Intent) -> Unit) {
+        val info = _uiState.value.updateInfo
+        pendingUpdateApkUrl = info?.apkDownloadUrl
+        pendingUpdateApkSize = info?.fileSize ?: 0L
+        _uiState.update { it.copy(showInstallPermissionNeeded = false) }
+        launch(updateDownloader.getInstallPermissionIntent())
+    }
+
+    /**
+     * Called from the HomeScreen lifecycle observer when the activity
+     * resumes. If we previously sent the user to Android settings to grant
+     * "install from unknown sources" and they returned with the permission
+     * now granted, kick off the download automatically instead of forcing
+     * them to re-tap Update.
+     */
+    fun retryPendingUpdateIfPermissionGranted() {
+        val url = pendingUpdateApkUrl ?: return
+        if (!updateDownloader.canInstallPackages()) return
+        val size = pendingUpdateApkSize
+        pendingUpdateApkUrl = null
+        pendingUpdateApkSize = 0L
+        updateDownloader.downloadAndInstall(apkUrl = url, totalBytesHint = size)
     }
 
     /**

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/home/HomeViewModel.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/home/HomeViewModel.kt
@@ -873,7 +873,13 @@ class HomeViewModel @Inject constructor(
 
     override fun onCleared() {
         super.onCleared()
-        updateDownloader.cleanup()
+        // Do NOT call updateDownloader.cleanup() here. The downloader is a
+        // @Singleton owned at app scope; the banner above the bottom nav
+        // (driven by UpdateBannerViewModel in MainScreen) is what surfaces
+        // its state. Cancelling here would kill an in-flight update the
+        // moment HomeScreen unmounts (e.g. configuration change, swap to
+        // Activity tab). The downloader cleans itself up on init for stale
+        // APKs and on cancel/resetState for in-flight ones.
     }
 
     companion object {

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/update/UpdateBannerViewModel.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/update/UpdateBannerViewModel.kt
@@ -33,6 +33,9 @@ class UpdateBannerViewModel @Inject constructor(
     /** User tapped Later/Dismiss to hide a terminal banner. */
     fun dismiss() = updateDownloader.resetState()
 
+    /** User tapped "Tap to retry" on a failed download. */
+    fun retry() = updateDownloader.retry()
+
     /**
      * Called from MainScreen's lifecycle observer when the activity resumes.
      * If we were Installing and the user came back (cancelled / install

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/update/UpdateBannerViewModel.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/update/UpdateBannerViewModel.kt
@@ -1,0 +1,42 @@
+package com.rjnr.pocketnode.ui.update
+
+import androidx.lifecycle.ViewModel
+import com.rjnr.pocketnode.data.update.DownloadState
+import com.rjnr.pocketnode.data.update.UpdateDownloader
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.StateFlow
+import javax.inject.Inject
+
+/**
+ * Thin Compose-side bridge over the singleton [UpdateDownloader]. Lives at
+ * MainScreen scope so the update banner sits above the bottom navigation
+ * regardless of which tab is showing.
+ *
+ * Why a ViewModel and not direct singleton injection: Compose composables
+ * cannot inject Hilt singletons directly; the standard way to surface a
+ * @Singleton flow into a composable is via a Hilt ViewModel. This class
+ * adds zero state of its own.
+ */
+@HiltViewModel
+class UpdateBannerViewModel @Inject constructor(
+    private val updateDownloader: UpdateDownloader,
+) : ViewModel() {
+
+    val state: StateFlow<DownloadState> = updateDownloader.state
+
+    /** User tapped the "Update" CTA on a finished download. */
+    fun installNow() = updateDownloader.installNow()
+
+    /** User tapped Cancel on an in-progress download. */
+    fun cancel() = updateDownloader.cancel()
+
+    /** User tapped Later/Dismiss to hide a terminal banner. */
+    fun dismiss() = updateDownloader.resetState()
+
+    /**
+     * Called from MainScreen's lifecycle observer when the activity resumes.
+     * If we were Installing and the user came back (cancelled / install
+     * conflict / etc.) we reset state and drop the on-disk APK.
+     */
+    fun onActivityResumed() = updateDownloader.onInstallerReturned()
+}


### PR DESCRIPTION
## Problem

Auto-update has been broken since v1.5.x. Symptoms reported during v1.6.0 release smoke:

- Tap **Update** in the version dialog → nothing happens (silent dismiss).
- Granting "install from unknown sources" in Android settings and returning → still nothing.
- When the download did fire, no in-app progress, system notification only on completion, and downloads stalled at 87% / 95% on emulator and several real handsets.

Logcat confirmed the download was being enqueued (`UpdateDownloader: Download enqueued: id=15`) but no UI ever reflected it.

## Three root causes, one PR

### 1. `showInstallPermissionNeeded` flag with no UI bound to it
`HomeViewModel.startUpdate()` flipped the flag when `canInstallPackages()` was false, but `HomeScreen` never rendered a dialog for it. Tapping Update with no permission grant looked identical to a no-op.

**Fix:** new `InstallPermissionDialog` rendered when the flag is set. Plus `pendingUpdateApkUrl/Size` captured before launching the settings intent so the `ON_RESUME` lifecycle hook auto-resumes the download once permission is granted, instead of making the user re-tap Update.

### 2. DownloadManager unreliable + invisible
`DownloadManager.enqueue` over GitHub→S3 redirects stalled mid-download on emulator and several Android handsets. `VISIBILITY_VISIBLE_NOTIFY_COMPLETED` meant the system notification only appeared on success, never during. The shared `HttpClient` in `AppModule` has a 10s socket timeout, fine for JSON polls but too tight for a 39 MB APK.

**Fix:** rewritten `UpdateDownloader` using Ktor streaming. Per-chunk `onDownload { bytesSoFar, contentLength -> ... }` callback drives the progress flow directly, 60s socket / 10min total budget on a dedicated `HttpClient`. Cancellation via `Job.cancel`. No `BroadcastReceiver`, no polling, no DownloadManager.

### 3. No persistent download UI
Even with progress wired, the only surface for it was the `UpdateDialog`, which dismissed itself on Update tap.

**Fix:** new `UpdateProgressBanner` mounted in `MainScreen.bottomBar` above the navigation bar. Telegram-style states:

- **Downloading** — thin row with linear progress + "Downloading update N%". Tap to cancel.
- **ReadyToInstall** — tappable "Update ready · Tap to install". Opens system installer.
- **Failed** — red tappable row "Tap to retry" + Dismiss.

Banner is backed by a thin `UpdateBannerViewModel` over the singleton `UpdateDownloader.state`, so it persists across tab switches and survives screen rotations.

## Disk hygiene

- `UpdateDownloader.init` drops any leftover `pocket-node-update.apk` on app boot. After a successful self-install, the new process boots and reclaims the ~39 MB file automatically.
- `ON_RESUME` from the system installer transitions the banner from Installing → Idle and deletes the APK, covering cancel / signing-mismatch / any other non-success path.

## Test plan
- [x] `./gradlew :app:compileDebugKotlin` clean
- [x] `./gradlew testDebugUnitTest` passes
- [x] Manual: emulator with spoofed `versionName=1.5.0`, discovered v1.6.0 on GH Releases, banner streamed through ~39 MB without stalling, surfaced the install CTA. (The final install on the test device fails on the signing-mismatch screen because the emulator had a debug-signed prior install; production sideloads are release-signed end to end, so that mismatch is a test-only artifact.)
- [ ] Real-device sanity check on Tecno / Infinix / MIUI when the v1.6.1 release ships.

## Notes for v1.6.1 release

This is a v1.6.1 hotfix. The actual fix only manifests for users coming from v1.5.0/v1.5.1 (whose updater URL was already broken) and v1.6.0 sideloaders who tried to use the auto-updater. Users on v1.5.2 saw the old broken flow too but the bug they saw matched this one.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Displays download progress banner with real-time percentage tracking during app updates
  * Shows permission dialog guiding users to enable unknown app installation
  * Added download cancellation support
  * Automatically resumes pending updates after permission is granted
  * Improved error state with retry functionality

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/RaheemJnr/pocket-node/pull/175?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->