### PR TITLE
fix(crypto): KeystoreV2 migration helper + v9→v10 schema (#213 sub-PR 3/5)

### DIFF
--- a/android/app/src/main/java/com/rjnr/pocketnode/data/crypto/KeystoreEncryptionManager.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/crypto/KeystoreEncryptionManager.kt
@@ -192,6 +192,10 @@ class KeystoreEncryptionManager @Inject constructor() {
 
     /** Delete the V1 (unrestricted) Keystore key. Called by the migration after re-encryption finishes. */
     fun deleteV1Key() {
+        if (testKey != null) {
+            testKey = null
+            return
+        }
         val keyStore = KeyStore.getInstance(KEYSTORE_PROVIDER)
         keyStore.load(null)
         if (keyStore.containsAlias(KEY_ALIAS)) {
@@ -201,6 +205,7 @@ class KeystoreEncryptionManager @Inject constructor() {
 
     /** True if the V1 (unrestricted) Keystore key is still present. */
     fun hasV1Key(): Boolean {
+        if (testKey != null || testKeyV2 != null) return testKey != null
         val keyStore = KeyStore.getInstance(KEYSTORE_PROVIDER)
         keyStore.load(null)
         return keyStore.containsAlias(KEY_ALIAS)
@@ -208,6 +213,7 @@ class KeystoreEncryptionManager @Inject constructor() {
 
     /** True if the V2 (auth-bound) Keystore key has been generated. */
     fun hasV2Key(): Boolean {
+        if (testKey != null || testKeyV2 != null) return testKeyV2 != null
         val keyStore = KeyStore.getInstance(KEYSTORE_PROVIDER)
         keyStore.load(null)
         return keyStore.containsAlias(KEY_ALIAS_V2)

--- a/android/app/src/main/java/com/rjnr/pocketnode/data/database/AppDatabase.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/database/AppDatabase.kt
@@ -36,7 +36,13 @@ import com.rjnr.pocketnode.data.database.entity.WalletEntity
     // produced this exact shape; the annotations just declare it correctly),
     // so MIGRATION_8_9 is a no-op. Version bump alone is needed to refresh
     // Room's stored identity hash after the entity declarations changed. (#90 / #141)
-    version = 9,
+    //
+    // Bumped from 9 to 10 for v1.7.0 because KeyMaterialEntity gained the
+    // `kdfVersion` column (default 1). Existing rows are tagged version 1
+    // (legacy unrestricted V1 keystore key); the v1.6.x → v1.7.0 migration
+    // re-encrypts them under the auth-bound V2 keystore key and bumps each
+    // row to version 2. See `KeystoreV2MigrationHelper` and #213.
+    version = 10,
     // Schema export deliberately OFF until the Room 2.8.4 / kotlinx-serialization
     // 1.8.0 binary incompatibility is resolved (tracked in #149). Enabling it
     // crashes KSP with AbstractMethodError in Room's bundled

--- a/android/app/src/main/java/com/rjnr/pocketnode/data/database/Migrations.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/database/Migrations.kt
@@ -396,3 +396,23 @@ val MIGRATION_8_9 = object : Migration(8, 9) {
         )
     }
 }
+
+/**
+ * 9 → 10: add `kdfVersion` column to `key_material` for the v1.6.x → v1.7.0
+ * Keystore auth-binding migration (#213).
+ *
+ * All existing rows are tagged version 1 (legacy unrestricted V1 Keystore
+ * key). `KeystoreV2MigrationHelper` re-encrypts each row under the new
+ * auth-bound V2 Keystore key and bumps the column to 2.
+ *
+ * `ALTER TABLE ADD COLUMN` is safe: SQLite appends the column with the
+ * declared default value for every existing row in one statement. No
+ * table recreate is needed since the rest of the schema is unchanged.
+ */
+val MIGRATION_9_10 = object : Migration(9, 10) {
+    override fun migrate(db: SupportSQLiteDatabase) {
+        db.execSQL(
+            "ALTER TABLE `key_material` ADD COLUMN `kdfVersion` INTEGER NOT NULL DEFAULT 1"
+        )
+    }
+}

--- a/android/app/src/main/java/com/rjnr/pocketnode/data/database/dao/KeyMaterialDao.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/database/dao/KeyMaterialDao.kt
@@ -23,4 +23,18 @@ interface KeyMaterialDao {
 
     @Query("UPDATE key_material SET mnemonicBackedUp = :backedUp, updatedAt = :updatedAt WHERE walletId = :walletId")
     suspend fun updateMnemonicBackedUp(walletId: String, backedUp: Boolean, updatedAt: Long)
+
+    /**
+     * Wallets still encrypted under the legacy V1 keystore key. The v1.6.x →
+     * v1.7.0 KeystoreV2 migration iterates this list one wallet at a time,
+     * each driven by its own BiometricPrompt-bound CryptoObject.
+     */
+    @Query("SELECT walletId FROM key_material WHERE kdfVersion = 1 ORDER BY walletId")
+    suspend fun getV1WalletIds(): List<String>
+
+    @Query("SELECT COUNT(*) FROM key_material WHERE kdfVersion = 1")
+    suspend fun countV1Wallets(): Int
+
+    @Query("SELECT COUNT(*) FROM key_material WHERE kdfVersion = 2")
+    suspend fun countV2Wallets(): Int
 }

--- a/android/app/src/main/java/com/rjnr/pocketnode/data/database/entity/KeyMaterialEntity.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/database/entity/KeyMaterialEntity.kt
@@ -1,5 +1,6 @@
 package com.rjnr.pocketnode.data.database.entity
 
+import androidx.room.ColumnInfo
 import androidx.room.Entity
 import androidx.room.PrimaryKey
 
@@ -11,7 +12,26 @@ data class KeyMaterialEntity(
     val iv: ByteArray,
     val walletType: String,
     val mnemonicBackedUp: Boolean,
-    val updatedAt: Long
+    val updatedAt: Long,
+    /**
+     * KDF version for the key material encryption.
+     *
+     * - **1** (legacy, v1.6.x and earlier): encrypted under the unrestricted V1
+     *   Keystore key (`pocket_node_key_material`). `encryptedPrivateKey` holds
+     *   just the private key ciphertext; `encryptedMnemonic` (if non-null) is
+     *   `mnemonicIv + mnemonicCiphertext`. `iv` is the private key IV.
+     * - **2** (v1.7.0+): encrypted under the auth-bound V2 Keystore key
+     *   (`pocket_node_key_material_v2`). `encryptedPrivateKey` holds a single
+     *   bundle ciphertext (JSON of `WalletKeyBundle` with both private key
+     *   and mnemonic); `encryptedMnemonic` is always null; `iv` is the bundle
+     *   IV. Decrypting V2 requires a fresh BiometricPrompt-bound CryptoObject.
+     *
+     * Rows added on a fresh v1.7.0 install start at version 2. Existing v1.6.x
+     * rows enter v1.7.0 at version 1 and are migrated to version 2 on first
+     * launch (one BiometricPrompt per wallet).
+     */
+    @ColumnInfo(defaultValue = "1")
+    val kdfVersion: Int = 1
 ) {
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
@@ -27,7 +47,8 @@ data class KeyMaterialEntity(
             iv.contentEquals(other.iv) &&
             walletType == other.walletType &&
             mnemonicBackedUp == other.mnemonicBackedUp &&
-            updatedAt == other.updatedAt
+            updatedAt == other.updatedAt &&
+            kdfVersion == other.kdfVersion
     }
 
     override fun hashCode(): Int {
@@ -38,6 +59,7 @@ data class KeyMaterialEntity(
         result = 31 * result + walletType.hashCode()
         result = 31 * result + mnemonicBackedUp.hashCode()
         result = 31 * result + updatedAt.hashCode()
+        result = 31 * result + kdfVersion.hashCode()
         return result
     }
 }

--- a/android/app/src/main/java/com/rjnr/pocketnode/data/migration/KeystoreV2MigrationHelper.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/migration/KeystoreV2MigrationHelper.kt
@@ -1,0 +1,181 @@
+package com.rjnr.pocketnode.data.migration
+
+import android.content.SharedPreferences
+import android.util.Log
+import com.rjnr.pocketnode.data.crypto.KeystoreEncryptionManager
+import com.rjnr.pocketnode.data.database.dao.KeyMaterialDao
+import javax.crypto.Cipher
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+
+/**
+ * The plaintext bundle written under the V2 (auth-bound) Keystore key.
+ *
+ * V1 stored `privateKey` and `mnemonic` as two separate AES-GCM ciphertexts
+ * with two separate IVs. V2 stores them as a single JSON blob inside one
+ * AES-GCM ciphertext, so each wallet's migration is exactly one
+ * BiometricPrompt + one `Cipher.doFinal` per direction. Reduces the prompt
+ * count from 2N → N during migration (where N = number of wallets).
+ */
+@Serializable
+data class WalletKeyBundle(
+    val privateKeyHex: String,
+    val mnemonic: String? = null,
+)
+
+/**
+ * Orchestrates the v1.6.x → v1.7.0 migration that re-encrypts every wallet's
+ * key material under the auth-bound V2 Keystore key (#213).
+ *
+ * ## Contract
+ *
+ * - The caller drives a BiometricPrompt per wallet and passes the
+ *   authenticated `Cipher` into [migrateWallet]. The helper does NOT
+ *   prompt; it only encrypts/decrypts and writes to Room.
+ * - V1 decrypt requires no auth (the V1 keystore key is unrestricted).
+ *   The helper acquires the V1 decrypt Cipher itself.
+ * - V2 encrypt requires auth. The caller passes in a Cipher already
+ *   unlocked by `BiometricPrompt.authenticate(promptInfo, CryptoObject(cipher))`.
+ * - Each [migrateWallet] call is atomic at the Room row level. A crash
+ *   between rows leaves the migrated rows on V2 (kdfVersion=2) and the
+ *   unmigrated rows on V1 (kdfVersion=1). Recovery is idempotent: re-run
+ *   the migration over the still-V1 wallets returned by [pendingWalletIds].
+ * - After all wallets are V2, the caller invokes [finalize] which deletes
+ *   the V1 Keystore key and sets the migration-complete flag in prefs.
+ *
+ * ## Idempotence
+ *
+ * Calling [migrateWallet] for an already-V2 wallet returns success without
+ * doing any crypto. This lets the caller blindly iterate without first
+ * filtering out completed rows.
+ */
+class KeystoreV2MigrationHelper(
+    private val keyMaterialDao: KeyMaterialDao,
+    private val encryptionManager: KeystoreEncryptionManager,
+    private val prefs: SharedPreferences,
+    private val nowProvider: () -> Long = { System.currentTimeMillis() }
+) {
+
+    private val json = Json {
+        ignoreUnknownKeys = true
+        encodeDefaults = true
+    }
+
+    /** True if every wallet has been migrated and [finalize] has run. */
+    fun isMigrationComplete(): Boolean {
+        return prefs.getBoolean(KEY_MIGRATION_V2_COMPLETE, false)
+    }
+
+    /** Walletids that still need to migrate from V1 to V2. */
+    suspend fun pendingWalletIds(): List<String> {
+        return keyMaterialDao.getV1WalletIds()
+    }
+
+    /** Re-encrypt one wallet's key material under the authenticated V2 Cipher. */
+    suspend fun migrateWallet(walletId: String, v2EncryptCipher: Cipher): Result<Unit> {
+        return runCatching {
+            val entity = keyMaterialDao.getByWalletId(walletId)
+                ?: throw IllegalStateException("No key_material row for walletId=$walletId")
+
+            if (entity.kdfVersion == V2_VERSION) {
+                Log.i(TAG, "Wallet $walletId already on V2; nothing to do")
+                return@runCatching
+            }
+            if (entity.kdfVersion != V1_VERSION) {
+                throw IllegalStateException(
+                    "Unknown kdfVersion ${entity.kdfVersion} for walletId=$walletId; refusing to migrate"
+                )
+            }
+
+            // Step 1: decrypt V1 ciphertexts. No auth needed; V1 key is unrestricted.
+            val privateKeyHex = decryptV1PrivateKey(entity.encryptedPrivateKey, entity.iv)
+            val mnemonic = entity.encryptedMnemonic?.let { combined ->
+                decryptV1Mnemonic(combined)
+            }
+
+            // Step 2: bundle the plaintext so one V2 encrypt covers both pieces.
+            val bundle = WalletKeyBundle(privateKeyHex = privateKeyHex, mnemonic = mnemonic)
+            val bundleBytes = json.encodeToString(bundle).toByteArray(Charsets.UTF_8)
+
+            // Step 3: encrypt the bundle under V2. The Cipher was unlocked by the
+            // caller via BiometricPrompt; doFinal here consumes that auth ticket.
+            val (encryptedBundle, newIv) = encryptionManager.encryptWithCipher(
+                v2EncryptCipher,
+                bundleBytes
+            )
+
+            // Step 4: atomic row swap. Room.upsert runs in a transaction; either
+            // both the ciphertext and the kdfVersion=2 land together or neither
+            // does. A crash here at worst leaves the wallet on V1 for retry.
+            val migrated = entity.copy(
+                encryptedPrivateKey = encryptedBundle,
+                encryptedMnemonic = null,
+                iv = newIv,
+                kdfVersion = V2_VERSION,
+                updatedAt = nowProvider()
+            )
+            keyMaterialDao.upsert(migrated)
+
+            Log.i(TAG, "Migrated wallet $walletId from V1 to V2")
+        }
+    }
+
+    /**
+     * After every wallet has been migrated, delete the V1 Keystore key and
+     * record the migration-complete flag. Safe to call only when
+     * [pendingWalletIds] returns an empty list.
+     */
+    suspend fun finalize(): Result<Unit> {
+        return runCatching {
+            val pending = pendingWalletIds()
+            if (pending.isNotEmpty()) {
+                throw IllegalStateException(
+                    "Refusing to finalize migration: ${pending.size} wallets still on V1 ($pending)"
+                )
+            }
+            encryptionManager.deleteV1Key()
+            prefs.edit().putBoolean(KEY_MIGRATION_V2_COMPLETE, true).apply()
+            Log.i(TAG, "Keystore V2 migration finalized")
+        }
+    }
+
+    /**
+     * Read a V2-encrypted wallet bundle. Used by callers that already know the
+     * row is on V2 (kdfVersion=2). The Cipher must be a decrypt-mode Cipher
+     * acquired via [KeystoreEncryptionManager.newDecryptCipherV2] and unlocked
+     * via BiometricPrompt.
+     */
+    suspend fun readV2Bundle(walletId: String, v2DecryptCipher: Cipher): WalletKeyBundle? {
+        val entity = keyMaterialDao.getByWalletId(walletId) ?: return null
+        if (entity.kdfVersion != V2_VERSION) {
+            Log.e(TAG, "readV2Bundle: wallet $walletId is not on V2 (kdfVersion=${entity.kdfVersion})")
+            return null
+        }
+        val bundleBytes = encryptionManager.decryptWithCipher(v2DecryptCipher, entity.encryptedPrivateKey)
+        return json.decodeFromString(WalletKeyBundle.serializer(), String(bundleBytes, Charsets.UTF_8))
+    }
+
+    private fun decryptV1PrivateKey(ciphertext: ByteArray, iv: ByteArray): String {
+        val cipher = encryptionManager.newDecryptCipher(iv)
+        val plaintext = encryptionManager.decryptWithCipher(cipher, ciphertext)
+        return String(plaintext, Charsets.UTF_8)
+    }
+
+    private fun decryptV1Mnemonic(combined: ByteArray): String {
+        val mnemonicIv = combined.sliceArray(0 until 12)
+        val mnemonicCiphertext = combined.sliceArray(12 until combined.size)
+        val cipher = encryptionManager.newDecryptCipher(mnemonicIv)
+        return String(
+            encryptionManager.decryptWithCipher(cipher, mnemonicCiphertext),
+            Charsets.UTF_8
+        )
+    }
+
+    companion object {
+        private const val TAG = "KeystoreV2Migration"
+        private const val KEY_MIGRATION_V2_COMPLETE = "keystore_v2_migration_complete"
+        const val V1_VERSION = 1
+        const val V2_VERSION = 2
+    }
+}

--- a/android/app/src/main/java/com/rjnr/pocketnode/di/AppModule.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/di/AppModule.kt
@@ -16,6 +16,7 @@ import com.rjnr.pocketnode.data.database.MIGRATION_5_6
 import com.rjnr.pocketnode.data.database.MIGRATION_6_7
 import com.rjnr.pocketnode.data.database.MIGRATION_7_8
 import com.rjnr.pocketnode.data.database.MIGRATION_8_9
+import com.rjnr.pocketnode.data.database.MIGRATION_9_10
 import com.rjnr.pocketnode.data.database.dao.BalanceCacheDao
 import com.rjnr.pocketnode.data.database.dao.DaoCellDao
 import com.rjnr.pocketnode.data.database.dao.HeaderCacheDao
@@ -126,7 +127,7 @@ object AppModule {
     fun provideAppDatabase(@ApplicationContext context: Context): AppDatabase =
         Room.databaseBuilder(context, AppDatabase::class.java, "pocket_node.db")
             .setJournalMode(RoomDatabase.JournalMode.WRITE_AHEAD_LOGGING)
-            .addMigrations(MIGRATION_1_2, MIGRATION_2_3, MIGRATION_3_4, MIGRATION_4_5, MIGRATION_5_6, MIGRATION_6_7, MIGRATION_7_8, MIGRATION_8_9)
+            .addMigrations(MIGRATION_1_2, MIGRATION_2_3, MIGRATION_3_4, MIGRATION_4_5, MIGRATION_5_6, MIGRATION_6_7, MIGRATION_7_8, MIGRATION_8_9, MIGRATION_9_10)
             .build()
 
     @Provides

--- a/android/app/src/test/java/com/rjnr/pocketnode/data/database/WalkingMigrationTest.kt
+++ b/android/app/src/test/java/com/rjnr/pocketnode/data/database/WalkingMigrationTest.kt
@@ -85,6 +85,24 @@ class WalkingMigrationTest {
     }
 
     /**
+     * v1.6.x → v1.7.0 path: bootstrap a v9 SQLite file (no `kdfVersion`
+     * column on `key_material`) and confirm MIGRATION_9_10 adds the
+     * column with default 1, then Room schema validation passes.
+     */
+    @Test
+    fun `v9 walks to v10 successfully and adds kdfVersion column`() {
+        bootstrapV9()
+        openViaRoomAndValidate()
+        // Re-open and inspect: kdfVersion column exists with DEFAULT 1.
+        val db = openedRoomDb!!.openHelper.readableDatabase
+        db.query("PRAGMA table_info(`key_material`)").use { c ->
+            val names = mutableListOf<String>()
+            while (c.moveToNext()) names.add(c.getString(c.getColumnIndexOrThrow("name")))
+            assertTrue("kdfVersion column missing after MIGRATION_9_10: $names", names.contains("kdfVersion"))
+        }
+    }
+
+    /**
      * Regression guard for the v1.5.1 → v1.5.2 hotfix (#143).
      *
      * If `MIGRATION_8_9` is reverted to a no-op (which is what the first
@@ -111,6 +129,7 @@ class WalkingMigrationTest {
                 .addMigrations(
                     MIGRATION_1_2, MIGRATION_2_3, MIGRATION_3_4, MIGRATION_4_5,
                     MIGRATION_5_6, MIGRATION_6_7, MIGRATION_7_8, noOpMigration8To9,
+                    MIGRATION_9_10,
                 )
                 .build()
             openedRoomDb = db
@@ -140,6 +159,7 @@ class WalkingMigrationTest {
             .addMigrations(
                 MIGRATION_1_2, MIGRATION_2_3, MIGRATION_3_4, MIGRATION_4_5,
                 MIGRATION_5_6, MIGRATION_6_7, MIGRATION_7_8, MIGRATION_8_9,
+                MIGRATION_9_10,
             )
             .build()
         openedRoomDb = db
@@ -155,6 +175,33 @@ class WalkingMigrationTest {
      * version 8 so when Room subsequently opens it at version 9,
      * `onUpgrade` fires and runs MIGRATION_8_9.
      */
+    /**
+     * Bootstrap a v9 SQLite file: same as `bootstrapV8(pathA = true)` but
+     * also applies the MIGRATION_8_9 changes inline so the on-disk shape
+     * matches what a real upgraded-to-v9 user has. The key thing for
+     * MIGRATION_9_10 coverage is that `key_material` has no `kdfVersion`
+     * column.
+     */
+    private fun bootstrapV9() {
+        val factory = FrameworkSQLiteOpenHelperFactory()
+        val callback = object : SupportSQLiteOpenHelper.Callback(9) {
+            override fun onCreate(db: SupportSQLiteDatabase) {
+                createV8Tables(db, pathA = true)
+                MIGRATION_8_9.migrate(db)
+                db.execSQL("CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)")
+                db.execSQL("INSERT OR REPLACE INTO room_master_table VALUES(42, 'bootstrap-v9')")
+            }
+            override fun onUpgrade(db: SupportSQLiteDatabase, oldV: Int, newV: Int) = Unit
+        }
+        val config = SupportSQLiteOpenHelper.Configuration.builder(ctx)
+            .name(dbName)
+            .callback(callback)
+            .build()
+        val helper = factory.create(config)
+        helper.writableDatabase.close()
+        helper.close()
+    }
+
     private fun bootstrapV8(pathA: Boolean) {
         val factory = FrameworkSQLiteOpenHelperFactory()
         val callback = object : SupportSQLiteOpenHelper.Callback(8) {

--- a/android/app/src/test/java/com/rjnr/pocketnode/data/migration/KeystoreV2MigrationHelperTest.kt
+++ b/android/app/src/test/java/com/rjnr/pocketnode/data/migration/KeystoreV2MigrationHelperTest.kt
@@ -1,0 +1,291 @@
+package com.rjnr.pocketnode.data.migration
+
+import android.content.Context
+import android.content.SharedPreferences
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import com.rjnr.pocketnode.data.crypto.KeystoreEncryptionManager
+import com.rjnr.pocketnode.data.database.AppDatabase
+import com.rjnr.pocketnode.data.database.dao.KeyMaterialDao
+import com.rjnr.pocketnode.data.database.entity.KeyMaterialEntity
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Assert.*
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [28], manifest = Config.NONE)
+class KeystoreV2MigrationHelperTest {
+
+    private lateinit var db: AppDatabase
+    private lateinit var keyMaterialDao: KeyMaterialDao
+    private lateinit var encryptionManager: KeystoreEncryptionManager
+    private lateinit var migrationPrefs: SharedPreferences
+    private lateinit var v1Helper: KeyStoreMigrationHelper
+    private lateinit var v2Helper: KeystoreV2MigrationHelper
+    private var fakeNow: Long = 1_000_000L
+
+    @Before
+    fun setUp() {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        db = Room.inMemoryDatabaseBuilder(context, AppDatabase::class.java)
+            .allowMainThreadQueries()
+            .build()
+        keyMaterialDao = db.keyMaterialDao()
+        encryptionManager = KeystoreEncryptionManager.createForTest()
+        migrationPrefs = context.getSharedPreferences("test_v2_migration", Context.MODE_PRIVATE)
+        migrationPrefs.edit().clear().commit()
+
+        // V1 helper to seed pre-v1.7.0 wallets into the in-memory DB
+        v1Helper = KeyStoreMigrationHelper(keyMaterialDao, encryptionManager, migrationPrefs)
+        v2Helper = KeystoreV2MigrationHelper(
+            keyMaterialDao,
+            encryptionManager,
+            migrationPrefs,
+            nowProvider = { fakeNow }
+        )
+    }
+
+    @After
+    fun tearDown() { db.close() }
+
+    private suspend fun seedV1Wallet(walletId: String, privateKeyHex: String, mnemonic: String?) {
+        v1Helper.migrateWallet(walletId, privateKeyHex, mnemonic, "mnemonic", true)
+        // V1 helper writes with the default kdfVersion = 1, which matches the
+        // production state of a wallet upgraded from v1.6.x.
+    }
+
+    // -- Discovery --
+
+    @Test
+    fun `pendingWalletIds returns all seeded V1 wallets`() = runTest {
+        seedV1Wallet("alpha", "aa".repeat(32), "word1 word2 word3")
+        seedV1Wallet("beta", "bb".repeat(32), null)
+        seedV1Wallet("gamma", "cc".repeat(32), "more words here")
+
+        val pending = v2Helper.pendingWalletIds()
+        assertEquals(listOf("alpha", "beta", "gamma"), pending)
+    }
+
+    @Test
+    fun `pendingWalletIds excludes wallets already on V2`() = runTest {
+        seedV1Wallet("alpha", "aa".repeat(32), "alpha mnemonic")
+        seedV1Wallet("beta", "bb".repeat(32), "beta mnemonic")
+
+        // Migrate alpha
+        val cipher = encryptionManager.newEncryptCipherV2()
+        v2Helper.migrateWallet("alpha", cipher).getOrThrow()
+
+        val pending = v2Helper.pendingWalletIds()
+        assertEquals(listOf("beta"), pending)
+    }
+
+    @Test
+    fun `isMigrationComplete is false until finalize runs`() = runTest {
+        assertFalse(v2Helper.isMigrationComplete())
+
+        seedV1Wallet("alpha", "aa".repeat(32), null)
+        v2Helper.migrateWallet("alpha", encryptionManager.newEncryptCipherV2()).getOrThrow()
+
+        // Still false even after all wallets migrated — finalize is the explicit
+        // signal that the migration cycle is done.
+        assertFalse(v2Helper.isMigrationComplete())
+
+        v2Helper.finalize().getOrThrow()
+        assertTrue(v2Helper.isMigrationComplete())
+    }
+
+    // -- Per-wallet migration --
+
+    @Test
+    fun `migrateWallet rewrites row with kdfVersion 2 and bundled blob`() = runTest {
+        seedV1Wallet("alpha", "ab".repeat(32), "twelve word mnemonic here for testing only")
+
+        val cipher = encryptionManager.newEncryptCipherV2()
+        v2Helper.migrateWallet("alpha", cipher).getOrThrow()
+
+        val migrated = keyMaterialDao.getByWalletId("alpha")!!
+        assertEquals(2, migrated.kdfVersion)
+        assertNull(
+            "V2 rows must store the bundle in encryptedPrivateKey, not in encryptedMnemonic",
+            migrated.encryptedMnemonic
+        )
+
+        // Round-trip: read the bundle back under a V2 decrypt cipher.
+        val decryptCipher = encryptionManager.newDecryptCipherV2(migrated.iv)
+        val bundle = v2Helper.readV2Bundle("alpha", decryptCipher)
+        assertNotNull(bundle)
+        assertEquals("ab".repeat(32), bundle!!.privateKeyHex)
+        assertEquals("twelve word mnemonic here for testing only", bundle.mnemonic)
+    }
+
+    @Test
+    fun `migrateWallet preserves null mnemonic for raw-key wallets`() = runTest {
+        seedV1Wallet("rawkey", "ff".repeat(32), null)
+
+        v2Helper.migrateWallet("rawkey", encryptionManager.newEncryptCipherV2()).getOrThrow()
+
+        val migrated = keyMaterialDao.getByWalletId("rawkey")!!
+        val bundle = v2Helper.readV2Bundle("rawkey", encryptionManager.newDecryptCipherV2(migrated.iv))
+        assertEquals("ff".repeat(32), bundle!!.privateKeyHex)
+        assertNull(bundle.mnemonic)
+    }
+
+    @Test
+    fun `migrateWallet is idempotent for already-V2 wallets`() = runTest {
+        seedV1Wallet("alpha", "aa".repeat(32), "alpha mnemonic")
+        v2Helper.migrateWallet("alpha", encryptionManager.newEncryptCipherV2()).getOrThrow()
+        val firstMigratedAt = keyMaterialDao.getByWalletId("alpha")!!.updatedAt
+
+        // Calling again should succeed but NOT re-encrypt (no fresh cipher consumed).
+        // The updatedAt should stay the same — proving the second call was a no-op.
+        fakeNow += 1_000L
+        v2Helper.migrateWallet("alpha", encryptionManager.newEncryptCipherV2()).getOrThrow()
+
+        val second = keyMaterialDao.getByWalletId("alpha")!!
+        assertEquals(2, second.kdfVersion)
+        assertEquals(
+            "Second migrate call must not rewrite the row",
+            firstMigratedAt,
+            second.updatedAt
+        )
+    }
+
+    @Test
+    fun `migrateWallet fails when row is missing`() = runTest {
+        val result = v2Helper.migrateWallet("nonexistent", encryptionManager.newEncryptCipherV2())
+        assertTrue(result.isFailure)
+        val msg = result.exceptionOrNull()?.message ?: ""
+        assertTrue("error mentions missing row, got: $msg", msg.contains("No key_material row"))
+    }
+
+    @Test
+    fun `migrateWallet rejects unknown kdfVersion values`() = runTest {
+        // Construct a row with an unrecognized kdfVersion directly. This guards
+        // against future schema changes that introduce a v3 without updating
+        // the migration helper.
+        keyMaterialDao.upsert(
+            KeyMaterialEntity(
+                walletId = "future",
+                encryptedPrivateKey = ByteArray(32) { 0x42 },
+                encryptedMnemonic = null,
+                iv = ByteArray(12) { 0x10 },
+                walletType = "mnemonic",
+                mnemonicBackedUp = false,
+                updatedAt = fakeNow,
+                kdfVersion = 99
+            )
+        )
+
+        val result = v2Helper.migrateWallet("future", encryptionManager.newEncryptCipherV2())
+        assertTrue(result.isFailure)
+        assertTrue(
+            (result.exceptionOrNull()?.message ?: "").contains("Unknown kdfVersion")
+        )
+    }
+
+    // -- Crash safety --
+
+    @Test
+    fun `crash between wallet migrations leaves remaining wallets recoverable`() = runTest {
+        seedV1Wallet("alpha", "aa".repeat(32), "alpha mnemonic")
+        seedV1Wallet("beta", "bb".repeat(32), "beta mnemonic")
+        seedV1Wallet("gamma", "cc".repeat(32), null)
+
+        // Migrate alpha and beta. Simulate a crash (process kill) right before
+        // gamma's migration would have run.
+        v2Helper.migrateWallet("alpha", encryptionManager.newEncryptCipherV2()).getOrThrow()
+        v2Helper.migrateWallet("beta", encryptionManager.newEncryptCipherV2()).getOrThrow()
+        // <crash here>
+
+        // On the next launch the caller re-instantiates the helper and resumes.
+        // pendingWalletIds returns only the un-migrated wallets — alpha and
+        // beta are NOT re-migrated.
+        val v2HelperAfterCrash = KeystoreV2MigrationHelper(
+            keyMaterialDao,
+            encryptionManager,
+            migrationPrefs,
+            nowProvider = { fakeNow }
+        )
+        val resumed = v2HelperAfterCrash.pendingWalletIds()
+        assertEquals(listOf("gamma"), resumed)
+
+        // Alpha and beta retain their migrated state (kdfVersion=2) and remain
+        // decryptable under V2.
+        val alphaMigrated = keyMaterialDao.getByWalletId("alpha")!!
+        assertEquals(2, alphaMigrated.kdfVersion)
+        val alphaBundle = v2HelperAfterCrash.readV2Bundle(
+            "alpha",
+            encryptionManager.newDecryptCipherV2(alphaMigrated.iv)
+        )
+        assertEquals("aa".repeat(32), alphaBundle!!.privateKeyHex)
+
+        // Finish the migration.
+        v2HelperAfterCrash.migrateWallet("gamma", encryptionManager.newEncryptCipherV2()).getOrThrow()
+        assertEquals(emptyList<String>(), v2HelperAfterCrash.pendingWalletIds())
+
+        v2HelperAfterCrash.finalize().getOrThrow()
+        assertTrue(v2HelperAfterCrash.isMigrationComplete())
+    }
+
+    @Test
+    fun `crash mid-encryption leaves the row on V1 untouched`() = runTest {
+        // The "crash mid-encryption" path: the caller obtains a V2 cipher but
+        // never calls migrateWallet (the process dies before doFinal). The row
+        // must remain at kdfVersion=1 with V1 ciphertext intact, so the next
+        // launch finds it via pendingWalletIds and can re-migrate.
+        seedV1Wallet("alpha", "aa".repeat(32), "alpha mnemonic")
+
+        // Acquire a cipher but never use it — simulating a kill between
+        // BiometricPrompt success and migrateWallet's first DB write.
+        encryptionManager.newEncryptCipherV2() // discarded
+
+        // Row is unchanged.
+        val unchanged = keyMaterialDao.getByWalletId("alpha")!!
+        assertEquals(1, unchanged.kdfVersion)
+        assertEquals(listOf("alpha"), v2Helper.pendingWalletIds())
+
+        // Retry succeeds.
+        v2Helper.migrateWallet("alpha", encryptionManager.newEncryptCipherV2()).getOrThrow()
+        assertEquals(2, keyMaterialDao.getByWalletId("alpha")!!.kdfVersion)
+    }
+
+    // -- Finalize --
+
+    @Test
+    fun `finalize refuses to run when wallets are still on V1`() = runTest {
+        seedV1Wallet("alpha", "aa".repeat(32), "alpha")
+        seedV1Wallet("beta", "bb".repeat(32), null)
+
+        v2Helper.migrateWallet("alpha", encryptionManager.newEncryptCipherV2()).getOrThrow()
+        // beta still on V1
+
+        val result = v2Helper.finalize()
+        assertTrue(result.isFailure)
+        assertTrue(
+            (result.exceptionOrNull()?.message ?: "").contains("Refusing to finalize")
+        )
+        assertFalse(v2Helper.isMigrationComplete())
+    }
+
+    @Test
+    fun `finalize succeeds when all wallets are V2`() = runTest {
+        seedV1Wallet("alpha", "aa".repeat(32), "alpha")
+        v2Helper.migrateWallet("alpha", encryptionManager.newEncryptCipherV2()).getOrThrow()
+
+        v2Helper.finalize().getOrThrow()
+        assertTrue(v2Helper.isMigrationComplete())
+    }
+
+    @Test
+    fun `finalize is callable with an empty database`() = runTest {
+        // Fresh-install case: no wallets exist yet, the migration is trivially
+        // complete on first v1.7.0 launch.
+        v2Helper.finalize().getOrThrow()
+        assertTrue(v2Helper.isMigrationComplete())
+    }
+}


### PR DESCRIPTION
## Summary

Third of five sub-PRs splitting [#213](https://github.com/RaheemJnr/pocket-node/issues/213) (audit Finding High 1: AES wallet key lacks user-authentication binding).

- Adds `kdfVersion` column to `key_material` (schema v9 → v10, MIGRATION_9_10)
- Introduces `KeystoreV2MigrationHelper` that re-encrypts wallet key material under the V2 (auth-bound) key
- Bundles `privateKey` + `mnemonic` into one V2 ciphertext to halve BiometricPrompt count during migration
- Idempotent + crash-safe at the Room-row level

The migration helper is wired but **not yet invoked from app code**. Sub-PR 4 will connect it to BiometricPrompt at the call sites (Send, Mnemonic backup, Settings, DAO). Until then, app behavior is unchanged.

## Test plan

- [x] `./gradlew :app:testDebugUnitTest` → 578/578 pass (12 new in `KeystoreV2MigrationHelperTest`, 1 new walking migration test for v9→v10)
- [x] Walking migration covers v8→v10 (path A + B) and v9→v10
- [x] Crash-safety: kill mid-loop leaves remaining wallets discoverable via `pendingWalletIds()`
- [x] Idempotence: re-running migration on an already-V2 row is a no-op
- [x] `finalize()` refuses to delete V1 key while any wallet remains on V1

Refs #213, #187 Finding High 1