### PR TITLE
docs(security): BouncyCastle 1.70 accepted-risk disclosure (#219)

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -53,17 +53,53 @@ Private keys and BIP39 mnemonics are encrypted using Android's `EncryptedSharedP
 
 ## Known Limitations
 
-- This software has **not undergone a formal security audit**
-- Single wallet support only (no wallet isolation between accounts)
-- No certificate pinning for any network connections
-- Light client P2P traffic is not encrypted beyond CKB protocol-level protections
+- An internal Milestone 4 security audit completed 2026-05-19 (#186, #187, #188 in the issue tracker). External audit by an independent firm is tracked under #204 and may engage post-grant. No formal third-party audit has been completed at the time of writing.
+- PIN derivation currently uses a single Blake2b pass with a per-device salt. Strengthening to Argon2id with cumulative lockout is tracked under #214 for v1.7.0.
+- Keystore-backed wallet keys are not yet bound to per-operation user authentication. Adding `setUserAuthenticationRequired` plus `BiometricPrompt`-gated `CryptoObject` use is tracked under #213 for v1.7.0.
+- Network switch requires a full app restart. The embedded Rust JNI bridge holds global state in `OnceLock` and cannot be re-initialized in-process. The app handles this with a confirm dialog plus `Process.killProcess` (see `GatewayRepository.switchNetwork`).
+- No certificate pinning for any outgoing connections (CoinGecko price fetch only; no auth headers, no user-supplied URLs).
+- Light client P2P traffic is not encrypted beyond CKB protocol-level protections.
+
+## Accepted Risks
+
+The following items have been identified during security review and are accepted for the current release with documented reasoning. They are revisited at each milestone.
+
+### BouncyCastle `bcprov-jdk15on` 1.70 — CVE chain (transitive via `ckb-sdk-java` 4.0.0)
+
+**Acknowledged CVEs**
+
+| CVE | Severity | Vulnerable code path |
+|-----|----------|----------------------|
+| CVE-2024-29857 | High (CVSS 7.5) | EC certificate import with crafted F2m parameters causes excessive CPU in `ECCurve.java` |
+| CVE-2023-33201 | Medium (CVSS 5.3) | LDAP wildcard handling in X.500 name parsing can disclose information |
+| CVE-2025-8916 | Medium | Excessive memory allocation in BC's PKIX/Provider DER parse path; affects 1.44 through 1.78 |
+
+**Reachability analysis**
+
+Pocket Node uses BouncyCastle only as a transitive dependency of `ckb-sdk-java`, which in turn uses it for Blake2b digest, secp256k1 signing helpers, and ASN.1/DER serialization of CKB transactions. The app does **not**:
+
+- Import third-party EC certificates from any source (the lock script is fixed `secp256k1-blake160`)
+- Parse LDAP, X.500, or PKIX structures from network input or user input
+- Accept DER/ASN.1 input from anywhere outside the CKB transaction format, which is validated by `ckb-sdk-java` against a fixed schema before reaching BC code paths
+- Run a TLS/PKI server, certificate authority, or X.509 verification flow
+
+Therefore the three CVEs listed above have no reachable attack path from any Pocket Node call site. The `jdk15on` artifact line is end-of-life upstream; BouncyCastle 1.78+ ships as `bcprov-jdk18on`. A direct Pocket Node upgrade would conflict with the `ckb-sdk-java` 4.0.0 dependency resolution.
+
+**Mitigation path**
+
+Migration tracking: an upstream issue against `nervosnetwork/ckb-sdk-java` requesting `bcprov-jdk18on` ≥ 1.78 is filed under #219 in this repo. Once upstream ships a compatible release, this row will be revisited.
+
+**Reviewer**: internal M4 Phase 1 audit (#188 Finding High 1)
+**Sign-off date**: 2026-05-19
+**Next review**: at v2.0.0 release cut or on publication of any new BouncyCastle CVE with a reachable code path.
 
 ## Supported Versions
 
 | Version | Supported |
 |---------|-----------|
-| 1.1.x   | Yes       |
-| < 1.1.0 | No        |
+| 1.6.x   | Yes       |
+| 1.5.x   | Security fixes via in-app updater to 1.6.1 |
+| < 1.5.0 | No        |
 
 ## Scope
 


### PR DESCRIPTION
## Summary
- Add an Accepted Risks section to SECURITY.md covering the BouncyCastle 1.70 multi-CVE chain (CVE-2024-29857, CVE-2023-33201, CVE-2025-8916) with reachability analysis and mitigation tracking.
- Refresh adjacent Known Limitations entries: drop the stale "Single wallet support only" line (M3 added multi-wallet), replace the old "PIN 5 attempts -> 30s lockout" copy with pointers to the #213/#214 follow-up issues, and add the network-switch process-restart note to keep SECURITY.md aligned with the post-M4-Phase-1 reality.
- Update the Supported Versions table from 1.1.x to 1.5.x+ (current is 1.6.1).

## Test plan
- [x] Render-check SECURITY.md on GitHub — confirmed in PR preview
- [ ] Cross-link added to README in a future doc-polish pass (tracked under #208)

## Notes
- The underlying BouncyCastle CVE chain is the audit's accepted-risk item, not a code fix. Per the dep audit (#188 Finding High 1), no call site in Pocket Node reaches the vulnerable EC import, LDAP/X.500 parser, or hostile DER parser. The path-to-clear is upstream `ckb-sdk-java` migrating from `bcprov-jdk15on` to `bcprov-jdk18on` >= 1.78.
- Upstream issue against `nervosnetwork/ckb-sdk-java` is referenced from #219 — that ask is non-blocking for v1.7.0.

Closes #219
Refs #188 Finding High 1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated security documentation with expanded known limitations section, added accepted risks assessment, and revised supported versions compatibility table.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/RaheemJnr/pocket-node/pull/223?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->