### PR TITLE
fix: harden release workflow tag provenance

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,17 +1,71 @@
 name: Release
 
 on:
-  push:
-    tags:
-      - 'v*'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Existing release tag to build (must match v*)'
+        required: true
+        type: string
+
+permissions:
+  contents: write
 
 jobs:
   release:
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    environment: release-signing
 
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout release workflow branch
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Validate release tag provenance
+        id: validate_tag
+        env:
+          RELEASE_TAG: ${{ inputs.tag }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+          WORKFLOW_REF: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+
+          if [ "$WORKFLOW_REF" != "$DEFAULT_BRANCH" ]; then
+            echo "::error::Release workflow must be run from the default branch ($DEFAULT_BRANCH), not $WORKFLOW_REF."
+            exit 1
+          fi
+
+          if [[ "$RELEASE_TAG" != v* ]]; then
+            echo "::error::Release tag '$RELEASE_TAG' must match v*."
+            exit 1
+          fi
+
+          git fetch --force --tags origin
+          git fetch --force origin "+refs/heads/$DEFAULT_BRANCH:refs/remotes/origin/$DEFAULT_BRANCH"
+
+          if ! git rev-parse --verify --quiet "refs/tags/$RELEASE_TAG" >/dev/null; then
+            echo "::error::Release tag '$RELEASE_TAG' does not exist."
+            exit 1
+          fi
+
+          TAG_COMMIT="$(git rev-list -n 1 "$RELEASE_TAG")"
+          MAIN_COMMIT="$(git rev-parse "origin/$DEFAULT_BRANCH")"
+
+          if ! git merge-base --is-ancestor "$TAG_COMMIT" "$MAIN_COMMIT"; then
+            echo "::error::Release tag '$RELEASE_TAG' ($TAG_COMMIT) is not reachable from origin/$DEFAULT_BRANCH ($MAIN_COMMIT)."
+            exit 1
+          fi
+
+          echo "Validated release tag $RELEASE_TAG at $TAG_COMMIT."
+          echo "release_tag=$RELEASE_TAG" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout validated release tag
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.validate_tag.outputs.release_tag }}
+          fetch-depth: 0
 
       - name: Set up JDK 17
         uses: actions/setup-java@v4
@@ -80,5 +134,6 @@ jobs:
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
+          tag_name: ${{ steps.validate_tag.outputs.release_tag }}
           files: android/app/build/outputs/apk/release/*.apk
           generate_release_notes: true


### PR DESCRIPTION
### Motivation
- Prevent signing and publishing release APKs from arbitrary unreviewed tag pushes by enforcing tag provenance and an approval gate in the release workflow.

### Description
- Replace the `push: tags: ['v*']` trigger with a manual `workflow_dispatch` input `tag` so releases are explicit and require a user-triggered run of the workflow.
- Add least-privilege `permissions: contents: write` and attach the job to an `environment: release-signing` to require environment protections/manual approval for signing secrets.
- Validate tag provenance before building by checking the workflow is run from the default branch, ensuring the supplied tag matches `v*`, exists, and that the tag commit is reachable (ancestor) from the repository default branch, then checkout that validated tag for the build.
- Wire the validated tag into the release step (`softprops/action-gh-release`) via the step output so the published GitHub Release is created against the validated tag.

### Testing
- `git diff --check` was run and reported no whitespace/format issues (passed). 
- Parsed ` .github/workflows/release.yml` with Ruby YAML loading to verify structure (passed).
- Extracted and `bash -n`-checked the `Validate release tag provenance` `run` script for shell syntax (passed).
- Attempted to run `actionlint` via `go run github.com/rhysd/actionlint/cmd/actionlint@latest` but it failed due to Go proxy/network restriction (`Forbidden`), so full linter execution was blocked (failed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a03481aa360832495f438b3b928e467)