### PR TITLE
chore(website): point download button at v1.6.1

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -1112,7 +1112,7 @@
             </p>
 
             <div class="hero-buttons">
-                <a href="https://github.com/RaheemJnr/pocket-node/releases/download/v1.6.0/PocketNode-v1.6.0.apk" class="btn btn--primary">
+                <a href="https://github.com/RaheemJnr/pocket-node/releases/download/v1.6.1/PocketNode-v1.6.1.apk" class="btn btn--primary">
                     <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 15v4a2 2 0 01-2 2H5a2 2 0 01-2-2v-4"/><polyline points="7,10 12,15 17,10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
                     Download APK
                 </a>
@@ -1413,7 +1413,7 @@
         <p class="section-desc animate-on-scroll">Join the growing community of Nervos users who verify everything locally. No trust required.</p>
 
         <div class="cta-buttons animate-on-scroll">
-            <a href="https://github.com/RaheemJnr/pocket-node/releases/download/v1.6.0/PocketNode-v1.6.0.apk" class="btn btn--primary">
+            <a href="https://github.com/RaheemJnr/pocket-node/releases/download/v1.6.1/PocketNode-v1.6.1.apk" class="btn btn--primary">
                 <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 15v4a2 2 0 01-2 2H5a2 2 0 01-2-2v-4"/><polyline points="7,10 12,15 17,10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
                 Download for Android
             </a>
@@ -1445,7 +1445,7 @@
                     <li><a href="#features">Features</a></li>
                     <li><a href="#security">Security</a></li>
                     <li><a href="#tech">Technical</a></li>
-                    <li><a href="https://github.com/RaheemJnr/pocket-node/releases/download/v1.6.0/PocketNode-v1.6.0.apk">Get App</a></li>
+                    <li><a href="https://github.com/RaheemJnr/pocket-node/releases/download/v1.6.1/PocketNode-v1.6.1.apk">Get App</a></li>
                 </ul>
             </div>
             <div class="footer-col">


### PR DESCRIPTION
## Summary
Updates the three v1.6.0 download URLs on the landing page to v1.6.1:

- Hero CTA
- Mid-page CTA
- Footer "Get App"

## Test plan
- [x] `grep -rn "v1.6.0" website` returns nothing
- [ ] Visit the deployed preview, confirm all three buttons resolve to the v1.6.1 GitHub Release asset