### PR TITLE
fix(android): defer release signing env validation, fail closed (supersedes #178)

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -109,16 +109,30 @@ android {
                 storePassword = keystorePassword
                 keyAlias = keyAliasEnv
                 keyPassword = keyPasswordEnv
-            } else {
-                if (keystorePath != null) {
-                    logger.warn("KEYSTORE_PATH is set but other signing env vars are missing — falling back to debug keystore")
-                }
-                // Fall back to debug keystore for local dev
-                val debugKeystore = signingConfigs.getByName("debug")
-                storeFile = debugKeystore.storeFile
-                storePassword = debugKeystore.storePassword
-                keyAlias = debugKeystore.keyAlias
-                keyPassword = debugKeystore.keyPassword
+            }
+            // else: leave release signingConfig unconfigured. The previous
+            // fallback to the checked-in public debug keystore was a real
+            // signing-key exposure for any locally-built release APK. Missing
+            // env validation is deferred to task-graph time below so debug,
+            // test, and IDE sync flows still work without release secrets.
+        }
+    }
+
+    gradle.taskGraph.whenReady {
+        val needsReleaseSigning = allTasks.any { task ->
+            task.name.contains("Release") && (
+                task.name.startsWith("assemble") ||
+                    task.name.startsWith("bundle") ||
+                    task.name.startsWith("package")
+                )
+        }
+        if (needsReleaseSigning) {
+            val missingVars = listOf("KEYSTORE_PATH", "KEYSTORE_PASSWORD", "KEY_ALIAS", "KEY_PASSWORD")
+                .filter { System.getenv(it) == null }
+            if (missingVars.isNotEmpty()) {
+                throw GradleException(
+                    "Release signing requires env vars: ${missingVars.joinToString(", ")}"
+                )
             }
         }
     }


### PR DESCRIPTION
## Summary
- Leave release signingConfig unconfigured when env vars are missing (previous fallback to the checked-in public debug keystore allowed app-impersonation risk for any locally-built release APK)
- Defer the missing-env failure to `gradle.taskGraph.whenReady` so it only fires when a release `assemble`/`bundle`/`package` task is scheduled, preserving debug/test/IDE-sync flows

## Why supersede #178

#178 applied the correct concept after my review feedback, but Codex branched off a pre-#170 base. Its diff rolled back:
- `versionCode 10 → 8`, `versionName "1.6.1" → "1.5.2"`
- Removed `BuildConfig.RELEASES_API_URL` (used in `UpdateRepository.kt:22` + `UpdateRepositoryTest.kt` — would break the in-app updater)
- Removed `BuildConfig.GIT_SHA` (used in `SettingsScreen.kt:528` for the debug version pill)

Rebasing in-place was slower than reapplying the small (~24 line) signing fix on current main. This PR is the signing fix alone, cleanly on top of current main.

## Test plan

- [x] `./gradlew :app:compileDebugKotlin testDebugUnitTest --no-daemon` → BUILD SUCCESSFUL
- [x] `./gradlew :app:assembleRelease --no-daemon -x cargoBuild` (no env vars) → fails with `Release signing requires env vars: KEYSTORE_PATH, KEYSTORE_PASSWORD, KEY_ALIAS, KEY_PASSWORD` at task-graph time
- [ ] CI release workflow still passes when env vars are present (verify on next v1.7.0 cut)

Refs #184

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Modified release build signing configuration to require all necessary environment variables; release builds will now fail if signing credentials are incomplete rather than falling back to alternative configurations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/RaheemJnr/pocket-node/pull/212?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->