### PR TITLE
chore(release): v1.6.1 changelog + versionCode 10

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -15,8 +15,8 @@ android {
         applicationId = "com.rjnr.pocketnode"
         minSdk = 26
         targetSdk = 35
-        versionCode = 9
-        versionName = "1.6.0"
+        versionCode = 10
+        versionName = "1.6.1"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 

--- a/fastlane/metadata/android/en-US/changelogs/10.txt
+++ b/fastlane/metadata/android/en-US/changelogs/10.txt
@@ -1,0 +1,5 @@
+v1.6.1:
+- Auto-update now actually works. When a new version is found, a compact banner sits above the bottom navigation and shows real-time download progress. Tap when ready to install.
+- If the app needs install-from-unknown-sources permission, returning from Android settings resumes the download automatically. No more re-tapping Update.
+- Cancel an in-progress download by tapping the banner. Retry a failed one the same way.
+- The downloaded APK is cleaned up after install or cancellation, so the update never sits around eating disk.


### PR DESCRIPTION
## Summary
Release-prep for v1.6.1, the auto-update hotfix tag. Bumps `versionCode` 9 → 10 and `versionName` 1.6.0 → 1.6.1 and lands the Play Store changelog at `fastlane/metadata/android/en-US/changelogs/10.txt`.

## What v1.6.1 ships
PR #175 (merged) rewrote the auto-update flow:

- Compact Telegram-style banner above the bottom navigation surfaces download progress in real time. Previously the only feedback was a single completion notification from `DownloadManager`.
- DownloadManager replaced with Ktor streaming. The old path stalled at ~87-95% on emulator + several real handsets.
- Install-permission dialog now actually renders. The flag was set in the ViewModel but no UI was bound to it, so tapping Update with no grant did nothing.
- Returning from Android settings auto-resumes the pending download. No re-tap required.
- Tap-to-cancel on in-flight downloads. Tap-to-retry on failed ones.
- Stale APK cleaned up after install or cancel; init also drops any orphan from a prior process.
- HTTP status validated before writing to disk (a 404/HTML error page won't be mistakenly mounted as an APK).
- Retry races serialised via `cancelAndJoin`.

## Test plan
- [x] `./gradlew :app:assembleDebug` clean
- [x] Tested on Pixel 7 Pro emulator with a spoofed `versionName=1.5.0` build: discovered v1.6.0, streamed the full 39 MB without stalling, banner CTAs all functional.
- [ ] Smoke-install v1.6.1 release APK over a v1.6.0 install on a real device before tagging (per project memory, every recent release has shipped upgrade-path bugs from fresh-install-only testing).
- [ ] Confirm in-app version row reads "1.6.1"