### PR TITLE
feat(crypto): biometric infrastructure + Send V2 wiring (#213 sub-PR 4/5)

### DIFF
--- a/android/app/src/main/java/com/rjnr/pocketnode/data/auth/AuthManager.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/auth/AuthManager.kt
@@ -7,9 +7,15 @@ import android.os.Build
 import androidx.annotation.VisibleForTesting
 import androidx.biometric.BiometricManager
 import androidx.biometric.BiometricManager.Authenticators
+import androidx.biometric.BiometricPrompt
+import androidx.core.content.ContextCompat
+import androidx.fragment.app.FragmentActivity
 import dagger.hilt.android.qualifiers.ApplicationContext
+import javax.crypto.Cipher
 import javax.inject.Inject
 import javax.inject.Singleton
+import kotlin.coroutines.resume
+import kotlinx.coroutines.suspendCancellableCoroutine
 
 @Singleton
 class AuthManager @Inject constructor(
@@ -101,6 +107,113 @@ class AuthManager @Inject constructor(
             Authenticators.DEVICE_CREDENTIAL
         } else {
             Authenticators.BIOMETRIC_STRONG
+        }
+    }
+
+    /**
+     * Outcome of a BiometricPrompt CryptoObject-bound authentication.
+     *
+     * `Success` carries the same [Cipher] the caller passed in, now unlocked
+     * by the Android Keystore. The caller must run `cipher.doFinal(...)`
+     * before any process boundary — Keystore will not honor it for a fresh
+     * `doFinal` later because V2 keys are configured with
+     * `setUserAuthenticationParameters(0, ...)` (per-operation auth).
+     *
+     * `Cancelled` is returned on user-cancel and negative-button press. The
+     * caller is responsible for routing to a fallback (PIN, navigation).
+     *
+     * `Error` carries the BiometricPrompt error code and message. The auth
+     * was rejected by the framework — distinguished from cancel so the UI
+     * can show a transient error (e.g. "Too many attempts, try again later").
+     */
+    sealed class CipherAuthResult {
+        data class Success(val cipher: Cipher) : CipherAuthResult()
+        object Cancelled : CipherAuthResult()
+        data class Error(val errorCode: Int, val errString: CharSequence) : CipherAuthResult()
+    }
+
+    /**
+     * Prompt the user via BiometricPrompt and return the same [cipher] back
+     * once Keystore has authorized it. Used by the V2 (auth-bound) wallet
+     * key path: the caller obtains an uninitialized-for-`doFinal` Cipher
+     * via `KeystoreEncryptionManager.newEncryptCipherV2` /
+     * `newDecryptCipherV2`, runs it through this helper, and only then
+     * passes it to `encryptWithCipher` / `decryptWithCipher`.
+     *
+     * The prompt always uses [getAllowedAuthenticators] so users without
+     * biometrics can fall back to the device PIN/pattern set in Android
+     * Settings. The negative-button text is only shown for biometric-only
+     * prompts; [Authenticators.DEVICE_CREDENTIAL] disallows it.
+     *
+     * Suspending: the coroutine is resumed when the framework callback
+     * fires. Cancelling the coroutine cancels the in-flight prompt.
+     */
+    suspend fun authenticateForCipher(
+        activity: FragmentActivity,
+        cipher: Cipher,
+        title: String,
+        subtitle: String,
+        negativeButtonText: String = "Cancel"
+    ): CipherAuthResult = suspendCancellableCoroutine { cont ->
+        val executor = ContextCompat.getMainExecutor(activity)
+        val prompt = BiometricPrompt(
+            activity,
+            executor,
+            object : BiometricPrompt.AuthenticationCallback() {
+                override fun onAuthenticationSucceeded(result: BiometricPrompt.AuthenticationResult) {
+                    val authedCipher = result.cryptoObject?.cipher
+                    if (authedCipher != null) {
+                        cont.resume(CipherAuthResult.Success(authedCipher))
+                    } else {
+                        // Defensive: framework returned success without a
+                        // CryptoObject. Should not happen when we pass one
+                        // in, but treat it as an error rather than silently
+                        // forging a Success with the un-authenticated cipher
+                        // (which would fail later at doFinal).
+                        cont.resume(
+                            CipherAuthResult.Error(
+                                BiometricPrompt.ERROR_VENDOR,
+                                "Authenticator returned no CryptoObject"
+                            )
+                        )
+                    }
+                }
+
+                override fun onAuthenticationError(errorCode: Int, errString: CharSequence) {
+                    val outcome = when (errorCode) {
+                        BiometricPrompt.ERROR_USER_CANCELED,
+                        BiometricPrompt.ERROR_NEGATIVE_BUTTON,
+                        BiometricPrompt.ERROR_CANCELED -> CipherAuthResult.Cancelled
+                        else -> CipherAuthResult.Error(errorCode, errString)
+                    }
+                    cont.resume(outcome)
+                }
+            }
+        )
+
+        val allowed = getAllowedAuthenticators()
+        val builder = BiometricPrompt.PromptInfo.Builder()
+            .setTitle(title)
+            .setSubtitle(subtitle)
+            .setAllowedAuthenticators(allowed)
+        // DEVICE_CREDENTIAL cannot coexist with a negative button — the
+        // framework throws IllegalArgumentException. The fallback button is
+        // only meaningful for biometric-only prompts.
+        if ((allowed and Authenticators.DEVICE_CREDENTIAL) == 0) {
+            builder.setNegativeButtonText(negativeButtonText)
+        }
+
+        try {
+            prompt.authenticate(builder.build(), BiometricPrompt.CryptoObject(cipher))
+        } catch (e: IllegalStateException) {
+            // The framework rejects authenticate() (e.g. fragment already
+            // destroyed). Surface as Error so the caller sees a deterministic
+            // failure rather than a hung coroutine.
+            cont.resume(CipherAuthResult.Error(BiometricPrompt.ERROR_VENDOR, e.message ?: "prompt failed"))
+        }
+
+        cont.invokeOnCancellation {
+            try { prompt.cancelAuthentication() } catch (_: Exception) {}
         }
     }
 

--- a/android/app/src/main/java/com/rjnr/pocketnode/data/database/dao/KeyMaterialDao.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/database/dao/KeyMaterialDao.kt
@@ -37,4 +37,13 @@ interface KeyMaterialDao {
 
     @Query("SELECT COUNT(*) FROM key_material WHERE kdfVersion = 2")
     suspend fun countV2Wallets(): Int
+
+    /**
+     * Peek the kdfVersion of a single wallet without loading its
+     * ciphertext columns. Used by V2-aware call sites to decide whether
+     * a BiometricPrompt CryptoObject step is needed before reading the
+     * private key. Returns null when the wallet has no key_material row.
+     */
+    @Query("SELECT kdfVersion FROM key_material WHERE walletId = :walletId")
+    suspend fun getKdfVersion(walletId: String): Int?
 }

--- a/android/app/src/main/java/com/rjnr/pocketnode/data/migration/KeyStoreMigrationHelper.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/migration/KeyStoreMigrationHelper.kt
@@ -5,6 +5,8 @@ import android.util.Log
 import com.rjnr.pocketnode.data.crypto.KeystoreEncryptionManager
 import com.rjnr.pocketnode.data.database.dao.KeyMaterialDao
 import com.rjnr.pocketnode.data.database.entity.KeyMaterialEntity
+import javax.crypto.Cipher
+import kotlinx.serialization.json.Json
 
 data class DecryptedKeyData(
     val privateKeyHex: String,
@@ -12,6 +14,20 @@ data class DecryptedKeyData(
     val walletType: String,
     val mnemonicBackedUp: Boolean
 )
+
+/**
+ * Thrown when [KeyStoreMigrationHelper.readDecryptedKey] is asked to read
+ * a V2 (auth-bound) row without an authenticated Cipher. The caller must
+ * obtain a Cipher via [KeystoreEncryptionManager.newDecryptCipherV2],
+ * pass it through `AuthManager.authenticateForCipher`, and retry with the
+ * returned overload that accepts a Cipher.
+ *
+ * Surfaced as an explicit exception (rather than a null return) so call
+ * sites that haven't yet migrated to the V2-aware overload fail loudly
+ * instead of silently treating the wallet as non-existent.
+ */
+class V2KeyMaterialRequiresAuthException(walletId: String) :
+    IllegalStateException("walletId=$walletId is on V2 (kdfVersion=2); caller must supply an authenticated Cipher")
 
 class KeyStoreMigrationHelper(
     private val keyMaterialDao: KeyMaterialDao,
@@ -50,9 +66,55 @@ class KeyStoreMigrationHelper(
         keyMaterialDao.upsert(entity)
     }
 
+    /**
+     * Read key material for a wallet. V1 (kdfVersion=1) rows decrypt
+     * silently under the legacy unrestricted Keystore key. V2 rows throw
+     * [V2KeyMaterialRequiresAuthException] — callers must use the overload
+     * that accepts an authenticated Cipher.
+     *
+     * Until sub-PR 5 of #213 wires every call site to the V2 path,
+     * production wallets remain on V1 (the migration is not yet invoked
+     * from app code), so this method behaves exactly like v1.6.x for live
+     * users.
+     */
     suspend fun readDecryptedKey(walletId: String): DecryptedKeyData? {
         val entity = keyMaterialDao.getByWalletId(walletId) ?: return null
+        return when (entity.kdfVersion) {
+            1 -> decryptV1Row(entity)
+            2 -> throw V2KeyMaterialRequiresAuthException(walletId)
+            else -> {
+                Log.e(TAG, "Unknown kdfVersion=${entity.kdfVersion} for walletId=$walletId")
+                null
+            }
+        }
+    }
 
+    /**
+     * Read key material from a V2 row. The caller has already authenticated
+     * [v2DecryptCipher] via `AuthManager.authenticateForCipher` — Keystore
+     * releases the key for exactly one `doFinal` call, which is exhausted
+     * here. The bundled JSON format is established by
+     * [KeystoreV2MigrationHelper.WalletKeyBundle].
+     *
+     * V1 rows are still readable through this overload (falls through to
+     * the V1 path; the V2 cipher is ignored) so that a caller that doesn't
+     * know which version a wallet is on can pass a V2 cipher unconditionally
+     * during migration. Post-migration, every row is V2 and this branch
+     * never fires.
+     */
+    suspend fun readDecryptedKey(walletId: String, v2DecryptCipher: Cipher): DecryptedKeyData? {
+        val entity = keyMaterialDao.getByWalletId(walletId) ?: return null
+        return when (entity.kdfVersion) {
+            1 -> decryptV1Row(entity)
+            2 -> decryptV2Row(entity, v2DecryptCipher)
+            else -> {
+                Log.e(TAG, "Unknown kdfVersion=${entity.kdfVersion} for walletId=$walletId")
+                null
+            }
+        }
+    }
+
+    private fun decryptV1Row(entity: KeyMaterialEntity): DecryptedKeyData? {
         return try {
             val keyCipher = encryptionManager.newDecryptCipher(entity.iv)
             val keyBytes = encryptionManager.decryptWithCipher(keyCipher, entity.encryptedPrivateKey)
@@ -75,9 +137,33 @@ class KeyStoreMigrationHelper(
                 mnemonicBackedUp = entity.mnemonicBackedUp
             )
         } catch (e: Exception) {
-            Log.e(TAG, "Failed to decrypt key material for $walletId", e)
+            Log.e(TAG, "Failed to decrypt V1 key material for ${entity.walletId}", e)
             null
         }
+    }
+
+    private fun decryptV2Row(entity: KeyMaterialEntity, v2Cipher: Cipher): DecryptedKeyData? {
+        return try {
+            val bundleBytes = encryptionManager.decryptWithCipher(v2Cipher, entity.encryptedPrivateKey)
+            val bundle = v2Json.decodeFromString(
+                WalletKeyBundle.serializer(),
+                String(bundleBytes, Charsets.UTF_8)
+            )
+            DecryptedKeyData(
+                privateKeyHex = bundle.privateKeyHex,
+                mnemonic = bundle.mnemonic,
+                walletType = entity.walletType,
+                mnemonicBackedUp = entity.mnemonicBackedUp
+            )
+        } catch (e: Exception) {
+            Log.e(TAG, "Failed to decrypt V2 key material for ${entity.walletId}", e)
+            null
+        }
+    }
+
+    private val v2Json = Json {
+        ignoreUnknownKeys = true
+        encodeDefaults = true
     }
 
     fun isMigrationComplete(): Boolean {

--- a/android/app/src/main/java/com/rjnr/pocketnode/data/migration/KeystoreV2MigrationRunner.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/migration/KeystoreV2MigrationRunner.kt
@@ -1,0 +1,121 @@
+package com.rjnr.pocketnode.data.migration
+
+import android.util.Log
+import androidx.fragment.app.FragmentActivity
+import com.rjnr.pocketnode.data.auth.AuthManager
+import com.rjnr.pocketnode.data.crypto.KeystoreEncryptionManager
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * UI-side orchestrator that drives the v1.6.x → v1.7.0 wallet key
+ * migration end-to-end: discovers pending wallets via
+ * [KeystoreV2MigrationHelper.pendingWalletIds], walks each wallet through
+ * a BiometricPrompt CryptoObject flow, then calls [KeystoreV2MigrationHelper.finalize]
+ * once all wallets are on V2.
+ *
+ * ## Status
+ *
+ * Wired but **not yet invoked from app code**. Sub-PR 5 of #213 will
+ * connect this from MainActivity post-PIN-unlock once every key-reading
+ * call site (Send, mnemonic backup, sub-account derivation, DAO ops) is
+ * V2-aware. Calling [runMigration] today would re-encrypt key material
+ * under the V2 key and then break every call site that still uses V1.
+ *
+ * ## Why a separate class
+ *
+ * The V2 helper itself is UI-agnostic — it accepts a pre-authenticated
+ * Cipher and writes one row. The runner owns the activity-scoped concerns:
+ * which prompt copy to show, what to do on cancel, how to resume after
+ * a process kill. Keeping these out of the helper means the helper stays
+ * unit-testable with Robolectric in-memory keys, and the runner can be
+ * exercised by instrumentation tests later without dragging
+ * `FragmentActivity` into the data layer.
+ */
+@Singleton
+class KeystoreV2MigrationRunner @Inject constructor(
+    private val helper: KeystoreV2MigrationHelper,
+    private val encryptionManager: KeystoreEncryptionManager,
+    private val authManager: AuthManager,
+) {
+
+    sealed class Outcome {
+        /** Every wallet migrated and `finalize()` succeeded. */
+        object Completed : Outcome()
+        /** User cancelled at least one prompt. Remaining wallets are still on V1. */
+        data class Cancelled(val pendingCount: Int) : Outcome()
+        /** Auth failed for at least one wallet (not user-cancel). Migration is partial. */
+        data class Failed(val pendingCount: Int, val reason: String) : Outcome()
+        /** Nothing to do — either no wallets exist or migration has already finalized. */
+        object NothingToDo : Outcome()
+    }
+
+    /**
+     * Drive the V2 migration to completion. Re-prompts per wallet until
+     * either every wallet is on V2 (then calls [KeystoreV2MigrationHelper.finalize])
+     * or the user cancels.
+     *
+     * Idempotent: re-running after a partial migration picks up where it
+     * left off via [KeystoreV2MigrationHelper.pendingWalletIds].
+     *
+     * @param activity host for `BiometricPrompt`. Must be alive for the
+     *   duration of the call.
+     * @param promptTitle title shown on every per-wallet prompt.
+     * @param promptSubtitle subtitle shown on every per-wallet prompt.
+     */
+    suspend fun runMigration(
+        activity: FragmentActivity,
+        promptTitle: String = "Upgrade wallet security",
+        promptSubtitle: String = "Unlock to re-encrypt your wallet keys.",
+    ): Outcome {
+        if (helper.isMigrationComplete()) return Outcome.NothingToDo
+
+        val pending = helper.pendingWalletIds()
+        if (pending.isEmpty()) {
+            return helper.finalize().fold(
+                onSuccess = { Outcome.Completed },
+                onFailure = { Outcome.Failed(0, it.message ?: "finalize failed") }
+            )
+        }
+
+        for (walletId in pending) {
+            val cipher = encryptionManager.newEncryptCipherV2()
+            val authResult = authManager.authenticateForCipher(
+                activity = activity,
+                cipher = cipher,
+                title = promptTitle,
+                subtitle = promptSubtitle,
+            )
+            when (authResult) {
+                is AuthManager.CipherAuthResult.Cancelled -> {
+                    Log.i(TAG, "User cancelled V2 migration prompt for $walletId")
+                    return Outcome.Cancelled(helper.pendingWalletIds().size)
+                }
+                is AuthManager.CipherAuthResult.Error -> {
+                    Log.e(TAG, "Auth error code=${authResult.errorCode} for $walletId: ${authResult.errString}")
+                    return Outcome.Failed(
+                        helper.pendingWalletIds().size,
+                        "auth error ${authResult.errorCode}: ${authResult.errString}"
+                    )
+                }
+                is AuthManager.CipherAuthResult.Success -> {
+                    val migrate = helper.migrateWallet(walletId, authResult.cipher)
+                    if (migrate.isFailure) {
+                        val msg = migrate.exceptionOrNull()?.message ?: "migrate failed"
+                        Log.e(TAG, "Migrate failed for $walletId: $msg")
+                        return Outcome.Failed(helper.pendingWalletIds().size, msg)
+                    }
+                }
+            }
+        }
+
+        return helper.finalize().fold(
+            onSuccess = { Outcome.Completed },
+            onFailure = { Outcome.Failed(helper.pendingWalletIds().size, it.message ?: "finalize failed") }
+        )
+    }
+
+    companion object {
+        private const val TAG = "KeystoreV2Migration"
+    }
+}

--- a/android/app/src/main/java/com/rjnr/pocketnode/data/wallet/WalletKeyReader.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/wallet/WalletKeyReader.kt
@@ -1,0 +1,119 @@
+package com.rjnr.pocketnode.data.wallet
+
+import android.util.Log
+import androidx.fragment.app.FragmentActivity
+import com.rjnr.pocketnode.data.auth.AuthManager
+import com.rjnr.pocketnode.data.crypto.KeystoreEncryptionManager
+import com.rjnr.pocketnode.data.database.dao.KeyMaterialDao
+import com.rjnr.pocketnode.data.migration.KeyStoreMigrationHelper
+import javax.inject.Inject
+import javax.inject.Singleton
+import org.nervos.ckb.utils.Numeric
+
+/**
+ * Activity-aware bridge between a ViewModel and the (V1 or V2)
+ * key-material store. Lets call sites read a wallet's private key without
+ * caring whether the row is on the legacy unrestricted Keystore key (V1)
+ * or the auth-bound key (V2); the BiometricPrompt CryptoObject dance is
+ * encapsulated here.
+ *
+ * ## Why a separate class
+ *
+ * `KeyManager` is `@Singleton` and never sees an `Activity`. Threading
+ * `FragmentActivity` through every call site for V2-only code paths was
+ * a bigger refactor than the audit fix warranted. This reader is the one
+ * boundary between the data layer and the UI layer that needs activity
+ * scope. It's intentionally small.
+ *
+ * ## Status
+ *
+ * Sub-PR 4 of #213 wires this into [SendViewModel][com.rjnr.pocketnode.ui.screens.send.SendViewModel]
+ * as the first user. Sub-PR 5 will migrate mnemonic backup, sub-account
+ * derivation, DAO ops, and the security settings export flow to this
+ * same reader.
+ */
+@Singleton
+class WalletKeyReader @Inject constructor(
+    private val keyMaterialDao: KeyMaterialDao,
+    private val keyStoreMigrationHelper: KeyStoreMigrationHelper,
+    private val encryptionManager: KeystoreEncryptionManager,
+    private val authManager: AuthManager,
+) {
+
+    sealed class Result {
+        data class Success(val privateKey: ByteArray) : Result()
+        /** User cancelled the biometric prompt; no key returned. */
+        object Cancelled : Result()
+        /** Auth framework reported an error (not user-cancel). */
+        data class AuthError(val errorCode: Int, val message: CharSequence) : Result()
+        /** Wallet row missing, decrypt failed, or unknown kdfVersion. */
+        data class NotAvailable(val reason: String) : Result()
+    }
+
+    /**
+     * Read the private key for [walletId]. Picks the V1 or V2 code path
+     * based on the row's `kdfVersion`. V2 prompts the user via
+     * `BiometricPrompt`; V1 returns silently.
+     *
+     * The Cipher returned by Keystore is single-shot: this method consumes
+     * it immediately in `decryptWithCipher` and discards it. Callers must
+     * not retain the returned key any longer than needed for the operation
+     * at hand (sign, derive sub-account, display mnemonic).
+     */
+    suspend fun readPrivateKey(
+        activity: FragmentActivity,
+        walletId: String,
+        promptTitle: String,
+        promptSubtitle: String,
+    ): Result {
+        val kdfVersion = keyMaterialDao.getKdfVersion(walletId)
+            ?: return Result.NotAvailable("no key_material row for $walletId")
+
+        return when (kdfVersion) {
+            1 -> readV1(walletId)
+            2 -> readV2(activity, walletId, promptTitle, promptSubtitle)
+            else -> Result.NotAvailable("unknown kdfVersion=$kdfVersion")
+        }
+    }
+
+    private suspend fun readV1(walletId: String): Result {
+        val data = keyStoreMigrationHelper.readDecryptedKey(walletId)
+            ?: return Result.NotAvailable("V1 decrypt failed for $walletId")
+        return Result.Success(Numeric.hexStringToByteArray(data.privateKeyHex))
+    }
+
+    private suspend fun readV2(
+        activity: FragmentActivity,
+        walletId: String,
+        promptTitle: String,
+        promptSubtitle: String,
+    ): Result {
+        val entity = keyMaterialDao.getByWalletId(walletId)
+            ?: return Result.NotAvailable("no key_material row for $walletId")
+        val cipher = encryptionManager.newDecryptCipherV2(entity.iv)
+        val authResult = authManager.authenticateForCipher(
+            activity = activity,
+            cipher = cipher,
+            title = promptTitle,
+            subtitle = promptSubtitle,
+        )
+        return when (authResult) {
+            is AuthManager.CipherAuthResult.Cancelled -> Result.Cancelled
+            is AuthManager.CipherAuthResult.Error ->
+                Result.AuthError(authResult.errorCode, authResult.errString)
+            is AuthManager.CipherAuthResult.Success -> {
+                val data = try {
+                    keyStoreMigrationHelper.readDecryptedKey(walletId, authResult.cipher)
+                } catch (e: Exception) {
+                    Log.e(TAG, "V2 decrypt failed for $walletId", e)
+                    null
+                } ?: return Result.NotAvailable("V2 decrypt failed for $walletId")
+                Result.Success(Numeric.hexStringToByteArray(data.privateKeyHex))
+            }
+        }
+    }
+
+    companion object {
+        private const val TAG = "WalletKeyReader"
+    }
+}

--- a/android/app/src/main/java/com/rjnr/pocketnode/data/wallet/WalletRepository.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/wallet/WalletRepository.kt
@@ -32,6 +32,16 @@ class WalletRepository @Inject constructor(
 ) {
     val walletsFlow: Flow<List<WalletEntity>> = walletDao.getAllFlow()
 
+    /**
+     * Synchronous snapshot of the currently-active walletId, or null if
+     * no wallet has been selected yet. Reads from
+     * [WalletPreferences.getActiveWalletId] directly so it can be called
+     * outside a coroutine; the underlying SharedPreferences read is fast.
+     * Used by V2-aware call sites that need to peek the kdfVersion before
+     * deciding whether a BiometricPrompt CryptoObject step is required.
+     */
+    fun activeWalletIdSnapshot(): String? = walletPreferences.getActiveWalletId()
+
     fun getActiveWallet(): Flow<WalletEntity?> = walletDao.getActiveWallet()
 
     fun getAllWallets(): Flow<List<WalletEntity>> = walletDao.getAllWallets()

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/send/SendScreen.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/send/SendScreen.kt
@@ -211,7 +211,20 @@ fun SendScreen(
         updateRecipient = viewModel::updateRecipient,
         updateAmount = viewModel::updateAmount,
         setMaxAmount = viewModel::setMaxAmount,
-        sendTransaction = viewModel::sendTransaction
+        sendTransaction = {
+            // V2-aware send: pass the host FragmentActivity so the
+            // ViewModel can drive a CryptoObject-bound BiometricPrompt
+            // for wallets on kdfVersion=2 (#213). V1 wallets fall back to
+            // the legacy non-CryptoObject biometric gate via the existing
+            // requiresAuth state. Compose previews don't have a
+            // FragmentActivity, so they keep using the no-arg overload.
+            val activity = context as? FragmentActivity
+            if (activity != null) {
+                viewModel.sendTransaction(activity)
+            } else {
+                viewModel.sendTransaction()
+            }
+        }
     )
 }
 

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/send/SendViewModel.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/send/SendViewModel.kt
@@ -1,16 +1,19 @@
 package com.rjnr.pocketnode.ui.screens.send
 
 import android.util.Log
+import androidx.fragment.app.FragmentActivity
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.rjnr.pocketnode.data.auth.AuthManager
 import com.rjnr.pocketnode.data.auth.PinManager
+import com.rjnr.pocketnode.data.database.dao.KeyMaterialDao
 import com.rjnr.pocketnode.data.database.entity.WalletEntity
 import com.rjnr.pocketnode.data.gateway.GatewayRepository
 import com.rjnr.pocketnode.data.gateway.models.NetworkType
 import com.rjnr.pocketnode.data.gateway.models.TransactionStatusResponse
 import com.rjnr.pocketnode.data.transaction.TransactionBuilder
 import com.rjnr.pocketnode.data.wallet.KeyManager
+import com.rjnr.pocketnode.data.wallet.WalletKeyReader
 import com.rjnr.pocketnode.data.wallet.WalletRepository
 import com.rjnr.pocketnode.util.sanitizeAmount
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -57,7 +60,9 @@ class SendViewModel @Inject constructor(
     private val transactionBuilder: TransactionBuilder,
     private val authManager: AuthManager,
     private val pinManager: PinManager,
-    private val walletRepository: WalletRepository
+    private val walletRepository: WalletRepository,
+    private val walletKeyReader: WalletKeyReader,
+    private val keyMaterialDao: KeyMaterialDao,
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow(SendUiState())
@@ -158,39 +163,86 @@ class SendViewModel @Inject constructor(
         updateAmount(formatted.ifEmpty { "0" })
     }
 
+    /**
+     * Legacy entry point (V1 wallets). Kept so non-Compose callers and
+     * tests that don't have a `FragmentActivity` still work. On a V2
+     * wallet this returns an error — Compose callers should use the
+     * [sendTransaction] overload that accepts an activity.
+     */
     fun sendTransaction() {
-        val state = _uiState.value
+        viewModelScope.launch {
+            if (peekActiveKdfVersion() == 2) {
+                _uiState.update {
+                    it.copy(error = "This wallet requires biometric unlock; reopen Send and try again")
+                }
+                return@launch
+            }
+            sendTransactionV1OrFallback()
+        }
+    }
 
+    /**
+     * V2-aware entry point. If the active wallet is on kdfVersion=2,
+     * acquires the private key via [WalletKeyReader] which drives the
+     * BiometricPrompt CryptoObject dance. Otherwise falls back to the
+     * V1 flow (which itself may show a non-CryptoObject biometric gate
+     * via the existing `requiresAuth` state, unchanged from v1.6.x).
+     */
+    fun sendTransaction(activity: FragmentActivity) {
+        viewModelScope.launch {
+            if (!validateInputs()) return@launch
+
+            val kdfVersion = peekActiveKdfVersion()
+            if (kdfVersion == 2) {
+                executeSendV2(activity)
+            } else {
+                sendTransactionV1OrFallback()
+            }
+        }
+    }
+
+    private suspend fun peekActiveKdfVersion(): Int? {
+        val walletId = walletPreferencesActiveId() ?: return null
+        return runCatching { keyMaterialDao.getKdfVersion(walletId) }.getOrNull()
+    }
+
+    private fun walletPreferencesActiveId(): String? {
+        return walletRepository.activeWalletIdSnapshot()?.takeIf { it.isNotEmpty() }
+    }
+
+    private fun validateInputs(): Boolean {
+        val state = _uiState.value
         if (state.recipientAddress.isBlank()) {
             _uiState.update { it.copy(error = "Please enter recipient address") }
-            return
+            return false
         }
-
         if (state.amountCkb.isBlank()) {
             _uiState.update { it.copy(error = "Please enter amount") }
-            return
+            return false
         }
-
         val amountShannons = try {
             BigDecimal(state.amountCkb).setScale(8, RoundingMode.DOWN)
                 .multiply(BigDecimal(100_000_000)).toLong()
         } catch (e: Exception) {
             _uiState.update { it.copy(error = "Invalid amount") }
-            return
+            return false
         }
-
         val minCapacity = 61_00000000L
         if (amountShannons < minCapacity) {
             _uiState.update { it.copy(error = "Minimum transfer is 61 CKB") }
-            return
+            return false
         }
-
         if (amountShannons > state.availableBalance) {
             _uiState.update { it.copy(error = "Insufficient balance") }
-            return
+            return false
         }
+        return true
+    }
 
-        // Check if authentication is required before sending
+    private fun sendTransactionV1OrFallback() {
+        if (!validateInputs()) return
+
+        // Check if authentication is required before sending (V1 path).
         if (authManager.isAuthBeforeSendEnabled() && pinManager.hasPin()) {
             val method = if (authManager.isBiometricEnabled() && authManager.isBiometricEnrolled()) {
                 AuthMethod.BIOMETRIC
@@ -202,6 +254,96 @@ class SendViewModel @Inject constructor(
         }
 
         executeSend()
+    }
+
+    private suspend fun executeSendV2(activity: FragmentActivity) {
+        val state = _uiState.value
+        val amountShannons = BigDecimal(state.amountCkb).setScale(8, RoundingMode.DOWN)
+            .multiply(BigDecimal(100_000_000)).toLong()
+
+        val capturedAddress = repository.getCurrentAddress()
+        if (capturedAddress == null) {
+            _uiState.update { it.copy(error = "Wallet not initialized") }
+            return
+        }
+
+        val walletId = walletPreferencesActiveId() ?: run {
+            _uiState.update { it.copy(error = "No active wallet") }
+            return
+        }
+
+        when (val readResult = walletKeyReader.readPrivateKey(
+            activity = activity,
+            walletId = walletId,
+            promptTitle = "Authenticate to Send",
+            promptSubtitle = "Verify your identity to send CKB",
+        )) {
+            is WalletKeyReader.Result.Cancelled -> {
+                _uiState.update { it.copy(error = null, isLoading = false) }
+                return
+            }
+            is WalletKeyReader.Result.AuthError -> {
+                _uiState.update {
+                    it.copy(error = "Authentication failed: ${readResult.message}", isLoading = false)
+                }
+                return
+            }
+            is WalletKeyReader.Result.NotAvailable -> {
+                _uiState.update {
+                    it.copy(error = "Cannot read wallet key: ${readResult.reason}", isLoading = false)
+                }
+                return
+            }
+            is WalletKeyReader.Result.Success -> {
+                proceedWithSend(amountShannons, capturedAddress, readResult.privateKey)
+            }
+        }
+    }
+
+    private suspend fun proceedWithSend(
+        amountShannons: Long,
+        capturedAddress: String,
+        privateKey: ByteArray,
+    ) {
+        val state = _uiState.value
+        _uiState.update {
+            it.copy(
+                isLoading = true,
+                error = null,
+                transactionState = TransactionState.SENDING,
+                statusMessage = "Building transaction..."
+            )
+        }
+        try {
+            _uiState.update { it.copy(statusMessage = "Broadcasting transaction...") }
+            val txHash = repository.prepareAndSend(
+                fromAddress = capturedAddress,
+                toAddress = state.recipientAddress,
+                amountShannons = amountShannons,
+                privateKey = privateKey,
+            ).getOrThrow()
+            _uiState.update {
+                it.copy(
+                    isLoading = false,
+                    txHash = txHash,
+                    recipientAddress = "",
+                    amountCkb = "",
+                    transactionState = TransactionState.PENDING,
+                    statusMessage = "Transaction submitted. Waiting for confirmation..."
+                )
+            }
+            startPollingTransactionStatus(txHash, capturedAddress)
+        } catch (e: Exception) {
+            Log.e(TAG, "V2 send failed", e)
+            _uiState.update {
+                it.copy(
+                    isLoading = false,
+                    error = parseErrorMessage(e),
+                    transactionState = TransactionState.FAILED,
+                    statusMessage = "Transaction failed"
+                )
+            }
+        }
     }
 
     fun executeSend() {

--- a/android/app/src/test/java/com/rjnr/pocketnode/data/migration/KeyStoreMigrationHelperTest.kt
+++ b/android/app/src/test/java/com/rjnr/pocketnode/data/migration/KeyStoreMigrationHelperTest.kt
@@ -101,4 +101,53 @@ class KeyStoreMigrationHelperTest {
         val result = helper.readDecryptedKey("nonexistent")
         assertNull(result)
     }
+
+    @Test
+    fun `readDecryptedKey throws on V2 row when no cipher supplied`() = runTest {
+        // Seed a V1 row, then migrate it to V2 via the V2 helper. After
+        // migration the V1 readDecryptedKey overload must refuse with
+        // V2KeyMaterialRequiresAuthException rather than silently returning
+        // garbage from the V1 cipher applied to a V2 ciphertext.
+        helper.migrateWallet("alpha", "aa".repeat(32), "alpha mnemonic", "mnemonic", false)
+        val v2Helper = KeystoreV2MigrationHelper(keyMaterialDao, encryptionManager, migrationPrefs)
+        v2Helper.migrateWallet("alpha", encryptionManager.newEncryptCipherV2()).getOrThrow()
+
+        try {
+            helper.readDecryptedKey("alpha")
+            fail("Expected V2KeyMaterialRequiresAuthException")
+        } catch (e: V2KeyMaterialRequiresAuthException) {
+            assertTrue(e.message?.contains("alpha") == true)
+        }
+    }
+
+    @Test
+    fun `readDecryptedKey with cipher returns V2 bundle data`() = runTest {
+        helper.migrateWallet("beta", "bb".repeat(32), "beta mnemonic", "mnemonic", true)
+        val v2Helper = KeystoreV2MigrationHelper(keyMaterialDao, encryptionManager, migrationPrefs)
+        v2Helper.migrateWallet("beta", encryptionManager.newEncryptCipherV2()).getOrThrow()
+
+        val entity = keyMaterialDao.getByWalletId("beta")!!
+        val decryptCipher = encryptionManager.newDecryptCipherV2(entity.iv)
+
+        val result = helper.readDecryptedKey("beta", decryptCipher)
+        assertNotNull(result)
+        assertEquals("bb".repeat(32), result!!.privateKeyHex)
+        assertEquals("beta mnemonic", result.mnemonic)
+        assertEquals("mnemonic", result.walletType)
+        assertTrue(result.mnemonicBackedUp)
+    }
+
+    @Test
+    fun `readDecryptedKey with cipher still reads V1 rows`() = runTest {
+        // A caller that doesn't know which kdf the wallet is on can pass a
+        // V2 cipher unconditionally during migration. V1 rows fall through
+        // to the V1 path; the supplied cipher is unused but not an error.
+        helper.migrateWallet("gamma", "cc".repeat(32), null, "raw_key", false)
+        val v2Cipher = encryptionManager.newDecryptCipherV2(ByteArray(12))
+
+        val result = helper.readDecryptedKey("gamma", v2Cipher)
+        assertNotNull(result)
+        assertEquals("cc".repeat(32), result!!.privateKeyHex)
+        assertNull(result.mnemonic)
+    }
 }


### PR DESCRIPTION
## Summary

Fourth of five sub-PRs for [#213](https://github.com/RaheemJnr/pocket-node/issues/213). Adds the activity-side plumbing needed to read V2 (auth-bound) keys, and wires the Send flow to use it. The V2 migration is **still not invoked from app code** — sub-PR 5 will turn it on once mnemonic backup, sub-account derivation, DAO ops, and security settings export are also V2-aware.

### Infrastructure

- \`AuthManager.authenticateForCipher\` — suspend BiometricPrompt + CryptoObject helper. Returns \`Success\`/\`Cancelled\`/\`Error\` sealed type.
- \`KeyStoreMigrationHelper.readDecryptedKey\` branches on \`kdfVersion\`. V1 path unchanged; V2 without a cipher throws \`V2KeyMaterialRequiresAuthException\` so non-wired callers fail loudly.
- \`KeystoreV2MigrationRunner\` — first-launch migration orchestrator. Idempotent + resumable. Wired into DI but **not yet invoked**.
- \`WalletKeyReader\` — the one activity-aware bridge between data layer and UI. Peeks \`kdfVersion\` → V1 returns silently, V2 drives the CryptoObject prompt.

### Send flow

- \`SendViewModel.sendTransaction(activity)\` — V2-aware overload. Active wallet on V2 → routes through \`WalletKeyReader\`. V1 → existing flow unchanged.
- Legacy no-arg \`sendTransaction()\` retained for tests and refuses V2 wallets with an instructive error.

## Test plan

- [x] \`./gradlew :app:testDebugUnitTest\` → 581/581 pass (3 new in \`KeyStoreMigrationHelperTest\`)
- [x] V2 row without cipher throws \`V2KeyMaterialRequiresAuthException\`
- [x] V2 row with authenticated cipher returns correct bundle
- [x] V1 row still readable via V2 overload (cipher ignored)
- [x] App compiles and existing Send tests unchanged behavior

Refs #213, #187 Finding High 1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added biometric authentication for wallet key access during transactions
  * Introduced automatic wallet key security enhancement and migration
  * Updated Send transaction flow to support biometric authentication for secured wallets
  * Enabled version-aware key reading with multiple decryption paths

* **Tests**
  * Added tests for key decryption and migration behavior

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/RaheemJnr/pocket-node/pull/228?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->