### PR TITLE
fix(android): require release signing env vars and fail closed

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -86,18 +86,10 @@ android {
                 storePassword = keystorePassword
                 keyAlias = keyAliasEnv
                 keyPassword = keyPasswordEnv
-            } else {
-                val missingVars = listOf(
-                    "KEYSTORE_PATH" to keystorePath,
-                    "KEYSTORE_PASSWORD" to keystorePassword,
-                    "KEY_ALIAS" to keyAliasEnv,
-                    "KEY_PASSWORD" to keyPasswordEnv
-                ).filter { it.second == null }.map { it.first }
-
-                throw GradleException(
-                    "Release signing is required. Missing environment variables: ${missingVars.joinToString(", ")}"
-                )
             }
+            // else: intentionally leave release signingConfig unconfigured.
+            // Missing env validation is deferred to task-graph time below so
+            // debug/test/sync workflows still work without release secrets.
         }
     }
 
@@ -154,6 +146,28 @@ android {
 
 // Pinned to the version mockk transitively brings in. Preloaded as a -javaagent
 // for unit tests so MockK works on JDK 21+ without self-attach.
+
+
+gradle.taskGraph.whenReady {
+    val needsReleaseSigning = allTasks.any { task ->
+        task.name.contains("Release") && (
+            task.name.startsWith("assemble") ||
+                task.name.startsWith("bundle") ||
+                task.name.startsWith("package")
+            )
+    }
+
+    if (needsReleaseSigning) {
+        val missingVars = listOf("KEYSTORE_PATH", "KEYSTORE_PASSWORD", "KEY_ALIAS", "KEY_PASSWORD")
+            .filter { System.getenv(it) == null }
+        if (missingVars.isNotEmpty()) {
+            throw GradleException(
+                "Release signing requires env vars: ${missingVars.joinToString(", ")}"
+            )
+        }
+    }
+}
+
 val byteBuddyAgent: Configuration by configurations.creating
 
 dependencies {

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -87,15 +87,16 @@ android {
                 keyAlias = keyAliasEnv
                 keyPassword = keyPasswordEnv
             } else {
-                if (keystorePath != null) {
-                    logger.warn("KEYSTORE_PATH is set but other signing env vars are missing — falling back to debug keystore")
-                }
-                // Fall back to debug keystore for local dev
-                val debugKeystore = signingConfigs.getByName("debug")
-                storeFile = debugKeystore.storeFile
-                storePassword = debugKeystore.storePassword
-                keyAlias = debugKeystore.keyAlias
-                keyPassword = debugKeystore.keyPassword
+                val missingVars = listOf(
+                    "KEYSTORE_PATH" to keystorePath,
+                    "KEYSTORE_PASSWORD" to keystorePassword,
+                    "KEY_ALIAS" to keyAliasEnv,
+                    "KEY_PASSWORD" to keyPasswordEnv
+                ).filter { it.second == null }.map { it.first }
+
+                throw GradleException(
+                    "Release signing is required. Missing environment variables: ${missingVars.joinToString(", ")}"
+                )
             }
         }
     }


### PR DESCRIPTION
### Motivation
- A checked-in debug keystore is intentionally used for CI smoke tests, and the existing `release` signingConfig fell back to the `debug` signingConfig when release env vars were missing, which could allow public repository key material to be used to sign release APKs.
- Release builds must not be signed with a public debug key, so the configuration should fail closed when release signing secrets are not provided.

### Description
- Modified `android/app/build.gradle.kts` to remove the fallback that copied values from the `debug` signingConfig into `release` when signing env vars were incomplete.
- Added a check that requires `KEYSTORE_PATH`, `KEYSTORE_PASSWORD`, `KEY_ALIAS`, and `KEY_PASSWORD` to all be present and throws a `GradleException` listing the missing variables if any are absent.
- Preserved normal behavior when all release signing environment variables are provided so CI/local release builds with proper secrets continue to work.

### Testing
- Attempted to list Gradle tasks with `./gradlew :android:app:tasks --all` and it failed because `./gradlew` is not at the repository root in this environment.
- Attempted `cd android && ./gradlew :app:tasks --all` and the Gradle run failed early due to a Java/Gradle compatibility error (`25.0.2`), so full build verification could not be completed in this container.
- Static validation: the `build.gradle.kts` change was applied and the missing-variable error message is produced by the new `GradleException` path when env vars are incomplete.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a0b5c28de8c8324ba2f865309229177)