### PR TITLE
Resolve active wallet type from durable state before mnemonic-backup startup gate

### DIFF
--- a/android/app/src/main/java/com/rjnr/pocketnode/data/gateway/GatewayRepository.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/gateway/GatewayRepository.kt
@@ -611,11 +611,33 @@ class GatewayRepository @Inject constructor(
     suspend fun hasWallet(): Boolean = keyManager.hasWallet()
 
     /**
+     * Resolve the active wallet type from durable state before making startup
+     * routing decisions. During a cold start [activeWalletType] may still hold
+     * its constructor default while repository initialization is running in the
+     * background, so trusting only the in-memory value can misclassify raw-key
+     * wallets as mnemonic wallets.
+     */
+    private suspend fun resolveActiveWalletType(): String {
+        val activeWallet = walletDao.getActive()
+            ?: activeWalletId.takeIf { it.isNotBlank() }?.let { walletDao.getById(it) }
+
+        if (activeWallet != null) {
+            activeWalletId = activeWallet.walletId
+            activeWalletType = activeWallet.type
+            return activeWallet.type
+        }
+
+        // Legacy single-wallet fallback for installs that have not been migrated
+        // into Room yet. KeyManager defaults unknown legacy wallets to raw-key.
+        return keyManager.getWalletType().also { activeWalletType = it }
+    }
+
+    /**
      * Returns true if the current wallet is a mnemonic wallet that hasn't completed backup verification.
      * Used by MainActivity to gate access to the dashboard until backup is done.
      */
     suspend fun needsMnemonicBackup(): Boolean {
-        return activeWalletType == KeyManager.WALLET_TYPE_MNEMONIC
+        return resolveActiveWalletType() == KeyManager.WALLET_TYPE_MNEMONIC
             && !hasMnemonicBackupForActiveWallet()
     }
 


### PR DESCRIPTION
### Motivation
- Prevent misclassification of raw-key wallets as mnemonic during cold start which causes the unauthenticated MnemonicBackup screen to be shown before PIN auth. 
- The in-memory `activeWalletType` defaulted to `mnemonic` prior to loading Room/legacy state, allowing PIN bypass and private-key exposure for certain migrated/imported raw-key wallets.

### Description
- Added a new helper `resolveActiveWalletType()` in `GatewayRepository` that reads the active wallet from Room via `walletDao.getActive()` (falling back to `walletDao.getById(activeWalletId)`), and falls back to `KeyManager.getWalletType()` for legacy single-wallet installs, while updating `activeWalletId` and `activeWalletType` from durable state.
- Updated `needsMnemonicBackup()` to call `resolveActiveWalletType()` instead of trusting the constructor-default `activeWalletType` so startup routing uses durable state.
- Preserved legacy behavior by using `KeyManager.getWalletType()` as a final fallback and updating the cached repository fields from whichever durable source is available.
- Change location: `android/app/src/main/java/com/rjnr/pocketnode/data/gateway/GatewayRepository.kt`.

### Testing
- Ran `git diff --check` which reported no whitespace/file errors.
- Attempted unit tests with `cd android && ./gradlew :app:testDebugUnitTest --no-daemon --stacktrace`, but the Gradle/Kotlin toolchain failed in this environment due to the container JVM reporting `java.lang.IllegalArgumentException: 25.0.2`, so test execution could not complete.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a033c6571108324a649575d62f1de33)