### PR TITLE
feat(crypto): wire V2 migration end-to-end (#213 sub-PR 5/5)

### DIFF
--- a/android/app/src/main/java/com/rjnr/pocketnode/data/gateway/GatewayRepository.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/gateway/GatewayRepository.kt
@@ -311,9 +311,10 @@ class GatewayRepository @Inject constructor(
     suspend fun onActiveWalletChanged(wallet: WalletEntity) {
         activeWalletId = wallet.walletId
         activeWalletType = wallet.type
-        val privateKey = keyManager.getPrivateKeyForWallet(wallet.walletId)
-            ?: throw Exception("No key for wallet ${wallet.walletId}")
-        val info = keyManager.deriveWalletInfo(privateKey)
+        // Address-only derivation: avoids a BiometricPrompt for V2 wallets
+        // on every wallet switch. Lock script + addresses round-trip from
+        // the cached WalletEntity, no key material needed (#213 sub-PR 5).
+        val info = keyManager.deriveWalletInfoFromEntity(wallet)
         _walletInfo.value = info
         _balance.value = null  // Clear old wallet's balance immediately
         _isRegistered.value = false
@@ -587,16 +588,16 @@ class GatewayRepository @Inject constructor(
      */
     suspend fun initializeWallet(): Result<WalletInfo> = runCatching {
         if (keyManager.hasWallet()) {
-            // Use wallet-scoped keys for the active wallet, not global legacy prefs
+            // Use wallet-scoped addresses for the active wallet, not global legacy prefs.
+            // Address-only derivation here (no key read) so V2 wallets boot without a
+            // BiometricPrompt — the sign path will prompt when actually needed (#213).
             val info = if (activeWalletId.isNotEmpty()) {
-                val privateKey = keyManager.getPrivateKeyForWallet(activeWalletId)
-                    ?: throw Exception("No key for active wallet $activeWalletId")
-                // Set activeWalletType from Room entity
                 val activeWallet = walletDao.getActive()
-                activeWalletType = activeWallet?.type ?: KeyManager.WALLET_TYPE_MNEMONIC
-                keyManager.deriveWalletInfo(privateKey)
+                    ?: throw Exception("No key for active wallet $activeWalletId")
+                activeWalletType = activeWallet.type
+                keyManager.deriveWalletInfoFromEntity(activeWallet)
             } else {
-                keyManager.getWalletInfo() // fallback for legacy single-wallet
+                keyManager.getWalletInfo() // fallback for legacy single-wallet (V1 only)
             }
             _walletInfo.value = info
             info
@@ -2100,7 +2101,19 @@ class GatewayRepository @Inject constructor(
         )
     }
 
-    suspend fun depositToDao(amountShannons: Long): Result<String> = runCatching {
+    suspend fun depositToDao(amountShannons: Long): Result<String> =
+        depositToDao(amountShannons, privateKey = getPrivateKey())
+
+    /**
+     * V2-aware overload: caller supplies the private key already
+     * unlocked via BiometricPrompt CryptoObject. Used by [DaoViewModel]
+     * when the active wallet is on `kdfVersion=2` and requires explicit
+     * user authentication per signing operation (#213 sub-PR 5).
+     */
+    suspend fun depositToDao(
+        amountShannons: Long,
+        privateKey: ByteArray,
+    ): Result<String> = runCatching {
         val info = _walletInfo.value ?: throw Exception("No wallet")
         val net = _network.value
 
@@ -2109,7 +2122,6 @@ class GatewayRepository @Inject constructor(
         }
 
         val cellsResponse = getCells().getOrThrow()
-        val privateKey = getPrivateKey()
 
         val tx = transactionBuilder.buildDaoDeposit(
             amountShannons = amountShannons,
@@ -2128,7 +2140,14 @@ class GatewayRepository @Inject constructor(
         txHash
     }
 
-    suspend fun withdrawFromDao(depositOutPoint: OutPoint): Result<String> = runCatching {
+    suspend fun withdrawFromDao(depositOutPoint: OutPoint): Result<String> =
+        withdrawFromDao(depositOutPoint, privateKey = getPrivateKey())
+
+    /** V2-aware overload — see [depositToDao]. */
+    suspend fun withdrawFromDao(
+        depositOutPoint: OutPoint,
+        privateKey: ByteArray,
+    ): Result<String> = runCatching {
         val info = _walletInfo.value ?: throw Exception("No wallet")
         val net = _network.value
         val address = getCurrentAddress() ?: throw Exception("No address")
@@ -2137,8 +2156,6 @@ class GatewayRepository @Inject constructor(
         val deposits = getDaoDeposits().getOrThrow()
         val deposit = deposits.find { it.outPoint == depositOutPoint }
             ?: throw Exception("Deposit not found")
-
-        val privateKey = getPrivateKey()
 
         require(deposit.depositBlockHash.isNotBlank()) {
             "Deposit block hash unavailable. Please retry after sync."
@@ -2175,8 +2192,13 @@ class GatewayRepository @Inject constructor(
         txHash
     }
 
+    suspend fun unlockDao(withdrawingOutPoint: OutPoint): Result<String> =
+        unlockDao(withdrawingOutPoint, privateKey = getPrivateKey())
+
+    /** V2-aware overload — see [depositToDao]. */
     suspend fun unlockDao(
-        withdrawingOutPoint: OutPoint
+        withdrawingOutPoint: OutPoint,
+        privateKey: ByteArray,
     ): Result<String> = runCatching {
         val info = _walletInfo.value ?: throw Exception("No wallet")
         val net = _network.value
@@ -2196,8 +2218,6 @@ class GatewayRepository @Inject constructor(
         }
         val withdrawBlockHash = deposit.withdrawBlockHash
             ?: throw Exception("Withdraw block hash unavailable. Please retry after sync.")
-
-        val privateKey = getPrivateKey()
 
         // Get headers for max withdraw calculation (cache-first)
         val depositHeader = getOrFetchHeader(depositBlockHash)
@@ -2409,18 +2429,22 @@ class GatewayRepository @Inject constructor(
             tip.number.removePrefix("0x").toLong(16)
         } else 0L
 
-        // Per-wallet derivation is independent CPU+IO work (Room read for the
-        // private key, blake2b hash for the lock script). Run them concurrently
-        // so a 5-wallet ALL_WALLETS sync doesn't pay the cost serially.
+        // Per-wallet lock-script recovery. Previously read the private key
+        // to hash → pubkey hash → lock args, which now requires a
+        // BiometricPrompt for V2 wallets. The cached WalletEntity already
+        // has the address, which round-trips to the exact same Script via
+        // AddressUtils.decode (#213 sub-PR 5). No key access needed.
         val pairs = coroutineScope {
             wallets.map { wallet ->
                 async(Dispatchers.IO) {
-                    val privateKey = keyManager.getPrivateKeyForWallet(wallet.walletId) ?: run {
-                        Log.w(TAG, "No key for wallet ${wallet.walletId}, skipping script registration")
+                    val lockScript = try {
+                        keyManager.deriveLockScriptFromAddress(
+                            wallet.testnetAddress.ifBlank { wallet.mainnetAddress }
+                        )
+                    } catch (e: Exception) {
+                        Log.w(TAG, "Cannot decode address for wallet ${wallet.walletId}, skipping", e)
                         return@async null
                     }
-                    val publicKey = keyManager.derivePublicKey(privateKey)
-                    val lockScript = keyManager.deriveLockScript(publicKey)
 
                     // Resume from saved per-wallet progress, or calculate from sync mode if first sync
                     val savedBlock = getWalletSyncBlock(wallet.walletId)

--- a/android/app/src/main/java/com/rjnr/pocketnode/data/wallet/KeyManager.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/wallet/KeyManager.kt
@@ -328,6 +328,42 @@ class KeyManager @Inject constructor(
         )
     }
 
+    /**
+     * Recover a wallet's lock script from a cached CKB address without
+     * touching key material. Used by init/sync paths that previously read
+     * the private key just to compute the lock args (those reads would
+     * now require a BiometricPrompt for V2 wallets and crash app startup).
+     *
+     * The bech32 address encodes the same args+codeHash+hashType triple
+     * that [deriveLockScript] would produce, so the round-trip is exact.
+     */
+    fun deriveLockScriptFromAddress(address: String): Script {
+        return AddressUtils.decode(address)
+    }
+
+    /**
+     * Derive [WalletInfo] from a Room [com.rjnr.pocketnode.data.database.entity.WalletEntity]'s
+     * cached addresses. No key access required — safe to call for V2
+     * wallets during app boot, wallet switch, and multi-wallet sync setup.
+     *
+     * `publicKey` is returned as an empty string because the address-only
+     * path cannot recover the SECP256K1 public key. Callers that need the
+     * raw public key (currently none — see #213 sub-PR 5 audit) must
+     * obtain the private key explicitly via [WalletKeyReader].
+     */
+    fun deriveWalletInfoFromEntity(
+        wallet: com.rjnr.pocketnode.data.database.entity.WalletEntity
+    ): WalletInfo {
+        val address = wallet.testnetAddress.ifBlank { wallet.mainnetAddress }
+        val script = deriveLockScriptFromAddress(address)
+        return WalletInfo(
+            publicKey = "",
+            script = script,
+            testnetAddress = wallet.testnetAddress,
+            mainnetAddress = wallet.mainnetAddress,
+        )
+    }
+
     suspend fun sign(message: ByteArray): ByteArray {
         val keyPair = getKeyPair()
         val signatureData = Sign.signMessage(message, keyPair)

--- a/android/app/src/main/java/com/rjnr/pocketnode/data/wallet/WalletKeyReader.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/wallet/WalletKeyReader.kt
@@ -50,6 +50,18 @@ class WalletKeyReader @Inject constructor(
         data class NotAvailable(val reason: String) : Result()
     }
 
+    sealed class MaterialResult {
+        data class Success(
+            val privateKey: ByteArray,
+            val mnemonic: String?,
+            val walletType: String,
+            val mnemonicBackedUp: Boolean,
+        ) : MaterialResult()
+        object Cancelled : MaterialResult()
+        data class AuthError(val errorCode: Int, val message: CharSequence) : MaterialResult()
+        data class NotAvailable(val reason: String) : MaterialResult()
+    }
+
     /**
      * Read the private key for [walletId]. Picks the V1 or V2 code path
      * based on the row's `kdfVersion`. V2 prompts the user via
@@ -73,6 +85,78 @@ class WalletKeyReader @Inject constructor(
             1 -> readV1(walletId)
             2 -> readV2(activity, walletId, promptTitle, promptSubtitle)
             else -> Result.NotAvailable("unknown kdfVersion=$kdfVersion")
+        }
+    }
+
+    /**
+     * Like [readPrivateKey] but returns the full key material bundle —
+     * private key, mnemonic, walletType, mnemonicBackedUp — in a single
+     * V2 cipher operation. Used by call sites that need both pieces (e.g.
+     * the seed-phrase reveal screen, or sub-account derivation that needs
+     * the parent's mnemonic).
+     *
+     * V2 cost: exactly one BiometricPrompt regardless of how much of the
+     * bundle the caller uses. V1 cost: silent, same as [readPrivateKey].
+     */
+    suspend fun readKeyMaterial(
+        activity: FragmentActivity,
+        walletId: String,
+        promptTitle: String,
+        promptSubtitle: String,
+    ): MaterialResult {
+        val kdfVersion = keyMaterialDao.getKdfVersion(walletId)
+            ?: return MaterialResult.NotAvailable("no key_material row for $walletId")
+        return when (kdfVersion) {
+            1 -> readMaterialV1(walletId)
+            2 -> readMaterialV2(activity, walletId, promptTitle, promptSubtitle)
+            else -> MaterialResult.NotAvailable("unknown kdfVersion=$kdfVersion")
+        }
+    }
+
+    private suspend fun readMaterialV1(walletId: String): MaterialResult {
+        val data = keyStoreMigrationHelper.readDecryptedKey(walletId)
+            ?: return MaterialResult.NotAvailable("V1 decrypt failed for $walletId")
+        return MaterialResult.Success(
+            privateKey = Numeric.hexStringToByteArray(data.privateKeyHex),
+            mnemonic = data.mnemonic,
+            walletType = data.walletType,
+            mnemonicBackedUp = data.mnemonicBackedUp,
+        )
+    }
+
+    private suspend fun readMaterialV2(
+        activity: FragmentActivity,
+        walletId: String,
+        promptTitle: String,
+        promptSubtitle: String,
+    ): MaterialResult {
+        val entity = keyMaterialDao.getByWalletId(walletId)
+            ?: return MaterialResult.NotAvailable("no key_material row for $walletId")
+        val cipher = encryptionManager.newDecryptCipherV2(entity.iv)
+        val authResult = authManager.authenticateForCipher(
+            activity = activity,
+            cipher = cipher,
+            title = promptTitle,
+            subtitle = promptSubtitle,
+        )
+        return when (authResult) {
+            is AuthManager.CipherAuthResult.Cancelled -> MaterialResult.Cancelled
+            is AuthManager.CipherAuthResult.Error ->
+                MaterialResult.AuthError(authResult.errorCode, authResult.errString)
+            is AuthManager.CipherAuthResult.Success -> {
+                val data = try {
+                    keyStoreMigrationHelper.readDecryptedKey(walletId, authResult.cipher)
+                } catch (e: Exception) {
+                    Log.e(TAG, "V2 material decrypt failed for $walletId", e)
+                    null
+                } ?: return MaterialResult.NotAvailable("V2 decrypt failed for $walletId")
+                MaterialResult.Success(
+                    privateKey = Numeric.hexStringToByteArray(data.privateKeyHex),
+                    mnemonic = data.mnemonic,
+                    walletType = data.walletType,
+                    mnemonicBackedUp = data.mnemonicBackedUp,
+                )
+            }
         }
     }
 

--- a/android/app/src/main/java/com/rjnr/pocketnode/data/wallet/WalletRepository.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/wallet/WalletRepository.kt
@@ -222,15 +222,26 @@ class WalletRepository @Inject constructor(
     /**
      * Create a sub-account derived from a parent mnemonic wallet.
      * Derives a new key at the next account index from the parent's mnemonic.
+     *
+     * If [parentMnemonicOverride] is provided, the parent's mnemonic is
+     * not read from key storage — useful when the caller has already
+     * unlocked it via BiometricPrompt (V2 wallets). When null, the parent
+     * mnemonic is read silently from V1 storage, which will throw for V2
+     * parents (#213 sub-PR 5).
      */
-    suspend fun createSubAccount(parentWalletId: String, name: String): WalletEntity {
+    suspend fun createSubAccount(
+        parentWalletId: String,
+        name: String,
+        parentMnemonicOverride: List<String>? = null,
+    ): WalletEntity {
         val parent = walletDao.getById(parentWalletId)
             ?: throw IllegalArgumentException("Parent wallet not found")
         require(parent.type == KeyManager.WALLET_TYPE_MNEMONIC) {
             "Sub-accounts require a mnemonic wallet"
         }
 
-        val parentMnemonic = keyManager.getMnemonicForWallet(parentWalletId)
+        val parentMnemonic = parentMnemonicOverride
+            ?: keyManager.getMnemonicForWallet(parentWalletId)
             ?: throw IllegalStateException("Parent mnemonic not found")
 
         // Use max existing sub-account index + 1 to avoid index collisions after deletions

--- a/android/app/src/main/java/com/rjnr/pocketnode/di/AppModule.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/di/AppModule.kt
@@ -175,6 +175,17 @@ object AppModule {
 
     @Provides
     @Singleton
+    fun provideKeystoreV2MigrationHelper(
+        keyMaterialDao: KeyMaterialDao,
+        encryptionManager: KeystoreEncryptionManager,
+        @Named("migrationPrefs") migrationPrefs: SharedPreferences
+    ): com.rjnr.pocketnode.data.migration.KeystoreV2MigrationHelper =
+        com.rjnr.pocketnode.data.migration.KeystoreV2MigrationHelper(
+            keyMaterialDao, encryptionManager, migrationPrefs
+        )
+
+    @Provides
+    @Singleton
     fun provideCacheManager(
         transactionDao: TransactionDao,
         balanceCacheDao: BalanceCacheDao

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/auth/AuthScreen.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/auth/AuthScreen.kt
@@ -77,7 +77,19 @@ fun AuthScreen(
     }
 
     LaunchedEffect(uiState.authSuccess) {
-        if (uiState.authSuccess) onAuthSuccess()
+        if (uiState.authSuccess) {
+            // Run the V2 migration (one BiometricPrompt per V1 wallet)
+            // before letting the user past the unlock screen (#213 sub-PR 5).
+            // The user is already in an "authenticating" mindset, which is
+            // the least jarring time to ask for more prompts. No-op for
+            // fresh installs / V2-already-complete states.
+            val activity = context as? FragmentActivity
+            if (activity != null) {
+                viewModel.runMigrationIfNeeded(activity) { onAuthSuccess() }
+            } else {
+                onAuthSuccess()
+            }
+        }
     }
 
     LaunchedEffect(uiState.error) {

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/auth/AuthViewModel.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/auth/AuthViewModel.kt
@@ -1,26 +1,36 @@
 package com.rjnr.pocketnode.ui.screens.auth
 
+import android.util.Log
+import androidx.fragment.app.FragmentActivity
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
 import com.rjnr.pocketnode.data.auth.AuthManager
 import com.rjnr.pocketnode.data.auth.PinManager
+import com.rjnr.pocketnode.data.migration.KeystoreV2MigrationHelper
+import com.rjnr.pocketnode.data.migration.KeystoreV2MigrationRunner
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 data class AuthUiState(
     val showBiometricButton: Boolean = false,
     val showPinFallback: Boolean = true,
     val authSuccess: Boolean = false,
-    val error: String? = null
+    val error: String? = null,
+    /** True while the V2 wallet migration is running per-wallet prompts. */
+    val isMigrating: Boolean = false,
 )
 
 @HiltViewModel
 class AuthViewModel @Inject constructor(
     private val authManager: AuthManager,
-    private val pinManager: PinManager
+    private val pinManager: PinManager,
+    private val migrationRunner: KeystoreV2MigrationRunner,
+    private val migrationHelper: KeystoreV2MigrationHelper,
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow(AuthUiState())
@@ -48,5 +58,61 @@ class AuthViewModel @Inject constructor(
 
     fun clearError() {
         _uiState.update { it.copy(error = null) }
+    }
+
+    /**
+     * Runs the v1.6.x → v1.7.0 Keystore V2 migration if any V1 wallets are
+     * still pending. Called from [AuthScreen] right after the user finishes
+     * the unlock prompt — the user is already in an authentication mindset,
+     * which is the right moment to prompt for the per-wallet re-encrypt
+     * (#213 sub-PR 5).
+     *
+     * No-op when migration is already complete or no V1 wallets exist.
+     * Surfaces the runner's [KeystoreV2MigrationRunner.Outcome] so the UI
+     * can decide how to recover: a Cancelled outcome leaves the app
+     * usable on V1 wallets but with V2-only call sites still gated;
+     * subsequent app starts will re-prompt until the user completes.
+     */
+    fun runMigrationIfNeeded(activity: FragmentActivity, onComplete: () -> Unit) {
+        viewModelScope.launch {
+            if (migrationHelper.isMigrationComplete()) {
+                onComplete()
+                return@launch
+            }
+            val pending = migrationHelper.pendingWalletIds()
+            if (pending.isEmpty()) {
+                // Empty DB (fresh install on v1.7.0) — finalize to mark
+                // the migration complete so future starts don't re-check.
+                migrationHelper.finalize()
+                onComplete()
+                return@launch
+            }
+            _uiState.update { it.copy(isMigrating = true) }
+            try {
+                val outcome = migrationRunner.runMigration(activity)
+                when (outcome) {
+                    is KeystoreV2MigrationRunner.Outcome.Completed,
+                    is KeystoreV2MigrationRunner.Outcome.NothingToDo -> Unit
+                    is KeystoreV2MigrationRunner.Outcome.Cancelled -> {
+                        _uiState.update {
+                            it.copy(error = "Wallet security upgrade incomplete; you'll be prompted again next launch")
+                        }
+                    }
+                    is KeystoreV2MigrationRunner.Outcome.Failed -> {
+                        Log.e(TAG, "Migration failed: ${outcome.reason}")
+                        _uiState.update {
+                            it.copy(error = "Wallet security upgrade failed: ${outcome.reason}")
+                        }
+                    }
+                }
+            } finally {
+                _uiState.update { it.copy(isMigrating = false) }
+                onComplete()
+            }
+        }
+    }
+
+    companion object {
+        private const val TAG = "AuthViewModel"
     }
 }

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/dao/DaoScreen.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/dao/DaoScreen.kt
@@ -248,7 +248,13 @@ fun DaoScreen(
             currentApc = uiState.overview.currentApc,
             onDeposit = { amount ->
                 showDepositSheet = false
-                viewModel.deposit(amount)
+                // V2-aware: passing the host FragmentActivity lets the VM
+                // drive a BiometricPrompt CryptoObject for V2 wallets when
+                // signing the DAO deposit (#213 sub-PR 5). V1 wallets fall
+                // through the same path with no extra prompt.
+                val activity = context as? FragmentActivity
+                if (activity != null) viewModel.depositWithActivity(activity, amount)
+                else viewModel.deposit(amount)
             },
             onDismiss = { showDepositSheet = false }
         )
@@ -273,7 +279,9 @@ fun DaoScreen(
             },
             confirmButton = {
                 Button(onClick = {
-                    viewModel.withdraw(deposit)
+                    val activity = context as? FragmentActivity
+                    if (activity != null) viewModel.withdrawWithActivity(activity, deposit)
+                    else viewModel.withdraw(deposit)
                     withdrawTarget = null
                 }) {
                     Text("Withdraw")
@@ -303,7 +311,9 @@ fun DaoScreen(
             },
             confirmButton = {
                 Button(onClick = {
-                    viewModel.unlock(deposit)
+                    val activity = context as? FragmentActivity
+                    if (activity != null) viewModel.unlockWithActivity(activity, deposit)
+                    else viewModel.unlock(deposit)
                     unlockTarget = null
                 }) {
                     Text("Unlock")

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/dao/DaoViewModel.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/dao/DaoViewModel.kt
@@ -1,5 +1,6 @@
 package com.rjnr.pocketnode.ui.screens.dao
 
+import androidx.fragment.app.FragmentActivity
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.rjnr.pocketnode.data.auth.AuthManager
@@ -7,6 +8,8 @@ import com.rjnr.pocketnode.data.auth.AuthMethod
 import com.rjnr.pocketnode.data.auth.PinManager
 import com.rjnr.pocketnode.data.gateway.GatewayRepository
 import com.rjnr.pocketnode.data.gateway.models.*
+import com.rjnr.pocketnode.data.wallet.WalletKeyReader
+import com.rjnr.pocketnode.data.wallet.WalletRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -23,7 +26,9 @@ import javax.inject.Inject
 class DaoViewModel @Inject constructor(
     private val repository: GatewayRepository,
     private val authManager: AuthManager,
-    private val pinManager: PinManager
+    private val pinManager: PinManager,
+    private val walletKeyReader: WalletKeyReader,
+    private val walletRepository: WalletRepository,
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow(DaoUiState())
@@ -143,6 +148,27 @@ class DaoViewModel @Inject constructor(
         }
     }
 
+    /**
+     * V2-aware deposit entry point. Reads the active wallet's private
+     * key via [WalletKeyReader] (which drives a BiometricPrompt
+     * CryptoObject on V2 wallets, or returns silently for V1), then
+     * invokes the overload of [GatewayRepository.depositToDao] that
+     * accepts an explicit key — avoiding a second key read inside the
+     * repository (#213 sub-PR 5).
+     */
+    fun depositWithActivity(activity: FragmentActivity, amountShannons: Long) {
+        viewModelScope.launch {
+            executeDaoOperationWithActivity(
+                activity = activity,
+                pendingAction = DaoAction.Depositing(amountShannons),
+                promptTitle = "Authenticate to deposit",
+                promptSubtitle = "Verify your identity to lock CKB in Nervos DAO",
+            ) { privateKey ->
+                repository.depositToDao(amountShannons, privateKey)
+            }
+        }
+    }
+
     /** Clear auth UI state but keep pendingDepositAmount (for PIN navigation fallback). */
     fun dismissAuthPrompt() {
         _uiState.update { it.copy(requiresAuth = false, authMethod = null) }
@@ -166,6 +192,20 @@ class DaoViewModel @Inject constructor(
         }
     }
 
+    /** V2-aware withdraw entry point. See [depositWithActivity]. */
+    fun withdrawWithActivity(activity: FragmentActivity, deposit: DaoDeposit) {
+        viewModelScope.launch {
+            executeDaoOperationWithActivity(
+                activity = activity,
+                pendingAction = DaoAction.Withdrawing(deposit.outPoint),
+                promptTitle = "Authenticate to withdraw",
+                promptSubtitle = "Verify your identity to begin Nervos DAO withdrawal",
+            ) { privateKey ->
+                repository.withdrawFromDao(deposit.outPoint, privateKey)
+            }
+        }
+    }
+
     fun unlock(deposit: DaoDeposit) {
         _uiState.update { it.copy(pendingAction = DaoAction.Unlocking(deposit.outPoint)) }
         viewModelScope.launch {
@@ -174,6 +214,58 @@ class DaoViewModel @Inject constructor(
                     _uiState.update {
                         it.copy(error = e.message, pendingAction = null)
                     }
+                }
+        }
+    }
+
+    /** V2-aware unlock entry point. See [depositWithActivity]. */
+    fun unlockWithActivity(activity: FragmentActivity, deposit: DaoDeposit) {
+        viewModelScope.launch {
+            executeDaoOperationWithActivity(
+                activity = activity,
+                pendingAction = DaoAction.Unlocking(deposit.outPoint),
+                promptTitle = "Authenticate to unlock",
+                promptSubtitle = "Verify your identity to claim your CKB and DAO compensation",
+            ) { privateKey ->
+                repository.unlockDao(deposit.outPoint, privateKey)
+            }
+        }
+    }
+
+    private suspend inline fun executeDaoOperationWithActivity(
+        activity: FragmentActivity,
+        pendingAction: DaoAction,
+        promptTitle: String,
+        promptSubtitle: String,
+        crossinline operation: suspend (ByteArray) -> Result<String>,
+    ) {
+        val walletId = walletRepository.activeWalletIdSnapshot()
+        if (walletId.isNullOrEmpty()) {
+            _uiState.update { it.copy(error = "No active wallet", pendingAction = null) }
+            return
+        }
+        _uiState.update {
+            it.copy(requiresAuth = false, authMethod = null, pendingAction = pendingAction)
+        }
+        when (val read = walletKeyReader.readPrivateKey(
+            activity = activity,
+            walletId = walletId,
+            promptTitle = promptTitle,
+            promptSubtitle = promptSubtitle,
+        )) {
+            is WalletKeyReader.Result.Cancelled ->
+                _uiState.update { it.copy(pendingAction = null) }
+            is WalletKeyReader.Result.AuthError ->
+                _uiState.update {
+                    it.copy(error = "Authentication failed: ${read.message}", pendingAction = null)
+                }
+            is WalletKeyReader.Result.NotAvailable ->
+                _uiState.update {
+                    it.copy(error = "Cannot read wallet key: ${read.reason}", pendingAction = null)
+                }
+            is WalletKeyReader.Result.Success ->
+                operation(read.privateKey).onFailure { e ->
+                    _uiState.update { it.copy(error = e.message, pendingAction = null) }
                 }
         }
     }

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/settings/SecuritySettingsViewModel.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/settings/SecuritySettingsViewModel.kt
@@ -143,8 +143,26 @@ class SecuritySettingsViewModel @Inject constructor(
             try {
                 val wallets = walletDao.getAll()
                 for (wallet in wallets) {
-                    val privateKey = keyManager.getPrivateKeyForWallet(wallet.walletId) ?: continue
-                    val mnemonic = keyManager.getMnemonicForWallet(wallet.walletId)
+                    // V2 wallets require a BiometricPrompt per read. Skip
+                    // them silently here — the user will populate the
+                    // backup when they next reveal their recovery phrase
+                    // (which already prompts for biometric). Without this
+                    // skip, the loop would crash on the first V2 wallet
+                    // with V2KeyMaterialRequiresAuthException (#213 sub-PR 5).
+                    val privateKey = try {
+                        keyManager.getPrivateKeyForWallet(wallet.walletId) ?: continue
+                    } catch (e: Exception) {
+                        android.util.Log.i(
+                            "SecuritySettingsVM",
+                            "Skipping V2-protected wallet ${wallet.walletId} during PIN backup",
+                        )
+                        continue
+                    }
+                    val mnemonic = try {
+                        keyManager.getMnemonicForWallet(wallet.walletId)
+                    } catch (e: Exception) {
+                        null
+                    }
                     val material = KeyMaterial(
                         privateKey = privateKey.joinToString("") { "%02x".format(it) },
                         mnemonic = mnemonic?.joinToString(" "),

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/wallet/WalletSettingsScreen.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/wallet/WalletSettingsScreen.kt
@@ -65,8 +65,19 @@ fun WalletSettingsScreen(
     val uiState by viewModel.uiState.collectAsState()
     val snackbarHostState = remember { SnackbarHostState() }
     val clipboardManager = androidx.compose.ui.platform.LocalClipboardManager.current
+    val context = androidx.compose.ui.platform.LocalContext.current
     var showSeedPhrase by rememberSaveable { mutableStateOf(false) }
     var showAddAccountDialog by remember { mutableStateOf(false) }
+
+    // V2-aware: route the "view recovery phrase" / "view private key"
+    // taps through the activity-bound entry point so a CryptoObject
+    // BiometricPrompt fires for V2 wallets (#213 sub-PR 5). V1 wallets
+    // fall through to the silent loadSensitiveData() inside the VM.
+    fun unlockSensitive() {
+        val activity = context as? androidx.fragment.app.FragmentActivity
+        if (activity != null) viewModel.loadSensitiveData(activity)
+        else viewModel.loadSensitiveData()
+    }
 
     LaunchedEffect(uiState.deleted) {
         if (uiState.deleted) onNavigateBack()
@@ -135,7 +146,12 @@ fun WalletSettingsScreen(
                 Button(
                     onClick = {
                         if (accountName.isNotBlank()) {
-                            viewModel.addSubAccount(accountName.trim())
+                            val activity = context as? androidx.fragment.app.FragmentActivity
+                            if (activity != null) {
+                                viewModel.addSubAccount(activity, accountName.trim())
+                            } else {
+                                viewModel.addSubAccount(accountName.trim())
+                            }
                             showAddAccountDialog = false
                         }
                     },
@@ -323,7 +339,7 @@ fun WalletSettingsScreen(
                                     onNavigateToPinVerify()
                                 } else {
                                     showSeedPhrase = true
-                                    viewModel.loadSensitiveData()
+                                    unlockSensitive()
                                 }
                             }
                         )
@@ -411,7 +427,7 @@ fun WalletSettingsScreen(
                                     onNavigateToPinVerify()
                                 } else {
                                     showPrivateKey = true
-                                    viewModel.loadSensitiveData()
+                                    unlockSensitive()
                                 }
                             }
                         )

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/wallet/WalletSettingsViewModel.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/wallet/WalletSettingsViewModel.kt
@@ -1,15 +1,18 @@
 package com.rjnr.pocketnode.ui.screens.wallet
 
 import android.util.Log
+import androidx.fragment.app.FragmentActivity
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.rjnr.pocketnode.data.auth.PinManager
 import com.rjnr.pocketnode.data.database.dao.DaoCellDao
+import com.rjnr.pocketnode.data.database.dao.KeyMaterialDao
 import com.rjnr.pocketnode.data.database.dao.TransactionDao
 import com.rjnr.pocketnode.data.database.dao.WalletDao
 import com.rjnr.pocketnode.data.database.entity.WalletEntity
 import com.rjnr.pocketnode.data.wallet.KeyManager
+import com.rjnr.pocketnode.data.wallet.WalletKeyReader
 import com.rjnr.pocketnode.data.wallet.WalletPreferences
 import com.rjnr.pocketnode.data.wallet.WalletRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -32,7 +35,9 @@ class WalletSettingsViewModel @Inject constructor(
     private val pinManager: PinManager,
     private val daoCellDao: DaoCellDao,
     private val transactionDao: TransactionDao,
-    private val walletPreferences: WalletPreferences
+    private val walletPreferences: WalletPreferences,
+    private val walletKeyReader: WalletKeyReader,
+    private val keyMaterialDao: KeyMaterialDao,
 ) : ViewModel() {
 
     private val walletId: String = savedStateHandle["walletId"] ?: ""
@@ -198,11 +203,20 @@ class WalletSettingsViewModel @Inject constructor(
     fun getMnemonic(): List<String>? = _uiState.value.mnemonicWords
 
     /**
-     * Load private key and mnemonic from Room into UiState.
+     * Load private key and mnemonic from Room into UiState (V1 path).
      * Called when seed phrase is unlocked (PIN verified or no PIN required).
+     * For V2 wallets the activity-aware overload [loadSensitiveData(activity)]
+     * must be used — otherwise the V2 read throws and the seed phrase view
+     * shows blank fields (#213 sub-PR 5).
      */
     fun loadSensitiveData() {
         viewModelScope.launch {
+            if (keyMaterialDao.getKdfVersion(walletId) == 2) {
+                _uiState.update {
+                    it.copy(error = "Reopen this screen — biometric unlock required for V2 wallets")
+                }
+                return@launch
+            }
             try {
                 val keyHex = keyManager.getPrivateKeyForWallet(walletId)?.let { bytes ->
                     bytes.joinToString("") { "%02x".format(it) }
@@ -220,6 +234,45 @@ class WalletSettingsViewModel @Inject constructor(
         }
     }
 
+    /**
+     * V2-aware variant of [loadSensitiveData]. For V2 wallets, drives a
+     * BiometricPrompt CryptoObject via [WalletKeyReader] to decrypt the
+     * bundled key+mnemonic. For V1 wallets, falls back to the silent
+     * path so existing PIN-only flows keep working. The mnemonic is
+     * pulled from the same V2 bundle, so V2 reads cost exactly one prompt.
+     */
+    fun loadSensitiveData(activity: FragmentActivity) {
+        viewModelScope.launch {
+            val kdf = keyMaterialDao.getKdfVersion(walletId)
+            if (kdf != 2) {
+                loadSensitiveData()
+                return@launch
+            }
+            // V2 path: single BiometricPrompt CryptoObject unlocks the
+            // bundle that contains both the private key and the mnemonic.
+            // No second prompt needed for the mnemonic display.
+            when (val result = walletKeyReader.readKeyMaterial(
+                activity = activity,
+                walletId = walletId,
+                promptTitle = "View recovery phrase",
+                promptSubtitle = "Verify your identity to display this wallet's secrets",
+            )) {
+                is WalletKeyReader.MaterialResult.Cancelled,
+                is WalletKeyReader.MaterialResult.AuthError -> {
+                    _uiState.update { it.copy(error = "Authentication cancelled") }
+                }
+                is WalletKeyReader.MaterialResult.NotAvailable -> {
+                    _uiState.update { it.copy(error = "Cannot read wallet key: ${result.reason}") }
+                }
+                is WalletKeyReader.MaterialResult.Success -> {
+                    val keyHex = result.privateKey.joinToString("") { "%02x".format(it) }
+                    val words = result.mnemonic?.split(" ")
+                    _uiState.update { it.copy(privateKeyHex = keyHex, mnemonicWords = words) }
+                }
+            }
+        }
+    }
+
     // -- Sub-accounts --
 
     fun addSubAccount(name: String) {
@@ -229,6 +282,48 @@ class WalletSettingsViewModel @Inject constructor(
             } catch (e: Exception) {
                 Log.e(TAG, "Failed to create sub-account", e)
                 _uiState.update { it.copy(error = "Failed to create account: ${e.message}") }
+            }
+        }
+    }
+
+    /**
+     * V2-aware sub-account creation. For V2 parent wallets, reads the
+     * parent's mnemonic via [WalletKeyReader] (one BiometricPrompt
+     * CryptoObject), then passes it as `parentMnemonicOverride` to
+     * [WalletRepository.createSubAccount] so the repository doesn't
+     * attempt a second (silent, failing) read.
+     */
+    fun addSubAccount(activity: FragmentActivity, name: String) {
+        viewModelScope.launch {
+            val kdf = keyMaterialDao.getKdfVersion(walletId)
+            if (kdf != 2) {
+                addSubAccount(name)
+                return@launch
+            }
+            when (val result = walletKeyReader.readKeyMaterial(
+                activity = activity,
+                walletId = walletId,
+                promptTitle = "Authenticate to add account",
+                promptSubtitle = "Verify your identity to derive a new sub-account",
+            )) {
+                is WalletKeyReader.MaterialResult.Cancelled,
+                is WalletKeyReader.MaterialResult.AuthError ->
+                    _uiState.update { it.copy(error = "Authentication cancelled") }
+                is WalletKeyReader.MaterialResult.NotAvailable ->
+                    _uiState.update { it.copy(error = "Cannot read parent wallet: ${result.reason}") }
+                is WalletKeyReader.MaterialResult.Success -> {
+                    val words = result.mnemonic?.split(" ")
+                    if (words.isNullOrEmpty()) {
+                        _uiState.update { it.copy(error = "Parent wallet has no mnemonic") }
+                        return@launch
+                    }
+                    try {
+                        walletRepository.createSubAccount(walletId, name, parentMnemonicOverride = words)
+                    } catch (e: Exception) {
+                        Log.e(TAG, "Failed to create V2 sub-account", e)
+                        _uiState.update { it.copy(error = "Failed to create account: ${e.message}") }
+                    }
+                }
             }
         }
     }

--- a/android/app/src/test/java/com/rjnr/pocketnode/ui/screens/dao/DaoViewModelTest.kt
+++ b/android/app/src/test/java/com/rjnr/pocketnode/ui/screens/dao/DaoViewModelTest.kt
@@ -5,6 +5,8 @@ import com.rjnr.pocketnode.data.auth.PinManager
 import com.rjnr.pocketnode.data.gateway.GatewayRepository
 import com.rjnr.pocketnode.data.gateway.models.*
 import com.rjnr.pocketnode.data.wallet.WalletInfo
+import com.rjnr.pocketnode.data.wallet.WalletKeyReader
+import com.rjnr.pocketnode.data.wallet.WalletRepository
 import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.mockk
@@ -26,6 +28,8 @@ class DaoViewModelTest {
     private lateinit var repository: GatewayRepository
     private lateinit var authManager: AuthManager
     private lateinit var pinManager: PinManager
+    private lateinit var walletKeyReader: WalletKeyReader
+    private lateinit var walletRepository: WalletRepository
 
     private val testOutPoint = OutPoint("0x" + "ab".repeat(32), "0x0")
     private val otherOutPoint = OutPoint("0x" + "cd".repeat(32), "0x0")
@@ -58,6 +62,8 @@ class DaoViewModelTest {
         pinManager = mockk(relaxed = true) {
             every { hasPin() } returns false
         }
+        walletKeyReader = mockk(relaxed = true)
+        walletRepository = mockk(relaxed = true)
     }
 
     @After
@@ -69,14 +75,14 @@ class DaoViewModelTest {
 
     @Test
     fun `selectTab changes tab to COMPLETED`() {
-        val vm = DaoViewModel(repository, authManager, pinManager)
+        val vm = DaoViewModel(repository, authManager, pinManager, walletKeyReader, walletRepository)
         vm.selectTab(DaoTab.COMPLETED)
         assertEquals(DaoTab.COMPLETED, vm.uiState.value.selectedTab)
     }
 
     @Test
     fun `selectTab changes tab back to ACTIVE`() {
-        val vm = DaoViewModel(repository, authManager, pinManager)
+        val vm = DaoViewModel(repository, authManager, pinManager, walletKeyReader, walletRepository)
         vm.selectTab(DaoTab.COMPLETED)
         vm.selectTab(DaoTab.ACTIVE)
         assertEquals(DaoTab.ACTIVE, vm.uiState.value.selectedTab)
@@ -84,14 +90,14 @@ class DaoViewModelTest {
 
     @Test
     fun `clearError sets error to null`() {
-        val vm = DaoViewModel(repository, authManager, pinManager)
+        val vm = DaoViewModel(repository, authManager, pinManager, walletKeyReader, walletRepository)
         vm.clearError()
         assertNull(vm.uiState.value.error)
     }
 
     @Test
     fun `deposit sets pending action to Depositing`() {
-        val vm = DaoViewModel(repository, authManager, pinManager)
+        val vm = DaoViewModel(repository, authManager, pinManager, walletKeyReader, walletRepository)
         val amount = 10_200_000_000L
         vm.deposit(amount)
         assertEquals(DaoAction.Depositing(amount), vm.uiState.value.pendingAction)
@@ -99,7 +105,7 @@ class DaoViewModelTest {
 
     @Test
     fun `withdraw sets pending action to Withdrawing`() {
-        val vm = DaoViewModel(repository, authManager, pinManager)
+        val vm = DaoViewModel(repository, authManager, pinManager, walletKeyReader, walletRepository)
         val deposit = makeDaoDeposit()
         vm.withdraw(deposit)
         assertEquals(DaoAction.Withdrawing(deposit.outPoint), vm.uiState.value.pendingAction)
@@ -107,7 +113,7 @@ class DaoViewModelTest {
 
     @Test
     fun `unlock sets pending action to Unlocking`() {
-        val vm = DaoViewModel(repository, authManager, pinManager)
+        val vm = DaoViewModel(repository, authManager, pinManager, walletKeyReader, walletRepository)
         val deposit = makeDaoDeposit()
         vm.unlock(deposit)
         assertEquals(DaoAction.Unlocking(deposit.outPoint), vm.uiState.value.pendingAction)


### PR DESCRIPTION
## Summary

Fifth and final sub-PR for [#213](https://github.com/RaheemJnr/pocket-node/issues/213). Turns the audit Finding High 1 fix on: the V2 migration is now triggered automatically post-unlock, every key-reading call site is V2-aware, and address-only derivation paths boot V2 wallets without prompting.

### Silent-read paths now key-free

\`onActiveWalletChanged\`, \`initializeWallet\`, ALL_WALLETS sync setup, and \`KeyManager.deriveWalletInfoFromEntity\` reverse the bech32 address into a Script. No private key read for wallet boot or address derivation.

### Sign / mnemonic paths gated via WalletKeyReader

- DaoViewModel: \`depositWithActivity\` / \`withdrawWithActivity\` / \`unlockWithActivity\` plus new repo overloads
- WalletSettingsViewModel: \`loadSensitiveData(activity)\` uses new \`readKeyMaterial\` bundle reader
- WalletRepository: \`createSubAccount(..., parentMnemonicOverride)\`
- SecuritySettings: PIN-creation backup loop skips V2 wallets gracefully

### Migration trigger

\`AuthScreen\` → \`AuthViewModel.runMigrationIfNeeded(activity)\` → \`KeystoreV2MigrationRunner\` between auth-success and onAuthSuccess. One prompt per pending wallet, then finalize + delete V1 Keystore key.

## Test plan

- [x] \`./gradlew :app:testDebugUnitTest\` → 581/581 pass
- [x] V1 wallets unchanged (no extra prompts during boot, send, DAO)
- [x] V2 wallets: address-only boot, CryptoObject prompt only when signing or revealing secrets

Sub-PR 6 will cover edge cases (KeyPermanentlyInvalidatedException recovery, no-credential device handling, enrollment warning modal).

Refs #213, #187 Finding High 1