### PR TITLE
Remove home private key backup exposure

### DIFF
--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/home/HomeScreen.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/home/HomeScreen.kt
@@ -261,20 +261,6 @@ fun HomeScreen(
         )
     }
 
-    // Backup dialog
-    if (uiState.showBackupDialog && uiState.privateKeyHex != null) {
-        BackupWalletDialog(
-            privateKeyHex = uiState.privateKeyHex!!,
-            onDismiss = { viewModel.hideBackup() },
-            onCopy = {
-                clipboardManager.setText(AnnotatedString(uiState.privateKeyHex!!))
-                scope.launch {
-                    snackbarHostState.showSnackbar("Private key copied to clipboard")
-                }
-            }
-        )
-    }
-
     // Import dialog
     if (uiState.showImportDialog) {
         ImportWalletDialog(
@@ -730,51 +716,6 @@ fun HomeScreenUI(
             }
         }
     }
-}
-
-@Composable
-private fun BackupWalletDialog(
-    privateKeyHex: String,
-    onDismiss: () -> Unit,
-    onCopy: () -> Unit
-) {
-    AlertDialog(
-        onDismissRequest = onDismiss,
-        title = { Text("Backup Wallet", fontWeight = FontWeight.Bold) },
-        text = {
-            Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
-                Text(
-                    "This is your private key. Anyone with this key can access your funds. Store it securely!",
-                    style = MaterialTheme.typography.bodyMedium,
-                    color = MaterialTheme.colorScheme.error
-                )
-
-                Card(
-                    colors = CardDefaults.cardColors(
-                        containerColor = MaterialTheme.colorScheme.surfaceVariant
-                    )
-                ) {
-                    Text(
-                        text = privateKeyHex,
-                        modifier = Modifier.padding(16.dp),
-                        fontFamily = FontFamily.Monospace,
-                        fontSize = 12.sp,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant
-                    )
-                }
-            }
-        },
-        confirmButton = {
-            Button(onClick = onCopy) {
-                Text("Copy Key")
-            }
-        },
-        dismissButton = {
-            TextButton(onClick = onDismiss) {
-                Text("Close")
-            }
-        }
-    )
 }
 
 @Composable

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/home/HomeViewModel.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/home/HomeViewModel.kt
@@ -573,24 +573,6 @@ class HomeViewModel @Inject constructor(
         savedStateHandle[SAVED_KEY_SHOW_SYNC_OPTIONS] = false
     }
 
-    /**
-     * Show the backup wallet dialog with the private key (raw key wallets only).
-     * For mnemonic wallets, HomeScreen navigates to MnemonicBackupScreen directly.
-     */
-    fun showBackup() {
-        if (isMnemonicWallet()) return // handled by navigation in HomeScreen
-        viewModelScope.launch {
-            try {
-                val privateKey = repository.getPrivateKey()
-                val hex = org.nervos.ckb.utils.Numeric.toHexStringNoPrefix(privateKey)
-                _uiState.update { it.copy(privateKeyHex = hex, showBackupDialog = true) }
-            } catch (e: Exception) {
-                Log.e(TAG, "Failed to get private key for backup", e)
-                _uiState.update { it.copy(error = "Failed to access wallet keys") }
-            }
-        }
-    }
-
     private fun checkBackupStatus() {
         viewModelScope.launch {
             val type = repository.getWalletType()
@@ -635,13 +617,6 @@ class HomeViewModel @Inject constructor(
     }
 
     fun isMnemonicWallet(): Boolean = _uiState.value.walletType == KeyManager.WALLET_TYPE_MNEMONIC
-
-    /**
-     * Hide the backup wallet dialog
-     */
-    fun hideBackup() {
-        _uiState.update { it.copy(showBackupDialog = false, privateKeyHex = null) }
-    }
 
     /**
      * Show the import wallet dialog
@@ -879,8 +854,6 @@ data class HomeUiState(
     val error: String? = null,
     val currentSyncMode: SyncMode = SyncMode.RECENT,
     val showSyncOptionsDialog: Boolean = false,
-    val showBackupDialog: Boolean = false,
-    val privateKeyHex: String? = null,
     val showImportDialog: Boolean = false,
     val showPostImportSyncDialog: Boolean = false,
     val showBackupReminder: Boolean = false,


### PR DESCRIPTION
### Motivation
- Close a high-risk UI data-flow that exposed the raw wallet private key on the Home screen without re-authentication or clipboard protections. 
- Reduce attack surface by preventing short-term physical/foreground access from revealing or copying wallet secrets.

### Description
- Removed the `BackupWalletDialog` composable and its rendering from `HomeScreen.kt` so the Home UI no longer displays the plaintext private key or a “Copy Key” action. 
- Removed the `showBackup()` and `hideBackup()` flows from `HomeViewModel.kt` and eliminated `privateKeyHex` and `showBackupDialog` from `HomeUiState`, preventing the ViewModel from fetching/storing the raw key in UI state. 
- Eliminated the Home-level clipboard write of the private key and the direct home-entry point that called into the repository to retrieve the raw private key, while preserving import and backup-reminder flows. 
- Kept mnemonic backup, import, and settings paths intact; this change only removes the immediate Home-screen private-key reveal/copy path.

### Testing
- PASS: Ran a source-level verification script (`python3` small check) that asserts the Home flow no longer contains `BackupWalletDialog`, the `Copy Key` clipboard action, the `showBackup()` entrypoint, or the `privateKeyHex` UI field. 
- WARN: Attempted a full Kotlin compile with `./gradlew :app:compileDebugKotlin --no-daemon --stacktrace`, but the Gradle/Kotlin script stage failed before compiling sources with `java.lang.IllegalArgumentException: 25.0.2`, so a full build/test could not be completed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a034a3a82d08324933c3bd7b9266c6c)