### PR TITLE
fix(jni): guard FFI exports with catch_unwind, recover RwLock poison (#215)

### DIFF
--- a/external/ckb-light-client/light-client-lib/src/jni_bridge/dao.rs
+++ b/external/ckb-light-client/light-client-lib/src/jni_bridge/dao.rs
@@ -5,6 +5,7 @@
 //! - Calculating max withdrawable capacity (deposit + compensation)
 //! - Calculating unlock epoch (since value for phase 2)
 
+use super::panic_guard::guard_jni;
 use jni::objects::{JClass, JString};
 use jni::sys::{jlong, jstring};
 use jni::JNIEnv;
@@ -62,6 +63,7 @@ pub extern "C" fn Java_com_nervosnetwork_ckblightclient_LightClientNative_native
     _class: JClass,
     dao_hex: JString,
 ) -> jstring {
+    guard_jni(std::ptr::null_mut(), move || {
     let dao_str = match get_string(&mut env, &dao_hex) {
         Some(s) => s,
         None => return ptr::null_mut(),
@@ -79,10 +81,27 @@ pub extern "C" fn Java_com_nervosnetwork_ckblightclient_LightClientNative_native
         }
     };
 
-    let c = u64::from_le_bytes(bytes[0..8].try_into().unwrap());
-    let ar = u64::from_le_bytes(bytes[8..16].try_into().unwrap());
-    let s = u64::from_le_bytes(bytes[16..24].try_into().unwrap());
-    let u = u64::from_le_bytes(bytes[24..32].try_into().unwrap());
+    // Slicing into 8-byte chunks of a verified 32-byte vec cannot fail; the
+    // pattern match still avoids the unwrap-as-panic-landmine in FFI context.
+    let chunks: Option<[[u8; 8]; 4]> = (|| {
+        Some([
+            bytes[0..8].try_into().ok()?,
+            bytes[8..16].try_into().ok()?,
+            bytes[16..24].try_into().ok()?,
+            bytes[24..32].try_into().ok()?,
+        ])
+    })();
+    let [c_buf, ar_buf, s_buf, u_buf] = match chunks {
+        Some(arr) => arr,
+        None => {
+            error!("DAO field chunk conversion failed");
+            return ptr::null_mut();
+        }
+    };
+    let c = u64::from_le_bytes(c_buf);
+    let ar = u64::from_le_bytes(ar_buf);
+    let s = u64::from_le_bytes(s_buf);
+    let u = u64::from_le_bytes(u_buf);
 
     let json = format!(
         r#"{{"c":"0x{:x}","ar":"0x{:x}","s":"0x{:x}","u":"0x{:x}"}}"#,
@@ -90,6 +109,7 @@ pub extern "C" fn Java_com_nervosnetwork_ckblightclient_LightClientNative_native
     );
 
     dao_to_jstring(&mut env, &json)
+    })
 }
 
 /// Calculate max withdrawable capacity (deposit + compensation).
@@ -103,6 +123,7 @@ pub extern "C" fn Java_com_nervosnetwork_ckblightclient_LightClientNative_native
     deposit_capacity: jlong,
     occupied_capacity: jlong,
 ) -> jlong {
+    guard_jni(-1, move || {
     let deposit_dao_str = match get_string(&mut env, &deposit_header_dao_hex) {
         Some(s) => s,
         None => return -1,
@@ -162,6 +183,7 @@ pub extern "C" fn Java_com_nervosnetwork_ckblightclient_LightClientNative_native
     }
 
     max_withdraw as jlong
+    })
 }
 
 /// Calculate the since value (absolute epoch) for phase 2 unlock.
@@ -173,6 +195,7 @@ pub extern "C" fn Java_com_nervosnetwork_ckblightclient_LightClientNative_native
     deposit_epoch_hex: JString,
     withdraw_epoch_hex: JString,
 ) -> jstring {
+    guard_jni(std::ptr::null_mut(), move || {
     let deposit_str = match get_string(&mut env, &deposit_epoch_hex) {
         Some(s) => s,
         None => return ptr::null_mut(),
@@ -259,4 +282,5 @@ pub extern "C" fn Java_com_nervosnetwork_ckblightclient_LightClientNative_native
 
     let result = format!("0x{:x}", since_value);
     dao_to_jstring(&mut env, &result)
+    })
 }

--- a/external/ckb-light-client/light-client-lib/src/jni_bridge/lifecycle.rs
+++ b/external/ckb-light-client/light-client-lib/src/jni_bridge/lifecycle.rs
@@ -3,6 +3,7 @@
 //! Implements init/start/stop/status functions that mirror light-client-bin/src/subcmds.rs
 
 use super::callbacks::invoke_status_callback;
+use super::panic_guard::guard_jni;
 use super::types::*;
 use crate::protocols::{
     FilterProtocol, LightClientProtocol, Peers, PendingTxs, RelayProtocol, SyncProtocol,
@@ -45,6 +46,7 @@ pub extern "C" fn Java_com_nervosnetwork_ckblightclient_LightClientNative_native
     config_path_jstr: JString,
     status_callback: JObject,
 ) -> jboolean {
+    guard_jni(JNI_FALSE, move || {
     // Check if already initialized
     if is_initialized() {
         error!("Already initialized!");
@@ -295,6 +297,7 @@ pub extern "C" fn Java_com_nervosnetwork_ckblightclient_LightClientNative_native
     let _ = invoke_status_callback("initialized", "");
 
     JNI_TRUE
+    })
 }
 
 /// Load config from TOML file
@@ -313,23 +316,25 @@ pub extern "C" fn Java_com_nervosnetwork_ckblightclient_LightClientNative_native
     _env: JNIEnv,
     _class: JClass,
 ) -> jboolean {
-    // Check if initialized
-    if !is_state(STATE_INIT) {
-        error!("Not in INIT state! Current state: {}", get_state());
-        return JNI_FALSE;
-    }
+    guard_jni(JNI_FALSE, || {
+        // Check if initialized
+        if !is_state(STATE_INIT) {
+            error!("Not in INIT state! Current state: {}", get_state());
+            return JNI_FALSE;
+        }
 
-    info!("Starting CKB Light Client...");
+        info!("Starting CKB Light Client...");
 
-    // Transition to RUNNING
-    set_state(STATE_RUNNING);
+        // Transition to RUNNING
+        set_state(STATE_RUNNING);
 
-    info!("CKB Light Client started successfully!");
+        info!("CKB Light Client started successfully!");
 
-    // Notify status callback
-    let _ = invoke_status_callback("running", "");
+        // Notify status callback
+        let _ = invoke_status_callback("running", "");
 
-    JNI_TRUE
+        JNI_TRUE
+    })
 }
 
 /// JNI: Stop the light client
@@ -343,30 +348,32 @@ pub extern "C" fn Java_com_nervosnetwork_ckblightclient_LightClientNative_native
     _env: JNIEnv,
     _class: JClass,
 ) -> jboolean {
-    // Check if running
-    if !is_state(STATE_RUNNING) {
-        warn!("Not in RUNNING state! Current state: {}", get_state());
-        return JNI_FALSE;
-    }
+    guard_jni(JNI_FALSE, || {
+        // Check if running
+        if !is_state(STATE_RUNNING) {
+            warn!("Not in RUNNING state! Current state: {}", get_state());
+            return JNI_FALSE;
+        }
 
-    info!("Stopping CKB Light Client...");
+        info!("Stopping CKB Light Client...");
 
-    // Broadcast exit signals to all services
-    broadcast_exit_signals();
+        // Broadcast exit signals to all services
+        broadcast_exit_signals();
 
-    // Wait for all CKB services to exit
-    info!("Waiting for services to exit...");
-    wait_all_ckb_services_exit();
+        // Wait for all CKB services to exit
+        info!("Waiting for services to exit...");
+        wait_all_ckb_services_exit();
 
-    // Transition to STOPPED
-    set_state(STATE_STOPPED);
+        // Transition to STOPPED
+        set_state(STATE_STOPPED);
 
-    info!("CKB Light Client stopped successfully!");
+        info!("CKB Light Client stopped successfully!");
 
-    // Notify status callback
-    let _ = invoke_status_callback("stopped", "");
+        // Notify status callback
+        let _ = invoke_status_callback("stopped", "");
 
-    JNI_TRUE
+        JNI_TRUE
+    })
 }
 
 /// JNI: Get current status
@@ -380,5 +387,5 @@ pub extern "C" fn Java_com_nervosnetwork_ckblightclient_LightClientNative_native
     _env: JNIEnv,
     _class: JClass,
 ) -> jint {
-    get_state() as jint
+    guard_jni(STATE_STOPPED as jint, || get_state() as jint)
 }

--- a/external/ckb-light-client/light-client-lib/src/jni_bridge/mod.rs
+++ b/external/ckb-light-client/light-client-lib/src/jni_bridge/mod.rs
@@ -25,6 +25,7 @@
 pub mod callbacks;
 pub mod dao;
 pub mod lifecycle;
+pub mod panic_guard;
 pub mod query;
 pub mod rpc_handler;
 pub mod types;

--- a/external/ckb-light-client/light-client-lib/src/jni_bridge/panic_guard.rs
+++ b/external/ckb-light-client/light-client-lib/src/jni_bridge/panic_guard.rs
@@ -1,0 +1,26 @@
+//! Panic safety wrapper for JNI exports.
+//!
+//! Rust panics that unwind across an `extern "C"` boundary are undefined
+//! behavior since Rust 1.71. Every JNI export wraps its body in `guard_jni`
+//! to convert any panic into the function's null/false/error sentinel.
+
+use std::panic::{catch_unwind, AssertUnwindSafe};
+
+/// Wrap an FFI body so panics return `default` instead of unwinding into the JVM.
+pub fn guard_jni<F, T>(default: T, f: F) -> T
+where
+    F: FnOnce() -> T,
+{
+    match catch_unwind(AssertUnwindSafe(f)) {
+        Ok(value) => value,
+        Err(panic_info) => {
+            let msg = panic_info
+                .downcast_ref::<&str>()
+                .map(|s| (*s).to_string())
+                .or_else(|| panic_info.downcast_ref::<String>().cloned())
+                .unwrap_or_else(|| "unknown panic payload".to_string());
+            log::error!("JNI export panicked: {}", msg);
+            default
+        }
+    }
+}

--- a/external/ckb-light-client/light-client-lib/src/jni_bridge/query.rs
+++ b/external/ckb-light-client/light-client-lib/src/jni_bridge/query.rs
@@ -3,6 +3,7 @@
 //! Provides 17 query APIs matching WASM implementation.
 //! All functions return JSON strings for complex types, or null on error.
 
+use super::panic_guard::guard_jni;
 use super::types::*;
 use crate::service::{
     Cell, CellType, CellsCapacity, FetchStatus, LocalNode, Pagination, RemoteNode, 
@@ -56,6 +57,7 @@ pub extern "C" fn Java_com_nervosnetwork_ckblightclient_LightClientNative_native
     mut env: JNIEnv,
     _class: JClass,
 ) -> jstring {
+    guard_jni(std::ptr::null_mut(), move || {
     check_running!(env);
 
     let swc = match STORAGE_WITH_DATA.get() {
@@ -70,6 +72,7 @@ pub extern "C" fn Java_com_nervosnetwork_ckblightclient_LightClientNative_native
     let header_view: HeaderView = tip_header.into_view().into();
 
     to_jstring(&mut env, &header_view)
+    })
 }
 
 /// Get genesis block
@@ -78,6 +81,7 @@ pub extern "C" fn Java_com_nervosnetwork_ckblightclient_LightClientNative_native
     mut env: JNIEnv,
     _class: JClass,
 ) -> jstring {
+    guard_jni(std::ptr::null_mut(), move || {
     check_running!(env);
 
     let swc = match STORAGE_WITH_DATA.get() {
@@ -94,6 +98,7 @@ pub extern "C" fn Java_com_nervosnetwork_ckblightclient_LightClientNative_native
     let core_block_view: ckb_types::core::BlockView = genesis_block.into_view();
     let block_view: BlockView = core_block_view.into();
     to_jstring(&mut env, &block_view)
+    })
 }
 
 /// Get header by hash
@@ -103,6 +108,7 @@ pub extern "C" fn Java_com_nervosnetwork_ckblightclient_LightClientNative_native
     _class: JClass,
     hash: JString,
 ) -> jstring {
+    guard_jni(std::ptr::null_mut(), move || {
     check_running!(env);
 
     let hash_str: String = match env.get_string(&hash) {
@@ -130,7 +136,15 @@ pub extern "C" fn Java_com_nervosnetwork_ckblightclient_LightClientNative_native
         }
     };
 
-    let hash = packed::Byte32::from_slice(h256.as_bytes()).expect("H256 to Byte32");
+    // H256 is always 32 bytes so the conversion cannot fail in practice;
+    // pattern-match anyway to avoid an FFI panic landmine.
+    let hash = match packed::Byte32::from_slice(h256.as_bytes()) {
+        Ok(h) => h,
+        Err(e) => {
+            error!("nativeGetHeader: Byte32 conversion failed: {}", e);
+            return ptr::null_mut();
+        }
+    };
 
     match swc.storage().get_header(&hash) {
         Some(header) => {
@@ -139,6 +153,7 @@ pub extern "C" fn Java_com_nervosnetwork_ckblightclient_LightClientNative_native
         }
         None => ptr::null_mut(),
     }
+    })
 }
 
 /// Get header by block number (two-hop lookup: BlockNumber → BlockHash → Header)
@@ -149,6 +164,7 @@ pub extern "C" fn Java_com_nervosnetwork_ckblightclient_LightClientNative_native
     _class: JClass,
     block_number: JString,
 ) -> jstring {
+    guard_jni(std::ptr::null_mut(), move || {
     check_running!(env);
 
     let number_str: String = match env.get_string(&block_number) {
@@ -209,6 +225,7 @@ pub extern "C" fn Java_com_nervosnetwork_ckblightclient_LightClientNative_native
             ptr::null_mut()
         }
     }
+    })
 }
 
 /// Fetch header (with fetch status)
@@ -218,6 +235,7 @@ pub extern "C" fn Java_com_nervosnetwork_ckblightclient_LightClientNative_native
     _class: JClass,
     hash: JString,
 ) -> jstring {
+    guard_jni(std::ptr::null_mut(), move || {
     check_running!(env);
 
     let hash_str: String = match env.get_string(&hash) {
@@ -253,7 +271,13 @@ pub extern "C" fn Java_com_nervosnetwork_ckblightclient_LightClientNative_native
         }
     };
 
-    let hash = packed::Byte32::from_slice(h256.as_bytes()).expect("H256 to Byte32");
+    let hash = match packed::Byte32::from_slice(h256.as_bytes()) {
+        Ok(h) => h,
+        Err(e) => {
+            error!("nativeFetchHeader: Byte32 conversion failed: {}", e);
+            return ptr::null_mut();
+        }
+    };
 
     let fetch_status: FetchStatus<HeaderView> =
         if let Some(header) = swc.storage().get_header(&hash) {
@@ -283,6 +307,7 @@ pub extern "C" fn Java_com_nervosnetwork_ckblightclient_LightClientNative_native
         };
 
     to_jstring(&mut env, &fetch_status)
+    })
 }
 
 /// Set scripts
@@ -293,6 +318,7 @@ pub extern "C" fn Java_com_nervosnetwork_ckblightclient_LightClientNative_native
     scripts_json: JString,
     command: i32,
 ) -> jni::sys::jboolean {
+    guard_jni(jni::sys::JNI_FALSE, move || {
     if !is_running() {
         warn!("Light client not running");
         return jni::sys::JNI_FALSE;
@@ -361,6 +387,7 @@ pub extern "C" fn Java_com_nervosnetwork_ckblightclient_LightClientNative_native
     peers.clear_matched_blocks(&mut matched_blocks);
 
     jni::sys::JNI_TRUE
+    })
 }
 
 /// Get scripts
@@ -369,6 +396,7 @@ pub extern "C" fn Java_com_nervosnetwork_ckblightclient_LightClientNative_native
     mut env: JNIEnv,
     _class: JClass,
 ) -> jstring {
+    guard_jni(std::ptr::null_mut(), move || {
     check_running!(env);
 
     let swc = match STORAGE_WITH_DATA.get() {
@@ -393,6 +421,7 @@ pub extern "C" fn Java_com_nervosnetwork_ckblightclient_LightClientNative_native
         })
         .collect();
     to_jstring(&mut env, &scripts)
+    })
 }
 
 /// Get local node info
@@ -401,6 +430,7 @@ pub extern "C" fn Java_com_nervosnetwork_ckblightclient_LightClientNative_native
     mut env: JNIEnv,
     _class: JClass,
 ) -> jstring {
+    guard_jni(std::ptr::null_mut(), move || {
     check_running!(env);
 
     let net_controller = match NET_CONTROL.get() {
@@ -431,6 +461,7 @@ pub extern "C" fn Java_com_nervosnetwork_ckblightclient_LightClientNative_native
     };
 
     to_jstring(&mut env, &node_info)
+    })
 }
 
 /// Get peers
@@ -439,6 +470,7 @@ pub extern "C" fn Java_com_nervosnetwork_ckblightclient_LightClientNative_native
     mut env: JNIEnv,
     _class: JClass,
 ) -> jstring {
+    guard_jni(std::ptr::null_mut(), move || {
     check_running!(env);
 
     let net_controller = match NET_CONTROL.get() {
@@ -478,6 +510,7 @@ pub extern "C" fn Java_com_nervosnetwork_ckblightclient_LightClientNative_native
     }
 
     to_jstring(&mut env, &remote_nodes)
+    })
 }
 
 // TODO: Implement remaining 10 APIs:
@@ -503,6 +536,7 @@ pub extern "C" fn Java_com_nervosnetwork_ckblightclient_LightClientNative_native
     limit: jni::sys::jint,
     cursor_jstr: JString,
 ) -> jstring {
+    guard_jni(std::ptr::null_mut(), move || {
     check_running!(env);
 
     let search_key_str: String = match env.get_string(&search_key_json) {
@@ -629,6 +663,7 @@ pub extern "C" fn Java_com_nervosnetwork_ckblightclient_LightClientNative_native
     };
 
     to_jstring(&mut env, &result)
+    })
 }
 
 #[no_mangle]
@@ -640,6 +675,7 @@ pub extern "C" fn Java_com_nervosnetwork_ckblightclient_LightClientNative_native
     limit: jni::sys::jint,
     cursor_jstr: JString,
 ) -> jstring {
+    guard_jni(std::ptr::null_mut(), move || {
 
     check_running!(env);
 
@@ -790,6 +826,7 @@ pub extern "C" fn Java_com_nervosnetwork_ckblightclient_LightClientNative_native
     };
 
     to_jstring(&mut env, &result)
+    })
 }
 
 #[no_mangle]
@@ -798,6 +835,7 @@ pub extern "C" fn Java_com_nervosnetwork_ckblightclient_LightClientNative_native
     _class: JClass,
     search_key_json: JString,
 ) -> jstring {
+    guard_jni(std::ptr::null_mut(), move || {
 
     check_running!(env);
 
@@ -873,6 +911,7 @@ pub extern "C" fn Java_com_nervosnetwork_ckblightclient_LightClientNative_native
     };
 
     to_jstring(&mut env, &result)
+    })
 }
 
 #[no_mangle]
@@ -881,6 +920,7 @@ pub extern "C" fn Java_com_nervosnetwork_ckblightclient_LightClientNative_native
     _class: JClass,
     tx_json: JString,
 ) -> jstring {
+    guard_jni(std::ptr::null_mut(), move || {
     check_running!(env);
 
     let tx_str: String = match env.get_string(&tx_json) {
@@ -929,17 +969,25 @@ pub extern "C" fn Java_com_nervosnetwork_ckblightclient_LightClientNative_native
         }
     };
 
-    // Add to pending transactions
-    swc.pending_txs()
-        .write()
-        .expect("pending_txs lock is poisoned")
-        .push(tx_view.clone(), cycles);
+    // Add to pending transactions. Recover from poisoning rather than
+    // double-panic on a lock that was poisoned by a prior panic — a
+    // re-panic across the FFI boundary is undefined behavior.
+    let mut pending_write = match swc.pending_txs().write() {
+        Ok(g) => g,
+        Err(poisoned) => {
+            error!("pending_txs write lock poisoned; recovering: {:?}", poisoned);
+            poisoned.into_inner()
+        }
+    };
+    pending_write.push(tx_view.clone(), cycles);
+    drop(pending_write);
 
     debug!("Transaction added to pending pool: {}", tx_view.hash());
 
     // Return the transaction hash
     let tx_hash: H256 = tx_view.hash().unpack();
     to_jstring(&mut env, &tx_hash)
+    })
 }
 
 #[no_mangle]
@@ -948,6 +996,7 @@ pub extern "C" fn Java_com_nervosnetwork_ckblightclient_LightClientNative_native
     _class: JClass,
     hash: JString,
 ) -> jstring {
+    guard_jni(std::ptr::null_mut(), move || {
     check_running!(env);
 
     let hash_str: String = match env.get_string(&hash) {
@@ -968,13 +1017,28 @@ pub extern "C" fn Java_com_nervosnetwork_ckblightclient_LightClientNative_native
             return ptr::null_mut();
         }
     };
-    let byte32 = packed::Byte32::from_slice(tx_hash.as_bytes()).expect("H256 to Byte32");
+    let byte32 = match packed::Byte32::from_slice(tx_hash.as_bytes()) {
+        Ok(b) => b,
+        Err(e) => {
+            error!("Byte32 conversion failed: {}", e);
+            return ptr::null_mut();
+        }
+    };
 
     let swc = match STORAGE_WITH_DATA.get() {
         Some(s) => s,
         None => {
             error!("nativeGetTransaction: storage not initialized");
             return ptr::null_mut();
+        }
+    };
+
+    // Recover from poisoning rather than double-panic across the FFI boundary.
+    let pending_read = match swc.pending_txs().read() {
+        Ok(g) => g,
+        Err(poisoned) => {
+            error!("nativeGetTransaction: pending_txs read lock poisoned; recovering");
+            poisoned.into_inner()
         }
     };
 
@@ -988,7 +1052,7 @@ pub extern "C" fn Java_com_nervosnetwork_ckblightclient_LightClientNative_native
                 status: crate::service::Status::Committed,
             },
         }
-    } else if let Some((transaction, cycles, _)) = swc.pending_txs().read().expect("pending_txs lock").get(&byte32) {
+    } else if let Some((transaction, cycles, _)) = pending_read.get(&byte32) {
         debug!("nativeGetTransaction: found pending tx {}", hash_str);
         crate::service::TransactionWithStatus {
             transaction: Some(transaction.into_view().into()),
@@ -1011,6 +1075,7 @@ pub extern "C" fn Java_com_nervosnetwork_ckblightclient_LightClientNative_native
     };
 
     to_jstring(&mut env, &result)
+    })
 }
 
 #[no_mangle]
@@ -1019,6 +1084,7 @@ pub extern "C" fn Java_com_nervosnetwork_ckblightclient_LightClientNative_native
     _class: JClass,
     hash: JString,
 ) -> jstring {
+    guard_jni(std::ptr::null_mut(), move || {
     check_running!(env);
 
     let hash_str: String = match env.get_string(&hash) {
@@ -1038,7 +1104,13 @@ pub extern "C" fn Java_com_nervosnetwork_ckblightclient_LightClientNative_native
             return ptr::null_mut();
         }
     };
-    let byte32 = packed::Byte32::from_slice(tx_hash.as_bytes()).expect("H256 to Byte32");
+    let byte32 = match packed::Byte32::from_slice(tx_hash.as_bytes()) {
+        Ok(b) => b,
+        Err(e) => {
+            error!("Byte32 conversion failed: {}", e);
+            return ptr::null_mut();
+        }
+    };
 
     let swc = match STORAGE_WITH_DATA.get() {
         Some(s) => s,
@@ -1064,8 +1136,16 @@ pub extern "C" fn Java_com_nervosnetwork_ckblightclient_LightClientNative_native
         return to_jstring(&mut env, &fetch_status);
     }
 
-    // 2. Check if tx is in pending pool
-    if let Some((transaction, cycles, _)) = swc.pending_txs().read().expect("pending_txs lock").get(&byte32) {
+    // 2. Check if tx is in pending pool. Recover from poisoning to avoid
+    // double-panic across the FFI boundary.
+    let pending_read = match swc.pending_txs().read() {
+        Ok(g) => g,
+        Err(poisoned) => {
+            error!("nativeFetchTransaction: pending_txs read lock poisoned; recovering");
+            poisoned.into_inner()
+        }
+    };
+    if let Some((transaction, cycles, _)) = pending_read.get(&byte32) {
         debug!("nativeFetchTransaction: tx {} is pending", hash_str);
         let tws = crate::service::TransactionWithStatus {
             transaction: Some(transaction.into_view().into()),
@@ -1122,6 +1202,7 @@ pub extern "C" fn Java_com_nervosnetwork_ckblightclient_LightClientNative_native
         };
 
     to_jstring(&mut env, &fetch_status)
+    })
 }
 
 #[no_mangle]
@@ -1130,7 +1211,9 @@ pub extern "C" fn Java_com_nervosnetwork_ckblightclient_LightClientNative_native
     _class: JClass,
     _tx_json: JString,
 ) -> jstring {
+    guard_jni(std::ptr::null_mut(), move || {
     // TODO: Implement
     warn!("nativeEstimateCycles not yet implemented");
     ptr::null_mut()
+    })
 }

--- a/external/ckb-light-client/light-client-lib/src/jni_bridge/rpc_handler.rs
+++ b/external/ckb-light-client/light-client-lib/src/jni_bridge/rpc_handler.rs
@@ -2,6 +2,7 @@
 //!
 //! Provides direct JNI methods for RPC calls instead of HTTP server
 
+use super::panic_guard::guard_jni;
 use super::types::*;
 use crate::service::ScriptStatus;
 use ckb_jsonrpc_types::{BlockView, HeaderView};
@@ -80,6 +81,7 @@ pub extern "C" fn Java_com_nervosnetwork_ckblightclient_LightClientNative_callRp
     _class: JClass,
     method_jstr: JString,
 ) -> jstring {
+    guard_jni(std::ptr::null_mut(), move || {
     // Get method name
     let method: String = match env.get_string(&method_jstr) {
         Ok(s) => s.into(),
@@ -200,4 +202,5 @@ pub extern "C" fn Java_com_nervosnetwork_ckblightclient_LightClientNative_callRp
             jni_rpc_error!(&mut env, -32601, error_msg)
         }
     }
+    })
 }


### PR DESCRIPTION
## Summary
- Add `panic_guard` module with `guard_jni` helper. Every `extern "C"` function in `lifecycle.rs` (4), `query.rs` (16), `dao.rs` (3), and `rpc_handler.rs` (1) — **24 exports total** — wrapped so Rust panics return a sentinel instead of unwinding across the FFI boundary (UB since Rust 1.71).
- Recover from RwLock poisoning on `PendingTxs` at the 3 `.expect("pending_txs lock")` sites in `nativeSendTransaction`, `nativeGetTransaction`, `nativeFetchTransaction`. Without this, a single panic anywhere in pending-tx handling cascades into permanent service degradation.
- Replace 4x `try_into().unwrap()` in `dao.rs` and 4x `Byte32::from_slice(...).expect("H256 to Byte32")` in `query.rs` with explicit pattern matches. Safe in practice (32-byte inputs verified upstream) but eliminates the panic landmines per audit acceptance criteria.

## Test plan
- [x] `cargo check --workspace` — Finished in 0.53s
- [x] `cargo check --tests --workspace` — Finished in 1m 40s
- [x] `./build-android-jni.sh` — all 4 ABIs built successfully
- [ ] CI release workflow rebuilds with new JNI (verified at v1.7.0 cut)
- [ ] Smoke harness passes on next nightly run

## Coverage

`grep -c "^pub extern \"C\"" jni_bridge/*.rs` = 24 functions
`grep -c "guard_jni(" jni_bridge/*.rs` = 24 wrapped + 4 `use` imports

`grep -E "\.expect\(|\.unwrap\(\)" jni_bridge/*.rs` = 0 hits in function bodies

## Notes
- Finding High 4 (partial-init recoverability) intentionally split into #217. Combining would have ballooned the diff.
- `nativeGetStatus` falls back to `STATE_STOPPED` on panic (defined value, surfaces as "broken" to Kotlin side) rather than a magic number.

Closes #215
Refs #186 Findings High 2 + High 3