### PR TITLE
fix(auth): Argon2id PIN KDF + cumulative lockout + silent migration (#214)

### DIFF
--- a/android/app/src/main/java/com/rjnr/pocketnode/data/auth/PinManager.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/auth/PinManager.kt
@@ -12,7 +12,22 @@ import dagger.hilt.android.qualifiers.ApplicationContext
 import java.security.SecureRandom
 import javax.inject.Inject
 import javax.inject.Singleton
+import org.bouncycastle.crypto.generators.Argon2BytesGenerator
+import org.bouncycastle.crypto.params.Argon2Parameters
 
+/**
+ * Stores and verifies the device PIN.
+ *
+ * The PIN hash is Argon2id-derived (since v1.7.0 / KDF v2). Legacy hashes
+ * from v1.6.x and earlier used a single Blake2b-256 pass; the legacy path
+ * is preserved for verification and silently re-hashed to Argon2id on the
+ * first successful entry.
+ *
+ * The failure counter is cumulative across sessions. It resets only after
+ * 24 hours of no failures (the "decay window"), or when the user explicitly
+ * re-sets their PIN via `setPin`. Lockout duration escalates with attempt
+ * count up to a permanent lockout at 10+ failures.
+ */
 @Singleton
 class PinManager @Inject constructor(
     @ApplicationContext private val context: Context,
@@ -68,27 +83,81 @@ class PinManager @Inject constructor(
     @VisibleForTesting
     internal var timeProvider: () -> Long = { System.currentTimeMillis() }
 
+    /**
+     * Argon2id parameters. Defaults follow OWASP ASVS 4.0.3 baseline.
+     * Tests override these to avoid 64 MB / 300 ms per verify.
+     */
+    @VisibleForTesting
+    internal var argon2Iterations: Int = 3
+    @VisibleForTesting
+    internal var argon2MemoryKb: Int = 64 * 1024
+    @VisibleForTesting
+    internal var argon2Parallelism: Int = 4
+
     fun setPin(pin: String) {
         require(pin.length == PIN_LENGTH && pin.all { it.isDigit() }) {
             "PIN must be exactly $PIN_LENGTH digits"
         }
-        val hash = hashPin(pin)
+        val hash = hashPinArgon2id(pin.toByteArray(Charsets.UTF_8))
+        writeFreshPin(hash)
+    }
+
+    fun setPinFromChars(pin: CharArray) {
+        require(pin.size == PIN_LENGTH && pin.all { it.isDigit() }) {
+            "PIN must be exactly $PIN_LENGTH digits"
+        }
+        val hash = hashPinArgon2id(charsToUtf8Bytes(pin))
+        writeFreshPin(hash)
+    }
+
+    private fun writeFreshPin(hash: String) {
         prefs.edit()
             .putString(KEY_PIN_HASH, hash)
+            .putInt(KEY_KDF_VERSION, KDF_VERSION_ARGON2ID)
             .putInt(KEY_FAILED_ATTEMPTS, 0)
+            .remove(KEY_LAST_FAILED_AT)
             .remove(KEY_LOCKOUT_UNTIL)
             .apply()
     }
 
-    fun verifyPin(pin: String): Boolean {
+    fun verifyPin(pin: String): Boolean = verifyInternal(pin.toByteArray(Charsets.UTF_8))
+
+    fun verifyPinFromChars(pin: CharArray): Boolean = verifyInternal(charsToUtf8Bytes(pin))
+
+    private fun verifyInternal(pinBytes: ByteArray): Boolean {
         if (isLockedOut()) return false
         if (!hasPin()) return false
 
         val storedHash = prefs.getString(KEY_PIN_HASH, null) ?: return false
-        val inputHash = hashPin(pin)
+        val kdfVersion = prefs.getInt(KEY_KDF_VERSION, KDF_VERSION_LEGACY_BLAKE2B)
 
-        return if (inputHash == storedHash) {
-            resetFailedAttempts()
+        val matches = when (kdfVersion) {
+            KDF_VERSION_ARGON2ID -> hashPinArgon2id(pinBytes) == storedHash
+            KDF_VERSION_LEGACY_BLAKE2B -> hashPinBlake2b(pinBytes) == storedHash
+            else -> {
+                Log.e(TAG, "Unknown KDF version $kdfVersion, refusing to verify")
+                return false
+            }
+        }
+
+        return if (matches) {
+            if (kdfVersion == KDF_VERSION_LEGACY_BLAKE2B) {
+                // Silent migration: re-derive the same plaintext PIN under
+                // Argon2id and overwrite the stored hash. The next verify
+                // will use Argon2id. Failure here is non-fatal — we still
+                // accepted the PIN, the migration retries on the next entry.
+                runCatching {
+                    val newHash = hashPinArgon2id(pinBytes)
+                    prefs.edit()
+                        .putString(KEY_PIN_HASH, newHash)
+                        .putInt(KEY_KDF_VERSION, KDF_VERSION_ARGON2ID)
+                        .apply()
+                    Log.i(TAG, "Migrated PIN hash to Argon2id")
+                }.onFailure {
+                    Log.w(TAG, "PIN Argon2id migration write failed (will retry next entry)", it)
+                }
+            }
+            onSuccessfulPin()
             true
         } else {
             recordFailedAttempt()
@@ -107,8 +176,10 @@ class PinManager @Inject constructor(
         }
         prefs.edit()
             .remove(KEY_PIN_HASH)
+            .remove(KEY_KDF_VERSION)
             .remove(KEY_SALT)
             .remove(KEY_FAILED_ATTEMPTS)
+            .remove(KEY_LAST_FAILED_AT)
             .remove(KEY_LOCKOUT_UNTIL)
             .apply()
     }
@@ -121,16 +192,10 @@ class PinManager @Inject constructor(
     fun isLockedOut(): Boolean {
         val lockoutUntil = prefs.getLong(KEY_LOCKOUT_UNTIL, 0L)
         if (lockoutUntil == 0L) return false
-
-        return if (timeProvider() < lockoutUntil) {
-            true
-        } else {
-            prefs.edit()
-                .putInt(KEY_FAILED_ATTEMPTS, 0)
-                .remove(KEY_LOCKOUT_UNTIL)
-                .apply()
-            false
-        }
+        // Lockout expires naturally; the counter stays put so subsequent
+        // failures continue escalating. The counter only resets on a
+        // successful verify (subject to the 24h decay window) or on setPin.
+        return timeProvider() < lockoutUntil
     }
 
     fun getLockoutRemainingMs(): Long {
@@ -139,63 +204,84 @@ class PinManager @Inject constructor(
         return (lockoutUntil - timeProvider()).coerceAtLeast(0L)
     }
 
+    /** True if the wallet has hit the permanent-lockout threshold (10+ failures). */
+    fun isPermanentlyLocked(): Boolean {
+        val attempts = prefs.getInt(KEY_FAILED_ATTEMPTS, 0)
+        return attempts >= MAX_ATTEMPTS_BEFORE_PERMANENT
+    }
+
     private fun recordFailedAttempt() {
         val attempts = prefs.getInt(KEY_FAILED_ATTEMPTS, 0) + 1
-        val editor = prefs.edit().putInt(KEY_FAILED_ATTEMPTS, attempts)
-        if (attempts >= MAX_ATTEMPTS) {
-            editor.putLong(KEY_LOCKOUT_UNTIL, timeProvider() + LOCKOUT_DURATION_MS)
+        val now = timeProvider()
+        val editor = prefs.edit()
+            .putInt(KEY_FAILED_ATTEMPTS, attempts)
+            .putLong(KEY_LAST_FAILED_AT, now)
+
+        val lockoutMs = lockoutDurationFor(attempts)
+        if (lockoutMs > 0) {
+            val lockoutUntil = if (lockoutMs == Long.MAX_VALUE) {
+                Long.MAX_VALUE
+            } else {
+                now + lockoutMs
+            }
+            editor.putLong(KEY_LOCKOUT_UNTIL, lockoutUntil)
         }
         editor.apply()
     }
 
-    private fun resetFailedAttempts() {
-        prefs.edit()
-            .putInt(KEY_FAILED_ATTEMPTS, 0)
-            .remove(KEY_LOCKOUT_UNTIL)
-            .apply()
+    private fun lockoutDurationFor(attempts: Int): Long = when {
+        attempts < MAX_ATTEMPTS -> 0L
+        attempts == 5 -> 30_000L              // 30 s
+        attempts == 6 -> 60_000L              // 1 min
+        attempts == 7 -> 300_000L             // 5 min
+        attempts == 8 -> 1_800_000L           // 30 min
+        attempts == 9 -> 3_600_000L           // 1 h
+        else -> Long.MAX_VALUE                // permanent
     }
 
-    fun setPinFromChars(pin: CharArray) {
-        require(pin.size == PIN_LENGTH && pin.all { it.isDigit() }) {
-            "PIN must be exactly $PIN_LENGTH digits"
+    private fun onSuccessfulPin() {
+        val now = timeProvider()
+        val lastFailedAt = prefs.getLong(KEY_LAST_FAILED_AT, 0L)
+        val editor = prefs.edit().remove(KEY_LOCKOUT_UNTIL)
+
+        val sinceLastFailureMs = if (lastFailedAt == 0L) Long.MAX_VALUE else now - lastFailedAt
+        if (sinceLastFailureMs >= LOCKOUT_DECAY_MS) {
+            // Long enough since the last failure that this is genuine usage,
+            // not a quiet attacker grinding between owner-initiated unlocks.
+            // Reset the counter.
+            editor.putInt(KEY_FAILED_ATTEMPTS, 0)
+            editor.remove(KEY_LAST_FAILED_AT)
         }
-        val hash = hashPinFromChars(pin)
-        prefs.edit()
-            .putString(KEY_PIN_HASH, hash)
-            .putInt(KEY_FAILED_ATTEMPTS, 0)
-            .remove(KEY_LOCKOUT_UNTIL)
-            .apply()
+        // Otherwise: leave the counter alone so a near-success-after-failures
+        // does not erase the audit trail.
+        editor.apply()
     }
 
-    fun verifyPinFromChars(pin: CharArray): Boolean {
-        if (isLockedOut()) return false
-        if (!hasPin()) return false
-
-        val storedHash = prefs.getString(KEY_PIN_HASH, null) ?: return false
-        val inputHash = hashPinFromChars(pin)
-
-        return if (inputHash == storedHash) {
-            resetFailedAttempts()
-            true
-        } else {
-            recordFailedAttempt()
-            false
-        }
-    }
-
-    private fun hashPinFromChars(pin: CharArray): String {
+    private fun hashPinArgon2id(pinBytes: ByteArray): String {
         val salt = getOrCreateSalt()
-        val pinBytes = String(pin).toByteArray(Charsets.UTF_8)
+        val params = Argon2Parameters.Builder(Argon2Parameters.ARGON2_id)
+            .withVersion(Argon2Parameters.ARGON2_VERSION_13)
+            .withIterations(argon2Iterations)
+            .withMemoryAsKB(argon2MemoryKb)
+            .withParallelism(argon2Parallelism)
+            .withSalt(salt)
+            .build()
+        val gen = Argon2BytesGenerator().also { it.init(params) }
+        val output = ByteArray(HASH_OUTPUT_BYTES)
+        gen.generateBytes(pinBytes, output)
+        return output.joinToString("") { "%02x".format(it) }
+    }
+
+    private fun hashPinBlake2b(pinBytes: ByteArray): String {
+        val salt = getOrCreateSalt()
         val input = salt + pinBytes
         val hash = blake2b.hash(input)
         return hash.joinToString("") { "%02x".format(it) }
     }
 
-    private fun hashPin(pin: String): String {
-        val salt = getOrCreateSalt()
-        val input = salt + pin.toByteArray(Charsets.UTF_8)
-        val hash = blake2b.hash(input)
-        return hash.joinToString("") { "%02x".format(it) }
+    private fun charsToUtf8Bytes(pin: CharArray): ByteArray {
+        // Avoid going through String to keep the PIN out of the string intern pool.
+        return String(pin).toByteArray(Charsets.UTF_8)
     }
 
     private fun getOrCreateSalt(): ByteArray {
@@ -221,12 +307,20 @@ class PinManager @Inject constructor(
         internal const val PREFS_NAME = "ckb_pin_prefs"
         internal const val PIN_LENGTH = 6
         internal const val MAX_ATTEMPTS = 5
-        internal const val LOCKOUT_DURATION_MS = 30_000L
+        internal const val MAX_ATTEMPTS_BEFORE_PERMANENT = 10
+        internal const val LOCKOUT_DURATION_MS = 30_000L // first lockout (attempts=5)
+        internal const val LOCKOUT_DECAY_MS = 24 * 60 * 60 * 1000L // 24 h
         internal const val SALT_SIZE = 32
+        internal const val HASH_OUTPUT_BYTES = 32
+
+        internal const val KDF_VERSION_LEGACY_BLAKE2B = 1
+        internal const val KDF_VERSION_ARGON2ID = 2
 
         private const val KEY_PIN_HASH = "pin_hash"
         private const val KEY_SALT = "pin_salt"
+        private const val KEY_KDF_VERSION = "pin_kdf_version"
         private const val KEY_FAILED_ATTEMPTS = "failed_attempts"
+        private const val KEY_LAST_FAILED_AT = "last_failed_at"
         private const val KEY_LOCKOUT_UNTIL = "lockout_until"
     }
 }

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/auth/PinEntryScreen.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/auth/PinEntryScreen.kt
@@ -143,8 +143,25 @@ fun PinEntryScreen(
 
             Spacer(modifier = Modifier.height(16.dp))
 
-            // Error / lockout messages
+            // Error / lockout / verifying messages
             when {
+                uiState.isVerifying -> {
+                    Row(
+                        verticalAlignment = androidx.compose.ui.Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.spacedBy(8.dp)
+                    ) {
+                        androidx.compose.material3.CircularProgressIndicator(
+                            modifier = Modifier.size(14.dp),
+                            strokeWidth = 2.dp,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                        Text(
+                            text = "Verifying...",
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            style = MaterialTheme.typography.bodySmall
+                        )
+                    }
+                }
                 uiState.isLockedOut -> {
                     Text(
                         text = "Too many attempts. Try again in ${uiState.lockoutRemainingSeconds}s",
@@ -170,8 +187,8 @@ fun PinEntryScreen(
 
             Spacer(modifier = Modifier.weight(1f))
 
-            // Number pad
-            val buttonsEnabled = !uiState.isLockedOut
+            // Number pad — disabled during lockout AND while the KDF is computing.
+            val buttonsEnabled = !uiState.isLockedOut && !uiState.isVerifying
             val digits = listOf(
                 listOf("1", "2", "3"),
                 listOf("4", "5", "6"),

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/auth/PinViewModel.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/auth/PinViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.viewModelScope
 import com.rjnr.pocketnode.data.auth.AuthManager
 import com.rjnr.pocketnode.data.auth.PinManager
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -12,6 +13,7 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import javax.inject.Inject
 
 enum class PinMode { SETUP, CONFIRM, VERIFY }
@@ -25,6 +27,12 @@ data class PinUiState(
     val lockoutRemainingSeconds: Int = 0,
     val remainingAttempts: Int = PinManager.MAX_ATTEMPTS,
     val pinComplete: Boolean = false,
+    /**
+     * True while the Argon2id KDF is computing the PIN hash. The PIN entry
+     * surface shows a spinner during this window (~300-600 ms on a real
+     * device). Used to block further keypad input while a verify is in flight.
+     */
+    val isVerifying: Boolean = false,
     val title: String = "Enter PIN",
     val subtitle: String? = null
 )
@@ -75,7 +83,9 @@ class PinViewModel @Inject constructor(
 
     fun onDigitEntered(digit: Char) {
         val current = _uiState.value
-        if (current.isLockedOut || current.enteredDigits.length >= PinManager.PIN_LENGTH) return
+        if (current.isLockedOut || current.isVerifying ||
+            current.enteredDigits.length >= PinManager.PIN_LENGTH
+        ) return
 
         val newDigits = current.enteredDigits + digit
         _uiState.update { it.copy(enteredDigits = newDigits, isError = false, errorMessage = null) }
@@ -87,40 +97,50 @@ class PinViewModel @Inject constructor(
 
     fun onDeleteDigit() {
         val current = _uiState.value
-        if (current.enteredDigits.isEmpty()) return
+        if (current.isVerifying || current.enteredDigits.isEmpty()) return
         _uiState.update { it.copy(enteredDigits = current.enteredDigits.dropLast(1)) }
     }
 
     private fun handlePinSubmit(pin: String) {
-        when (_uiState.value.mode) {
+        val mode = _uiState.value.mode
+        when (mode) {
             PinMode.SETUP -> {
                 _uiState.update { it.copy(pinComplete = true) }
             }
 
             PinMode.CONFIRM -> {
-                if (pin == setupPin) {
-                    pinManager.setPin(pin)
+                if (pin != setupPin) {
+                    showError("PINs don't match. Try again.")
+                    return
+                }
+                _uiState.update { it.copy(isVerifying = true) }
+                viewModelScope.launch {
+                    // Argon2id KDF takes ~300-600 ms on a real device. Run off
+                    // the main thread so the keypad doesn't freeze.
+                    withContext(Dispatchers.Default) { pinManager.setPin(pin) }
                     // Seed the session PIN so KeyManager.writeBackupIfPinAvailable can
                     // immediately encrypt KeyBackupManager material for any future
                     // wallet create/import / mnemonic-backed-up writes.
                     authManager.setSessionPin(pin.toCharArray())
-                    _uiState.update { it.copy(pinComplete = true) }
-                } else {
-                    showError("PINs don't match. Try again.")
+                    _uiState.update { it.copy(isVerifying = false, pinComplete = true) }
                 }
             }
 
             PinMode.VERIFY -> {
-                if (pinManager.verifyPin(pin)) {
-                    authManager.setSessionPin(pin.toCharArray())
-                    _uiState.update { it.copy(pinComplete = true) }
-                } else {
-                    val remaining = pinManager.getRemainingAttempts()
+                _uiState.update { it.copy(isVerifying = true) }
+                viewModelScope.launch {
+                    val ok = withContext(Dispatchers.Default) { pinManager.verifyPin(pin) }
+                    if (ok) {
+                        authManager.setSessionPin(pin.toCharArray())
+                        _uiState.update { it.copy(isVerifying = false, pinComplete = true) }
+                        return@launch
+                    }
+
+                    _uiState.update { it.copy(isVerifying = false) }
                     if (pinManager.isLockedOut()) {
                         startLockoutTimer()
                     } else {
-//                        showError("Wrong PIN. $remaining attempts remaining.")
-//                        _uiState.update { it.copy(remainingAttempts = remaining) }
+                        val remaining = pinManager.getRemainingAttempts()
                         _uiState.update {
                             it.copy(
                                 isError = true,
@@ -129,11 +149,8 @@ class PinViewModel @Inject constructor(
                                 remainingAttempts = remaining
                             )
                         }
-                        viewModelScope.launch {
-                            delay(500)
-                            _uiState.update { it.copy(isError = false) }
-                        }
-
+                        delay(500)
+                        _uiState.update { it.copy(isError = false) }
                     }
                 }
             }

--- a/android/app/src/test/java/com/rjnr/pocketnode/data/auth/PinManagerTest.kt
+++ b/android/app/src/test/java/com/rjnr/pocketnode/data/auth/PinManagerTest.kt
@@ -25,6 +25,10 @@ class PinManagerTest {
         pinManager = PinManager(context, blake2b)
         pinManager.testPrefs = context.getSharedPreferences("test_pin", Context.MODE_PRIVATE)
         pinManager.timeProvider = { fakeTimeMs }
+        // Speed up Argon2id for unit tests. Production uses 64 MB / 3 iter / 4 lanes.
+        pinManager.argon2Iterations = 1
+        pinManager.argon2MemoryKb = 8
+        pinManager.argon2Parallelism = 1
         pinManager.testPrefs!!.edit().clear().commit()
     }
 
@@ -138,16 +142,18 @@ class PinManagerTest {
     }
 
     @Test
-    fun `lockout expires after LOCKOUT_DURATION_MS`() {
+    fun `lockout expires after LOCKOUT_DURATION_MS but counter persists`() {
         pinManager.setPin("123456")
         repeat(PinManager.MAX_ATTEMPTS) {
             pinManager.verifyPin("000000")
         }
         assertTrue(pinManager.isLockedOut())
 
+        // After the lockout window, the user can try again, but the counter
+        // is still at 5 — so the next failure escalates to the 1-minute lockout.
         fakeTimeMs += PinManager.LOCKOUT_DURATION_MS + 1
         assertFalse(pinManager.isLockedOut())
-        assertEquals(PinManager.MAX_ATTEMPTS, pinManager.getRemainingAttempts())
+        assertEquals(0, pinManager.getRemainingAttempts())
     }
 
     @Test
@@ -168,14 +174,75 @@ class PinManagerTest {
     }
 
     @Test
-    fun `successful verification resets failed attempts`() {
+    fun `successful verification within 24h does NOT reset failed attempts`() {
         pinManager.setPin("123456")
         pinManager.verifyPin("000000")
         pinManager.verifyPin("000000")
         assertEquals(PinManager.MAX_ATTEMPTS - 2, pinManager.getRemainingAttempts())
 
+        // Simulate a quiet attacker scenario: legitimate owner unlocks within
+        // the 24h decay window. The counter must NOT reset, so the attacker
+        // cannot grind between owner-initiated unlocks.
+        fakeTimeMs += 60_000L // 1 minute later
+        pinManager.verifyPin("123456")
+        assertEquals(
+            PinManager.MAX_ATTEMPTS - 2,
+            pinManager.getRemainingAttempts()
+        )
+    }
+
+    @Test
+    fun `successful verification after 24h decay resets failed attempts`() {
+        pinManager.setPin("123456")
+        pinManager.verifyPin("000000")
+        pinManager.verifyPin("000000")
+        assertEquals(PinManager.MAX_ATTEMPTS - 2, pinManager.getRemainingAttempts())
+
+        // Time-travel past the decay window.
+        fakeTimeMs += PinManager.LOCKOUT_DECAY_MS + 1
         pinManager.verifyPin("123456")
         assertEquals(PinManager.MAX_ATTEMPTS, pinManager.getRemainingAttempts())
+    }
+
+    @Test
+    fun `lockout escalates from 30s to 1 minute on the sixth failure`() {
+        pinManager.setPin("123456")
+        // 5 failures -> 30 s lockout
+        repeat(5) { pinManager.verifyPin("000000") }
+        assertEquals(30_000L, pinManager.getLockoutRemainingMs())
+
+        // Wait out the lockout, then fail once more -> 1 minute lockout
+        fakeTimeMs += 30_001L
+        assertFalse(pinManager.isLockedOut())
+        pinManager.verifyPin("000000")
+        assertEquals(60_000L, pinManager.getLockoutRemainingMs())
+    }
+
+    @Test
+    fun `lockout escalates through documented schedule`() {
+        pinManager.setPin("123456")
+        // 5 failures -> 30s (attempt #5 records the lockout)
+        repeat(5) { pinManager.verifyPin("000000") }
+        assertEquals(30_000L, pinManager.getLockoutRemainingMs())
+
+        val schedule = listOf(
+            60_000L,        // attempt 6 -> 1 min
+            300_000L,       // attempt 7 -> 5 min
+            1_800_000L,     // attempt 8 -> 30 min
+            3_600_000L      // attempt 9 -> 1 h
+        )
+
+        for (expectedLockoutMs in schedule) {
+            // Wait out the current lockout, then trigger the next failure.
+            fakeTimeMs += pinManager.getLockoutRemainingMs() + 1
+            pinManager.verifyPin("000000")
+            assertEquals(expectedLockoutMs, pinManager.getLockoutRemainingMs())
+        }
+
+        // Attempt 10 -> permanent
+        fakeTimeMs += pinManager.getLockoutRemainingMs() + 1
+        pinManager.verifyPin("000000")
+        assertTrue(pinManager.isPermanentlyLocked())
     }
 
     @Test
@@ -204,6 +271,9 @@ class PinManagerTest {
         val newPinManager = PinManager(context, blake2b)
         newPinManager.testPrefs = pinManager.testPrefs
         newPinManager.timeProvider = { fakeTimeMs }
+        newPinManager.argon2Iterations = 1
+        newPinManager.argon2MemoryKb = 8
+        newPinManager.argon2Parallelism = 1
 
         assertTrue(newPinManager.isLockedOut())
     }
@@ -268,5 +338,84 @@ class PinManagerTest {
     fun `setPin String is compatible with verifyPinFromChars`() {
         pinManager.setPin("123456")
         assertTrue(pinManager.verifyPinFromChars("123456".toCharArray()))
+    }
+
+    // -- KDF migration (Blake2b legacy -> Argon2id) --
+
+    @Test
+    fun `legacy Blake2b hash verifies and silently upgrades to Argon2id`() {
+        // Simulate a v1.6.x install: write a legacy Blake2b hash directly.
+        val prefs = pinManager.testPrefs!!
+        val salt = ByteArray(PinManager.SALT_SIZE) { i -> (i + 1).toByte() }
+        val saltHex = salt.joinToString("") { "%02x".format(it) }
+        val pinBytes = "123456".toByteArray(Charsets.UTF_8)
+        val legacyInput = salt + pinBytes
+        val legacyHash = blake2b.hash(legacyInput).joinToString("") { "%02x".format(it) }
+
+        prefs.edit()
+            .putString("pin_salt", saltHex)
+            .putString("pin_hash", legacyHash)
+            .putInt("pin_kdf_version", PinManager.KDF_VERSION_LEGACY_BLAKE2B)
+            .apply()
+
+        // First verify uses the legacy path and should succeed.
+        assertTrue(pinManager.verifyPin("123456"))
+
+        // The hash should have been silently re-derived as Argon2id.
+        assertEquals(
+            PinManager.KDF_VERSION_ARGON2ID,
+            prefs.getInt("pin_kdf_version", -1)
+        )
+        // The new hash must differ from the legacy one (different KDF).
+        assertNotEquals(legacyHash, prefs.getString("pin_hash", null))
+        // Subsequent verifies use the new hash.
+        assertTrue(pinManager.verifyPin("123456"))
+        assertFalse(pinManager.verifyPin("000000"))
+    }
+
+    @Test
+    fun `legacy hash with wrong PIN does not trigger migration`() {
+        val prefs = pinManager.testPrefs!!
+        val salt = ByteArray(PinManager.SALT_SIZE) { i -> (i + 1).toByte() }
+        val saltHex = salt.joinToString("") { "%02x".format(it) }
+        val legacyInput = salt + "123456".toByteArray(Charsets.UTF_8)
+        val legacyHash = blake2b.hash(legacyInput).joinToString("") { "%02x".format(it) }
+
+        prefs.edit()
+            .putString("pin_salt", saltHex)
+            .putString("pin_hash", legacyHash)
+            .putInt("pin_kdf_version", PinManager.KDF_VERSION_LEGACY_BLAKE2B)
+            .apply()
+
+        assertFalse(pinManager.verifyPin("999999"))
+        // No migration happened: stored hash + version unchanged.
+        assertEquals(legacyHash, prefs.getString("pin_hash", null))
+        assertEquals(
+            PinManager.KDF_VERSION_LEGACY_BLAKE2B,
+            prefs.getInt("pin_kdf_version", -1)
+        )
+    }
+
+    @Test
+    fun `legacy stores without KDF version still verify (assumed Blake2b)`() {
+        // Older v1.6.x installs may not have written the version key at all.
+        val prefs = pinManager.testPrefs!!
+        val salt = ByteArray(PinManager.SALT_SIZE) { i -> (i + 2).toByte() }
+        val saltHex = salt.joinToString("") { "%02x".format(it) }
+        val legacyInput = salt + "999999".toByteArray(Charsets.UTF_8)
+        val legacyHash = blake2b.hash(legacyInput).joinToString("") { "%02x".format(it) }
+
+        prefs.edit()
+            .putString("pin_salt", saltHex)
+            .putString("pin_hash", legacyHash)
+            // Note: no pin_kdf_version key
+            .apply()
+
+        assertTrue(pinManager.verifyPin("999999"))
+        // Should have been migrated.
+        assertEquals(
+            PinManager.KDF_VERSION_ARGON2ID,
+            prefs.getInt("pin_kdf_version", -1)
+        )
     }
 }


### PR DESCRIPTION
## Summary
- Replace single Blake2b pass with Argon2id via BouncyCastle (64 MB / 3 iter / 4 lanes, OWASP ASVS 4.0.3 baseline). No new dep — BouncyCastle is already on classpath via ckb-sdk-java.
- Cumulative failure counter with 24 h decay: counter resets only after 24 h with no failures, not on every successful unlock. Defeats the "quiet attacker grinding between owner-initiated unlocks" pattern.
- Escalating lockout: 30 s → 1 min → 5 min → 30 min → 1 h → permanent (10+ failures).
- Silent migration of v1.6.x Blake2b hashes on first successful verify under v1.7.0. Migration is idempotent; partial failure retries on next verify, no data loss.
- `PinViewModel` now runs PIN ops on `Dispatchers.Default` and surfaces `isVerifying` so `PinEntryScreen` can show a spinner during the 300-600 ms KDF window.

## Test plan
- [x] PinManagerTest — 34 tests, 0 failures (3 new migration tests, 2 new decay tests, 2 new escalation tests, plus 27 carried over)
- [x] Full unit test suite — 561 tests, 0 failures, 0 errors
- [x] `./gradlew :app:compileDebugKotlin` — clean (only pre-existing deprecation warnings)
- [ ] Manual smoke on a physical device — verify Argon2id latency is in the 300-600 ms range on Pixel 5
- [ ] Manual smoke on a 2 GB low-end device — verify 64 MB memory peak does not OOM

## Migration behavior

v1.6.x users opening v1.7.0:
1. PIN entry screen prompts as usual
2. User enters PIN → Blake2b match → ~300 ms Argon2id re-derivation runs silently → stored hash is upgraded → counter reset (if applicable)
3. From this point on, all verifies use Argon2id

If the user never enters their PIN on v1.7.0, the migration never runs — they remain on Blake2b. Correct behavior: the upgrade only happens after the user proves they know the PIN.

## Approved design choices (per #214 sign-off)
- ✅ Argon2id via BouncyCastle (recommended in design doc)
- ✅ 64 MB memory cost, OWASP baseline (low-end device profiling deferred to manual smoke)
- ✅ Permanent lockout at 10+ failures, require wallet wipe + re-import
- ✅ Migration test in unit tests only (smoke harness folding deferred)

## What does NOT change
- `PinManager` public API — all callers see same return types
- `EncryptedSharedPreferences` storage backend
- The 32-byte salt format (re-used across both KDFs)
- Biometric flow (unchanged in this PR; #213 addresses the keystore-binding side)

Closes #214
Refs #187 Finding High 2