### PR TITLE
Require auth before showing mnemonic backup

### DIFF
--- a/android/app/src/main/java/com/rjnr/pocketnode/MainActivity.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/MainActivity.kt
@@ -71,7 +71,6 @@ class MainActivity : FragmentActivity() {
             when {
                 keyManager.wasResetDueToCorruption() -> Screen.Recovery.route
                 !cachedHasWallet -> Screen.Onboarding.route
-                repository.needsMnemonicBackup() -> Screen.MnemonicBackup.route
                 !pinManager.hasPin() -> Screen.InitialPinSetup.route
                 else -> Screen.Auth.route
             }
@@ -109,7 +108,10 @@ class MainActivity : FragmentActivity() {
                     CkbNavGraph(
                         navController = navController,
                         startDestination = startDestination,
-                        pinManager = pinManager
+                        pinManager = pinManager,
+                        needsMnemonicBackup = {
+                            runBlocking { repository.needsMnemonicBackup() }
+                        }
                     )
                 }
                 }

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/navigation/NavGraph.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/navigation/NavGraph.kt
@@ -84,13 +84,18 @@ sealed class BottomTab(val route: String, val label: String) {
 fun CkbNavGraph(
     navController: NavHostController,
     startDestination: String = Screen.Onboarding.route,
-    pinManager: PinManager
+    pinManager: PinManager,
+    needsMnemonicBackup: () -> Boolean = { false }
 ) {
     // PIN is mandatory: if the user doesn't have one yet, any "go to Main" action
-    // must first pass through PIN setup. See MainActivity startup gate for the
-    // cold-start path.
-    fun destinationAfterWalletReady(): String =
-        if (pinManager.hasPin()) Screen.Main.route else Screen.InitialPinSetup.route
+    // must first pass through PIN setup. Once a PIN exists, mnemonic backup is
+    // enforced after authentication/setup so recovery material is not shown from
+    // the unauthenticated startup path.
+    fun destinationAfterWalletReady(): String = when {
+        !pinManager.hasPin() -> Screen.InitialPinSetup.route
+        needsMnemonicBackup() -> Screen.MnemonicBackup.createRoute()
+        else -> Screen.Main.route
+    }
 
     NavHost(
         navController = navController,
@@ -148,7 +153,7 @@ fun CkbNavGraph(
         composable(Screen.Auth.route) {
             AuthScreen(
                 onAuthSuccess = {
-                    navController.navigate(Screen.Main.route) {
+                    navController.navigate(destinationAfterWalletReady()) {
                         popUpTo(Screen.Auth.route) { inclusive = true }
                     }
                 },
@@ -489,7 +494,7 @@ fun CkbNavGraph(
         composable(Screen.InitialPinSetup.route) {
             InitialPinSetupScreen(
                 onPinCreated = {
-                    navController.navigate(Screen.Main.route) {
+                    navController.navigate(destinationAfterWalletReady()) {
                         popUpTo(navController.graph.id) { inclusive = true }
                         launchSingleTop = true
                     }


### PR DESCRIPTION
### Motivation
- Prevent unauthenticated display of mnemonic/private key by ensuring the app does not route to the backup screen before PIN authentication when a PIN exists.
- Enforce mnemonic backup only after the user has successfully authenticated or completed PIN setup so secrets are not exposed on cold-start.

### Description
- Removed the unauthenticated mnemonic-backup check from the cold-start decision in `MainActivity.kt` so startup routes go to auth/PIN first instead of `MnemonicBackup`.
- Added a `needsMnemonicBackup: () -> Boolean` callback parameter to `CkbNavGraph` in `ui/navigation/NavGraph.kt` and wired it to call `repository.needsMnemonicBackup()` from `MainActivity` after startup, so backup enforcement runs in the authenticated/post-setup flow.
- Reworked `destinationAfterWalletReady()` to require `pinManager.hasPin()` first, then check `needsMnemonicBackup()`, and otherwise route to the main dashboard; updated `Auth` success and `InitialPinSetup` completion to navigate via this shared post-unlock destination logic.
- Files changed: `android/app/src/main/java/com/rjnr/pocketnode/MainActivity.kt` and `android/app/src/main/java/com/rjnr/pocketnode/ui/navigation/NavGraph.kt`.

### Testing
- Ran `git diff --check` (no diff-level issues found). — succeeded.
- Attempted `cd android && ./gradlew :app:compileDebugKotlin` in this environment but the run failed due to the host Java version parsing issue (`OpenJDK 25.0.2`) reported by the Kotlin/Gradle tooling. — blocked.
- Attempted `cd android && JAVA_HOME=/root/.local/share/mise/installs/java/17.0.2 ./gradlew :app:compileDebugKotlin` to use Java 17; the build progressed but dependency resolution failed because the Android Gradle plugin `com.android.application:8.13.2` could not be resolved from configured repositories in this environment. — blocked.
- No runtime/instrumented tests could be executed here due to the environment limitations above, but the change is minimal and preserves existing navigation paths while moving the mnemonic-backup enforcement into the post-auth flow.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a0340fe4a9883249ad76a8e580be4c6)