### PR TITLE
fix(deps): cargo update tokio + ring (#216)

### DIFF
--- a/external/ckb-light-client/Cargo.lock
+++ b/external/ckb-light-client/Cargo.lock
@@ -2556,6 +2556,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "io-uring"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d09b98f7eace8982db770e4408e7470b028ce513ac28fecdc6bf4c30fe92b62"
+dependencies = [
+ "bitflags 2.9.1",
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
 name = "ipnetwork"
 version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3526,15 +3537,14 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "ring"
-version = "0.17.8"
+version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
 dependencies = [
  "cc",
  "cfg-if",
  "getrandom 0.2.15",
  "libc",
- "spin",
  "untrusted",
  "windows-sys 0.52.0",
 ]
@@ -3844,12 +3854,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "spin"
-version = "0.9.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
-
-[[package]]
 name = "spinning_top"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4108,16 +4112,18 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.43.0"
+version = "1.46.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d61fa4ffa3de412bfea335c6ecff681de2b609ba3c77ef3e00e521813a9ed9e"
+checksum = "0cc3a2344dafbe23a245241fe8b09735b521110d30fcefbbd5feb1797ca35d17"
 dependencies = [
  "backtrace",
  "bytes",
+ "io-uring",
  "libc",
  "mio",
  "pin-project-lite",
  "signal-hook-registry",
+ "slab",
  "socket2",
  "tokio-macros",
  "windows-sys 0.52.0",


### PR DESCRIPTION
## Summary
- `tokio 1.43.0 → 1.46.1` (closes RUSTSEC-2025-0023, broadcast channel correctness bug)
- `ring 0.17.8 → 0.17.14` (closes RUSTSEC-2025-0009, reachable via `overflow-checks = true`)
- Transitive: `io-uring 0.7.12` added (new tokio dep), `spin 0.9.8` removed (no longer pulled in)

Both are SemVer-compatible patch/minor updates with no API change.

## Test plan
- [x] `cargo check --workspace` — Finished dev profile in 11s
- [x] `./build-android-jni.sh` — all 4 ABIs (arm64-v8a, armeabi-v7a, x86_64, x86) built successfully
- [ ] CI release workflow rebuilds with new lockfile (verified at v1.7.0 cut)

## Notes
- Latest tokio is 1.52.3, but our `Cargo.toml` constraint pins us within the SemVer-compatible range to 1.46.1. Moving to 1.52.3 requires constraint relaxation + transitive re-verification, out of scope here.
- `.so` files are gitignored (built locally at release time per existing flow). No binary changes in this PR.

Closes #216
Refs #188 (Dep audit)