### PR TITLE
refactor(crypto): split KeystoreEncryptionManager into cipher-acquisition + cipher-use (#213, sub-PR 1/5)

### DIFF
--- a/android/app/src/main/java/com/rjnr/pocketnode/data/crypto/KeystoreEncryptionManager.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/crypto/KeystoreEncryptionManager.kt
@@ -11,6 +11,23 @@ import javax.crypto.spec.GCMParameterSpec
 import javax.inject.Inject
 import javax.inject.Singleton
 
+/**
+ * AES-256-GCM wrapper around the Android Keystore-backed wallet encryption key.
+ *
+ * ## API surface
+ *
+ * Callers must build a `Cipher` (via [newEncryptCipher] or [newDecryptCipher])
+ * and then invoke [encryptWithCipher] / [decryptWithCipher]. The separation
+ * exists because the Keystore is moving to per-operation user-authentication
+ * binding (see #213). A future change will require callers to thread the
+ * Cipher through `BiometricPrompt.CryptoObject(cipher)` before they call
+ * `doFinal`; isolating cipher-acquisition from cipher-use makes that change
+ * mechanical.
+ *
+ * For the moment the spec on the underlying [SecretKey] is unchanged — the
+ * Cipher is usable without a separate auth step. The audit-binding flags
+ * land in the follow-up sub-PR.
+ */
 @Singleton
 class KeystoreEncryptionManager @Inject constructor() {
 
@@ -19,17 +36,31 @@ class KeystoreEncryptionManager @Inject constructor() {
     private val secretKey: SecretKey
         get() = testKey ?: getOrCreateKeystoreKey()
 
-    fun encrypt(plaintext: ByteArray): Pair<ByteArray, ByteArray> {
+    /** Returns a fresh `Cipher` in ENCRYPT_MODE, ready for [encryptWithCipher]. */
+    fun newEncryptCipher(): Cipher {
         val cipher = Cipher.getInstance(CIPHER_TRANSFORM)
         cipher.init(Cipher.ENCRYPT_MODE, secretKey)
-        val iv = cipher.iv
-        val ciphertext = cipher.doFinal(plaintext)
-        return Pair(ciphertext, iv)
+        return cipher
     }
 
-    fun decrypt(ciphertext: ByteArray, iv: ByteArray): ByteArray {
+    /** Returns a fresh `Cipher` in DECRYPT_MODE for the given IV, ready for [decryptWithCipher]. */
+    fun newDecryptCipher(iv: ByteArray): Cipher {
         val cipher = Cipher.getInstance(CIPHER_TRANSFORM)
         cipher.init(Cipher.DECRYPT_MODE, secretKey, GCMParameterSpec(GCM_TAG_BITS, iv))
+        return cipher
+    }
+
+    /**
+     * Encrypt `plaintext` using a Cipher obtained from [newEncryptCipher].
+     * Returns (ciphertext, iv).
+     */
+    fun encryptWithCipher(cipher: Cipher, plaintext: ByteArray): Pair<ByteArray, ByteArray> {
+        val ciphertext = cipher.doFinal(plaintext)
+        return Pair(ciphertext, cipher.iv)
+    }
+
+    /** Decrypt `ciphertext` using a Cipher obtained from [newDecryptCipher]. */
+    fun decryptWithCipher(cipher: Cipher, ciphertext: ByteArray): ByteArray {
         return cipher.doFinal(ciphertext)
     }
 

--- a/android/app/src/main/java/com/rjnr/pocketnode/data/migration/KeyStoreMigrationHelper.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/migration/KeyStoreMigrationHelper.kt
@@ -27,11 +27,13 @@ class KeyStoreMigrationHelper(
         mnemonicBackedUp: Boolean
     ) {
         val keyBytes = privateKeyHex.toByteArray(Charsets.UTF_8)
-        val (encryptedKey, iv) = encryptionManager.encrypt(keyBytes)
+        val keyCipher = encryptionManager.newEncryptCipher()
+        val (encryptedKey, iv) = encryptionManager.encryptWithCipher(keyCipher, keyBytes)
 
         val mnemonicWithIv = mnemonic?.let {
             val mnemonicBytes = it.toByteArray(Charsets.UTF_8)
-            val (encMnemonic, mnemonicIv) = encryptionManager.encrypt(mnemonicBytes)
+            val mnemonicCipher = encryptionManager.newEncryptCipher()
+            val (encMnemonic, mnemonicIv) = encryptionManager.encryptWithCipher(mnemonicCipher, mnemonicBytes)
             mnemonicIv + encMnemonic // 12-byte IV prefix + ciphertext
         }
 
@@ -52,13 +54,18 @@ class KeyStoreMigrationHelper(
         val entity = keyMaterialDao.getByWalletId(walletId) ?: return null
 
         return try {
-            val keyBytes = encryptionManager.decrypt(entity.encryptedPrivateKey, entity.iv)
+            val keyCipher = encryptionManager.newDecryptCipher(entity.iv)
+            val keyBytes = encryptionManager.decryptWithCipher(keyCipher, entity.encryptedPrivateKey)
             val privateKeyHex = String(keyBytes, Charsets.UTF_8)
 
             val mnemonic = entity.encryptedMnemonic?.let { combined ->
                 val mnemonicIv = combined.sliceArray(0 until 12)
                 val mnemonicCiphertext = combined.sliceArray(12 until combined.size)
-                String(encryptionManager.decrypt(mnemonicCiphertext, mnemonicIv), Charsets.UTF_8)
+                val mnemonicCipher = encryptionManager.newDecryptCipher(mnemonicIv)
+                String(
+                    encryptionManager.decryptWithCipher(mnemonicCipher, mnemonicCiphertext),
+                    Charsets.UTF_8
+                )
             }
 
             DecryptedKeyData(

--- a/android/app/src/test/java/com/rjnr/pocketnode/data/crypto/KeystoreEncryptionManagerTest.kt
+++ b/android/app/src/test/java/com/rjnr/pocketnode/data/crypto/KeystoreEncryptionManagerTest.kt
@@ -18,23 +18,33 @@ class KeystoreEncryptionManagerTest {
         manager = KeystoreEncryptionManager.createForTest()
     }
 
+    private fun encrypt(plaintext: ByteArray): Pair<ByteArray, ByteArray> {
+        val cipher = manager.newEncryptCipher()
+        return manager.encryptWithCipher(cipher, plaintext)
+    }
+
+    private fun decrypt(ciphertext: ByteArray, iv: ByteArray): ByteArray {
+        val cipher = manager.newDecryptCipher(iv)
+        return manager.decryptWithCipher(cipher, ciphertext)
+    }
+
     @Test
     fun `encrypt and decrypt round-trip`() {
         val plaintext = "hello world private key".toByteArray()
-        val (ciphertext, iv) = manager.encrypt(plaintext)
+        val (ciphertext, iv) = encrypt(plaintext)
 
         assertFalse(ciphertext.contentEquals(plaintext))
         assertEquals(12, iv.size)
 
-        val decrypted = manager.decrypt(ciphertext, iv)
+        val decrypted = decrypt(ciphertext, iv)
         assertArrayEquals(plaintext, decrypted)
     }
 
     @Test
     fun `encrypt produces different ciphertext each time`() {
         val plaintext = "same input".toByteArray()
-        val (ct1, _) = manager.encrypt(plaintext)
-        val (ct2, _) = manager.encrypt(plaintext)
+        val (ct1, _) = encrypt(plaintext)
+        val (ct2, _) = encrypt(plaintext)
 
         assertFalse(ct1.contentEquals(ct2))
     }
@@ -42,11 +52,11 @@ class KeystoreEncryptionManagerTest {
     @Test
     fun `decrypt with wrong IV fails`() {
         val plaintext = "secret".toByteArray()
-        val (ciphertext, _) = manager.encrypt(plaintext)
+        val (ciphertext, _) = encrypt(plaintext)
         val wrongIv = ByteArray(12) { 0xFF.toByte() }
 
         try {
-            manager.decrypt(ciphertext, wrongIv)
+            decrypt(ciphertext, wrongIv)
             fail("Should throw on wrong IV")
         } catch (e: Exception) {
             // Expected
@@ -56,16 +66,16 @@ class KeystoreEncryptionManagerTest {
     @Test
     fun `encrypt empty data works`() {
         val plaintext = ByteArray(0)
-        val (ciphertext, iv) = manager.encrypt(plaintext)
-        val decrypted = manager.decrypt(ciphertext, iv)
+        val (ciphertext, iv) = encrypt(plaintext)
+        val decrypted = decrypt(ciphertext, iv)
         assertArrayEquals(plaintext, decrypted)
     }
 
     @Test
     fun `encrypt large data works`() {
         val plaintext = ByteArray(10_000) { (it % 256).toByte() }
-        val (ciphertext, iv) = manager.encrypt(plaintext)
-        val decrypted = manager.decrypt(ciphertext, iv)
+        val (ciphertext, iv) = encrypt(plaintext)
+        val decrypted = decrypt(ciphertext, iv)
         assertArrayEquals(plaintext, decrypted)
     }
 }

--- a/android/app/src/test/java/com/rjnr/pocketnode/data/migration/KeyStoreMigrationHelperTest.kt
+++ b/android/app/src/test/java/com/rjnr/pocketnode/data/migration/KeyStoreMigrationHelperTest.kt
@@ -58,7 +58,8 @@ class KeyStoreMigrationHelperTest {
         assertFalse(entity.mnemonicBackedUp)
 
         // Decrypt and verify round-trip
-        val decryptedKey = encryptionManager.decrypt(entity.encryptedPrivateKey, entity.iv)
+        val decryptCipher = encryptionManager.newDecryptCipher(entity.iv)
+        val decryptedKey = encryptionManager.decryptWithCipher(decryptCipher, entity.encryptedPrivateKey)
         assertEquals("aabb".repeat(16), String(decryptedKey, Charsets.UTF_8))
     }
 


### PR DESCRIPTION
## Summary
First of five planned sub-PRs implementing the Keystore audit Finding High 1 fix. **Behavior is unchanged in this PR**; the follow-ups add the user-authentication binding flags to the `KeyGenParameterSpec` and wire `BiometricPrompt` at each call site.

This PR is purely structural — replace the one-shot `encrypt(plaintext) / decrypt(ciphertext, iv)` API with a two-step `newEncryptCipher() / encryptWithCipher(cipher, plaintext)` (same for decrypt). The split lets the future `BiometricPrompt.authenticate(promptInfo, CryptoObject(cipher))` step slot in between cipher acquisition and `doFinal`, without rewriting every call site again.

## API change

```diff
- fun encrypt(plaintext: ByteArray): Pair<ByteArray, ByteArray>
- fun decrypt(ciphertext: ByteArray, iv: ByteArray): ByteArray
+ fun newEncryptCipher(): Cipher
+ fun newDecryptCipher(iv: ByteArray): Cipher
+ fun encryptWithCipher(cipher: Cipher, plaintext: ByteArray): Pair<ByteArray, ByteArray>
+ fun decryptWithCipher(cipher: Cipher, ciphertext: ByteArray): ByteArray
```

## Callers updated

- `KeyStoreMigrationHelper.migrateWallet` — 2 cipher acquisitions (private key + mnemonic, each with its own IV)
- `KeyStoreMigrationHelper.readDecryptedKey` — 2 cipher acquisitions (decrypt path)
- `KeystoreEncryptionManagerTest` — 5 test methods, moved to helper `encrypt`/`decrypt` functions in the test file so test bodies stay readable
- `KeyStoreMigrationHelperTest` — one decrypt call site

No code outside `KeyStoreMigrationHelper` invokes the old methods, so the surface change is contained.

## Test plan
- [x] `./gradlew :app:compileDebugKotlin` — clean
- [x] `./gradlew :app:testDebugUnitTest` — **561 / 561 pass, 0 failures, 0 errors**

## Phased rollout for #213

| Sub-PR | Scope | Status |
|--------|-------|--------|
| 1 | Cipher-acquisition / use split (this PR) | ⬅ here |
| 2 | Add auth-binding flags to `KeyGenParameterSpec` | pending |
| 3 | v1.6.x → v1.7.0 re-encryption migration with row-level journaling + crash test | pending |
| 4 | Wire `BiometricPrompt` `CryptoObject` at each call site (SendVM, MnemonicBackupVM, WalletSettingsVM, DaoVM) | pending |
| 5 | Edge cases: `KeyPermanentlyInvalidatedException`, no-credential devices, enrollment warning | pending |

Refs #213, #187 Finding High 1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Refactored internal encryption handling to improve cryptographic operation flow and code maintainability.

* **Tests**
  * Updated encryption and migration tests to align with refactored encryption methods.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/RaheemJnr/pocket-node/pull/225?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->