### PR TITLE
feat(crypto): V2 auth-bound Keystore key (#213, sub-PR 2/5)

### DIFF
--- a/android/app/src/main/java/com/rjnr/pocketnode/data/crypto/KeystoreEncryptionManager.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/crypto/KeystoreEncryptionManager.kt
@@ -1,5 +1,6 @@
 package com.rjnr.pocketnode.data.crypto
 
+import android.os.Build
 import android.security.keystore.KeyGenParameterSpec
 import android.security.keystore.KeyProperties
 import androidx.annotation.VisibleForTesting
@@ -14,55 +15,112 @@ import javax.inject.Singleton
 /**
  * AES-256-GCM wrapper around the Android Keystore-backed wallet encryption key.
  *
+ * ## Key aliases
+ *
+ * Two keys coexist while the v1.7.0 user-authentication migration is in flight:
+ *
+ * - **V1** (`pocket_node_key_material`): unrestricted. Any caller that can
+ *   reach the Keystore service can decrypt the wallet blobs. This is what
+ *   v1.6.x and earlier shipped with, and what the Keystore audit
+ *   ([#187 Finding High 1](https://github.com/RaheemJnr/pocket-node/issues/187))
+ *   flagged as inadequate.
+ * - **V2** (`pocket_node_key_material_v2`): bound to the user's biometric or
+ *   device credential via `setUserAuthenticationRequired(true)`. Every
+ *   `Cipher.doFinal` requires a fresh `BiometricPrompt.authenticate(promptInfo,
+ *   CryptoObject(cipher))` before the keystore releases the key.
+ *
+ * ## Current state
+ *
+ * - Existing call sites (`KeyStoreMigrationHelper`) use the V1 API.
+ *   Behavior on v1.7.0 is unchanged from v1.6.x for those callers.
+ * - The V2 API is wired but unused. Migration from V1 to V2 happens in the
+ *   follow-up sub-PR for #213.
+ * - Once migration ships, V1 is deleted and only V2 remains.
+ *
  * ## API surface
  *
- * Callers must build a `Cipher` (via [newEncryptCipher] or [newDecryptCipher])
- * and then invoke [encryptWithCipher] / [decryptWithCipher]. The separation
- * exists because the Keystore is moving to per-operation user-authentication
- * binding (see #213). A future change will require callers to thread the
- * Cipher through `BiometricPrompt.CryptoObject(cipher)` before they call
- * `doFinal`; isolating cipher-acquisition from cipher-use makes that change
- * mechanical.
- *
- * For the moment the spec on the underlying [SecretKey] is unchanged — the
- * Cipher is usable without a separate auth step. The audit-binding flags
- * land in the follow-up sub-PR.
+ * Callers obtain a `Cipher` via [newEncryptCipher] / [newDecryptCipher] (V1)
+ * or [newEncryptCipherV2] / [newDecryptCipherV2] (V2). The Cipher returned
+ * by the V2 variants is **not yet authenticated** — the caller must pass it
+ * through `BiometricPrompt.authenticate(promptInfo, CryptoObject(cipher))`
+ * before invoking [encryptWithCipher] / [decryptWithCipher]. Without that
+ * step, `doFinal` throws `UserNotAuthenticatedException`.
  */
 @Singleton
 class KeystoreEncryptionManager @Inject constructor() {
 
     private var testKey: SecretKey? = null
+    private var testKeyV2: SecretKey? = null
 
     private val secretKey: SecretKey
         get() = testKey ?: getOrCreateKeystoreKey()
 
-    /** Returns a fresh `Cipher` in ENCRYPT_MODE, ready for [encryptWithCipher]. */
+    private val secretKeyV2: SecretKey
+        get() = testKeyV2 ?: getOrCreateKeystoreKeyV2()
+
+    // -- V1 (unrestricted) API ---------------------------------------------
+
+    /** Returns a fresh `Cipher` in ENCRYPT_MODE under the V1 (unrestricted) key. */
     fun newEncryptCipher(): Cipher {
         val cipher = Cipher.getInstance(CIPHER_TRANSFORM)
         cipher.init(Cipher.ENCRYPT_MODE, secretKey)
         return cipher
     }
 
-    /** Returns a fresh `Cipher` in DECRYPT_MODE for the given IV, ready for [decryptWithCipher]. */
+    /** Returns a fresh `Cipher` in DECRYPT_MODE under the V1 (unrestricted) key. */
     fun newDecryptCipher(iv: ByteArray): Cipher {
         val cipher = Cipher.getInstance(CIPHER_TRANSFORM)
         cipher.init(Cipher.DECRYPT_MODE, secretKey, GCMParameterSpec(GCM_TAG_BITS, iv))
         return cipher
     }
 
+    // -- V2 (auth-bound) API -----------------------------------------------
+
     /**
-     * Encrypt `plaintext` using a Cipher obtained from [newEncryptCipher].
-     * Returns (ciphertext, iv).
+     * Returns a fresh `Cipher` in ENCRYPT_MODE under the V2 (auth-bound) key.
+     *
+     * The caller must run the returned Cipher through
+     * `BiometricPrompt.authenticate(promptInfo, CryptoObject(cipher))` before
+     * calling [encryptWithCipher]. Calling `doFinal` on an unauthenticated
+     * Cipher throws `UserNotAuthenticatedException`.
+     */
+    fun newEncryptCipherV2(): Cipher {
+        val cipher = Cipher.getInstance(CIPHER_TRANSFORM)
+        cipher.init(Cipher.ENCRYPT_MODE, secretKeyV2)
+        return cipher
+    }
+
+    /**
+     * Returns a fresh `Cipher` in DECRYPT_MODE under the V2 (auth-bound) key.
+     *
+     * Same authentication requirement as [newEncryptCipherV2].
+     */
+    fun newDecryptCipherV2(iv: ByteArray): Cipher {
+        val cipher = Cipher.getInstance(CIPHER_TRANSFORM)
+        cipher.init(Cipher.DECRYPT_MODE, secretKeyV2, GCMParameterSpec(GCM_TAG_BITS, iv))
+        return cipher
+    }
+
+    // -- Cipher use (shared between V1 and V2) -----------------------------
+
+    /**
+     * Encrypt `plaintext` using a Cipher obtained from [newEncryptCipher] or
+     * [newEncryptCipherV2]. Returns (ciphertext, iv).
      */
     fun encryptWithCipher(cipher: Cipher, plaintext: ByteArray): Pair<ByteArray, ByteArray> {
         val ciphertext = cipher.doFinal(plaintext)
         return Pair(ciphertext, cipher.iv)
     }
 
-    /** Decrypt `ciphertext` using a Cipher obtained from [newDecryptCipher]. */
+    /**
+     * Decrypt `ciphertext` using a Cipher obtained from [newDecryptCipher] or
+     * [newDecryptCipherV2].
+     */
     fun decryptWithCipher(cipher: Cipher, ciphertext: ByteArray): ByteArray {
         return cipher.doFinal(ciphertext)
     }
+
+    // -- Key acquisition ---------------------------------------------------
 
     private fun getOrCreateKeystoreKey(): SecretKey {
         val keyStore = KeyStore.getInstance(KEYSTORE_PROVIDER)
@@ -83,19 +141,93 @@ class KeystoreEncryptionManager @Inject constructor() {
         return keyGen.generateKey()
     }
 
+    private fun getOrCreateKeystoreKeyV2(): SecretKey {
+        val keyStore = KeyStore.getInstance(KEYSTORE_PROVIDER)
+        keyStore.load(null)
+
+        keyStore.getEntry(KEY_ALIAS_V2, null)?.let { entry ->
+            return (entry as KeyStore.SecretKeyEntry).secretKey
+        }
+
+        val keyGen = KeyGenerator.getInstance(KeyProperties.KEY_ALGORITHM_AES, KEYSTORE_PROVIDER)
+        val specBuilder = KeyGenParameterSpec.Builder(
+            KEY_ALIAS_V2,
+            KeyProperties.PURPOSE_ENCRYPT or KeyProperties.PURPOSE_DECRYPT
+        )
+            .setBlockModes(KeyProperties.BLOCK_MODE_GCM)
+            .setEncryptionPaddings(KeyProperties.ENCRYPTION_PADDING_NONE)
+            .setKeySize(KEY_SIZE_BITS)
+            // The OS-enforced auth binding: doFinal will throw
+            // UserNotAuthenticatedException until BiometricPrompt unlocks the
+            // Cipher via CryptoObject(cipher).
+            .setUserAuthenticationRequired(true)
+            // Adding or removing a biometric enrollment invalidates the key.
+            // Forces re-import after a fingerprint change. This is the right
+            // default for a money-storing wallet: a thief who enrolls their
+            // own fingerprint cannot read existing data.
+            .setInvalidatedByBiometricEnrollment(true)
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            // Per-operation auth, no grace window. Each doFinal needs a fresh
+            // BiometricPrompt success. AUTH_BIOMETRIC_STRONG plus
+            // AUTH_DEVICE_CREDENTIAL lets users without enrolled biometrics
+            // fall back to the device PIN/pattern set in Android Settings.
+            specBuilder.setUserAuthenticationParameters(
+                0,
+                KeyProperties.AUTH_BIOMETRIC_STRONG or KeyProperties.AUTH_DEVICE_CREDENTIAL
+            )
+        } else {
+            // API 26-29 uses the legacy validity-duration knob. -1 means
+            // "every operation needs fresh auth" (the closest analogue of
+            // setUserAuthenticationParameters(0, ...)).
+            @Suppress("DEPRECATION")
+            specBuilder.setUserAuthenticationValidityDurationSeconds(-1)
+        }
+
+        keyGen.init(specBuilder.build())
+        return keyGen.generateKey()
+    }
+
+    // -- Migration helpers (used by the upcoming v1.6.x -> v1.7.0 flow) ----
+
+    /** Delete the V1 (unrestricted) Keystore key. Called by the migration after re-encryption finishes. */
+    fun deleteV1Key() {
+        val keyStore = KeyStore.getInstance(KEYSTORE_PROVIDER)
+        keyStore.load(null)
+        if (keyStore.containsAlias(KEY_ALIAS)) {
+            keyStore.deleteEntry(KEY_ALIAS)
+        }
+    }
+
+    /** True if the V1 (unrestricted) Keystore key is still present. */
+    fun hasV1Key(): Boolean {
+        val keyStore = KeyStore.getInstance(KEYSTORE_PROVIDER)
+        keyStore.load(null)
+        return keyStore.containsAlias(KEY_ALIAS)
+    }
+
+    /** True if the V2 (auth-bound) Keystore key has been generated. */
+    fun hasV2Key(): Boolean {
+        val keyStore = KeyStore.getInstance(KEYSTORE_PROVIDER)
+        keyStore.load(null)
+        return keyStore.containsAlias(KEY_ALIAS_V2)
+    }
+
     companion object {
         private const val KEYSTORE_PROVIDER = "AndroidKeyStore"
         private const val KEY_ALIAS = "pocket_node_key_material"
+        private const val KEY_ALIAS_V2 = "pocket_node_key_material_v2"
         private const val CIPHER_TRANSFORM = "AES/GCM/NoPadding"
         private const val GCM_TAG_BITS = 128
         private const val KEY_SIZE_BITS = 256
 
         @VisibleForTesting
         fun createForTest(): KeystoreEncryptionManager {
-            val keyGen = KeyGenerator.getInstance("AES")
-            keyGen.init(KEY_SIZE_BITS)
+            val keyGen1 = KeyGenerator.getInstance("AES").apply { init(KEY_SIZE_BITS) }
+            val keyGen2 = KeyGenerator.getInstance("AES").apply { init(KEY_SIZE_BITS) }
             return KeystoreEncryptionManager().apply {
-                testKey = keyGen.generateKey()
+                testKey = keyGen1.generateKey()
+                testKeyV2 = keyGen2.generateKey()
             }
         }
     }

--- a/android/app/src/test/java/com/rjnr/pocketnode/data/crypto/KeystoreEncryptionManagerTest.kt
+++ b/android/app/src/test/java/com/rjnr/pocketnode/data/crypto/KeystoreEncryptionManagerTest.kt
@@ -78,4 +78,67 @@ class KeystoreEncryptionManagerTest {
         val decrypted = decrypt(ciphertext, iv)
         assertArrayEquals(plaintext, decrypted)
     }
+
+    // -- V2 (auth-bound) API --
+    //
+    // In Robolectric the V2 key is a raw AES key (no real Keystore), so the
+    // OS-level auth requirement is not exercised here. These tests cover the
+    // structural side: V2 ciphers round-trip correctly, are independent of V1,
+    // and reject mismatched ciphertext.
+
+    private fun encryptV2(plaintext: ByteArray): Pair<ByteArray, ByteArray> {
+        val cipher = manager.newEncryptCipherV2()
+        return manager.encryptWithCipher(cipher, plaintext)
+    }
+
+    private fun decryptV2(ciphertext: ByteArray, iv: ByteArray): ByteArray {
+        val cipher = manager.newDecryptCipherV2(iv)
+        return manager.decryptWithCipher(cipher, ciphertext)
+    }
+
+    @Test
+    fun `V2 encrypt and decrypt round-trip`() {
+        val plaintext = "v2 wallet key material".toByteArray()
+        val (ciphertext, iv) = encryptV2(plaintext)
+
+        assertFalse(ciphertext.contentEquals(plaintext))
+        assertEquals(12, iv.size)
+
+        val decrypted = decryptV2(ciphertext, iv)
+        assertArrayEquals(plaintext, decrypted)
+    }
+
+    @Test
+    fun `V2 key is independent of V1 key`() {
+        // A ciphertext produced under V1 must not decrypt under V2, and vice
+        // versa. This guards against accidentally using the same key for both
+        // aliases (which would silently downgrade V2's security guarantees).
+        val plaintext = "isolation check".toByteArray()
+        val (ctV1, ivV1) = encrypt(plaintext)
+        val (ctV2, ivV2) = encryptV2(plaintext)
+
+        // Cross-decrypt attempts should fail.
+        try {
+            decryptV2(ctV1, ivV1)
+            fail("V2 should not decrypt V1 ciphertext")
+        } catch (e: Exception) {
+            // Expected — AES-GCM authentication tag mismatch
+        }
+
+        try {
+            decrypt(ctV2, ivV2)
+            fail("V1 should not decrypt V2 ciphertext")
+        } catch (e: Exception) {
+            // Expected
+        }
+    }
+
+    @Test
+    fun `V2 encrypt produces different ciphertext each time`() {
+        val plaintext = "same input".toByteArray()
+        val (ct1, _) = encryptV2(plaintext)
+        val (ct2, _) = encryptV2(plaintext)
+
+        assertFalse(ct1.contentEquals(ct2))
+    }
 }


### PR DESCRIPTION
## Summary
Second of five planned sub-PRs for #213. Adds the auth-bound Keystore key path under a new alias `pocket_node_key_material_v2` alongside the existing `pocket_node_key_material` (V1). **No call site uses V2 yet** — behavior is unchanged in this PR. The v1.6.x → v1.7.0 migration that moves wallet blobs from V1 to V2 lands in sub-PR 3.

## V2 key spec

```kotlin
KeyGenParameterSpec.Builder(KEY_ALIAS_V2, PURPOSE_ENCRYPT or PURPOSE_DECRYPT)
    .setBlockModes(BLOCK_MODE_GCM)
    .setEncryptionPaddings(ENCRYPTION_PADDING_NONE)
    .setKeySize(256)
    .setUserAuthenticationRequired(true)              // OS-enforced
    .setInvalidatedByBiometricEnrollment(true)        // thief defense
    .apply {
        if (Build.VERSION.SDK_INT >= R) {
            setUserAuthenticationParameters(
                0,  // no grace window
                AUTH_BIOMETRIC_STRONG or AUTH_DEVICE_CREDENTIAL
            )
        } else {
            // API 26-29 legacy equivalent
            setUserAuthenticationValidityDurationSeconds(-1)
        }
    }
    .build()
```

## New API surface

- `newEncryptCipherV2()` / `newDecryptCipherV2(iv)` — returns an **unauthenticated** Cipher. Caller must thread through `BiometricPrompt.authenticate(promptInfo, CryptoObject(cipher))` before `doFinal`.
- `encryptWithCipher` / `decryptWithCipher` — unchanged, work for both V1 and V2 ciphers.
- `deleteV1Key()` / `hasV1Key()` / `hasV2Key()` — helpers for the upcoming migration's atomic swap and idempotence checks.

## Test plan
- [x] `./gradlew :app:compileDebugKotlin` — clean
- [x] `./gradlew :app:testDebugUnitTest` — **564/564 pass** (561 carryover + 3 new V2 tests)
- [ ] Real-device verification deferred to sub-PR 3 (where V2 becomes the active key path)

In Robolectric the V2 key is a raw AES key — the OS-level auth requirement is not exercised. The Robolectric tests cover the structural side (V2 round-trip, V1/V2 ciphertext isolation, IV-per-encrypt uniqueness). Real-device behavior (`UserNotAuthenticatedException` on unauthenticated `doFinal`) is exercised in sub-PR 3's migration smoke.

## Phased rollout

| Sub-PR | Scope | Status |
|--------|-------|--------|
| 1 | Cipher-acquisition / use split | ✅ #225 merged |
| 2 | Add V2 auth-bound key (this PR) | ⬅ here |
| 3 | V1 → V2 migration with journaling + crash test | pending |
| 4 | Wire `BiometricPrompt` `CryptoObject` at each call site | pending |
| 5 | Edge cases (`KeyPermanentlyInvalidatedException`, no-credential devices) | pending |

Refs #213, #187 Finding High 1