### PR TITLE
feat(crypto): V2 edge cases — invalidated key + no-credential + enrollment warning (#213 sub-PR 6/6)

### DIFF
--- a/android/app/src/main/java/com/rjnr/pocketnode/data/wallet/WalletKeyReader.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/wallet/WalletKeyReader.kt
@@ -1,5 +1,6 @@
 package com.rjnr.pocketnode.data.wallet
 
+import android.security.keystore.KeyPermanentlyInvalidatedException
 import android.util.Log
 import androidx.fragment.app.FragmentActivity
 import com.rjnr.pocketnode.data.auth.AuthManager
@@ -48,6 +49,13 @@ class WalletKeyReader @Inject constructor(
         data class AuthError(val errorCode: Int, val message: CharSequence) : Result()
         /** Wallet row missing, decrypt failed, or unknown kdfVersion. */
         data class NotAvailable(val reason: String) : Result()
+        /**
+         * The V2 Keystore key has been invalidated because the user changed
+         * biometric enrollment (added/removed a fingerprint or face).
+         * Recovery requires re-importing the wallet from the recovery
+         * phrase — the encrypted bundle on disk is unrecoverable.
+         */
+        object KeyInvalidated : Result()
     }
 
     sealed class MaterialResult {
@@ -60,6 +68,7 @@ class WalletKeyReader @Inject constructor(
         object Cancelled : MaterialResult()
         data class AuthError(val errorCode: Int, val message: CharSequence) : MaterialResult()
         data class NotAvailable(val reason: String) : MaterialResult()
+        object KeyInvalidated : MaterialResult()
     }
 
     /**
@@ -132,7 +141,12 @@ class WalletKeyReader @Inject constructor(
     ): MaterialResult {
         val entity = keyMaterialDao.getByWalletId(walletId)
             ?: return MaterialResult.NotAvailable("no key_material row for $walletId")
-        val cipher = encryptionManager.newDecryptCipherV2(entity.iv)
+        val cipher = try {
+            encryptionManager.newDecryptCipherV2(entity.iv)
+        } catch (e: KeyPermanentlyInvalidatedException) {
+            Log.w(TAG, "V2 key invalidated by biometric enrollment change for $walletId")
+            return MaterialResult.KeyInvalidated
+        }
         val authResult = authManager.authenticateForCipher(
             activity = activity,
             cipher = cipher,
@@ -174,7 +188,16 @@ class WalletKeyReader @Inject constructor(
     ): Result {
         val entity = keyMaterialDao.getByWalletId(walletId)
             ?: return Result.NotAvailable("no key_material row for $walletId")
-        val cipher = encryptionManager.newDecryptCipherV2(entity.iv)
+        val cipher = try {
+            encryptionManager.newDecryptCipherV2(entity.iv)
+        } catch (e: KeyPermanentlyInvalidatedException) {
+            // User changed biometric enrollment — the V2 key was wiped by
+            // Keystore (setInvalidatedByBiometricEnrollment=true). The
+            // ciphertext on disk is unrecoverable; caller must surface a
+            // re-import flow to the user.
+            Log.w(TAG, "V2 key invalidated by biometric enrollment change for $walletId")
+            return Result.KeyInvalidated
+        }
         val authResult = authManager.authenticateForCipher(
             activity = activity,
             cipher = cipher,

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/dao/DaoViewModel.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/dao/DaoViewModel.kt
@@ -263,6 +263,13 @@ class DaoViewModel @Inject constructor(
                 _uiState.update {
                     it.copy(error = "Cannot read wallet key: ${read.reason}", pendingAction = null)
                 }
+            is WalletKeyReader.Result.KeyInvalidated ->
+                _uiState.update {
+                    it.copy(
+                        error = "Biometric enrollment changed — re-import this wallet from its recovery phrase to continue",
+                        pendingAction = null,
+                    )
+                }
             is WalletKeyReader.Result.Success ->
                 operation(read.privateKey).onFailure { e ->
                     _uiState.update { it.copy(error = e.message, pendingAction = null) }

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/onboarding/OnboardingViewModel.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/onboarding/OnboardingViewModel.kt
@@ -3,6 +3,7 @@ package com.rjnr.pocketnode.ui.screens.onboarding
 import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.rjnr.pocketnode.data.auth.AuthManager
 import com.rjnr.pocketnode.data.gateway.GatewayRepository
 import com.rjnr.pocketnode.data.wallet.WalletRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -19,30 +20,61 @@ data class OnboardingUiState(
     val isLoading: Boolean = false,
     val error: String? = null,
     val isWalletCreated: Boolean = false,
-    val wasCorrupted: Boolean = false
+    val wasCorrupted: Boolean = false,
+    /**
+     * True when the device has neither enrolled biometrics nor a device
+     * lock (PIN/pattern/password). The V2 Keystore key cannot be created
+     * on such devices because `setUserAuthenticationRequired(true)`
+     * requires *some* credential to authenticate against. Banking-app
+     * pattern: refuse setup and tell the user to enable a lock in Android
+     * Settings before proceeding (#213 sub-PR 6).
+     */
+    val noDeviceCredential: Boolean = false,
 )
 
 @HiltViewModel
 class OnboardingViewModel @Inject constructor(
     private val repository: GatewayRepository,
-    private val walletRepository: WalletRepository
+    private val walletRepository: WalletRepository,
+    private val authManager: AuthManager,
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow(OnboardingUiState())
     val uiState: StateFlow<OnboardingUiState> = _uiState.asStateFlow()
 
     init {
-        _uiState.update { it.copy(wasCorrupted = repository.wasResetDueToCorruption()) }
+        _uiState.update {
+            it.copy(
+                wasCorrupted = repository.wasResetDueToCorruption(),
+                noDeviceCredential = !canCreateV2BoundKey(),
+            )
+        }
     }
 
+    /**
+     * True if Keystore can mint a V2 (auth-bound) key on this device.
+     * Either an enrolled biometric or a device credential (PIN/pattern/
+     * password) is required — the V2 spec uses
+     * `AUTH_BIOMETRIC_STRONG or AUTH_DEVICE_CREDENTIAL`.
+     */
+    private fun canCreateV2BoundKey(): Boolean =
+        authManager.isBiometricEnrolled() || authManager.hasDeviceCredential()
+
     fun createNewWallet() {
+        if (!canCreateV2BoundKey()) {
+            _uiState.update {
+                it.copy(
+                    error = "Set a screen lock (PIN, pattern, password, or biometric) in Android Settings, then try again. Pocket Node uses your device lock to protect your wallet keys.",
+                    noDeviceCredential = true,
+                )
+            }
+            return
+        }
         viewModelScope.launch {
             _uiState.update { it.copy(isLoading = true, error = null) }
             try {
-                // Create wallet via WalletRepository so a Room entity is created
                 val (entity, _) = walletRepository.createWallet("My Wallet")
                 Log.d(TAG, "Created wallet entity: ${entity.walletId}")
-                // Initialize the gateway repository with the new wallet's keys
                 repository.onActiveWalletChanged(entity)
                 _uiState.update { it.copy(isLoading = false, isWalletCreated = true) }
             } catch (e: Exception) {

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/send/SendViewModel.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/send/SendViewModel.kt
@@ -294,6 +294,15 @@ class SendViewModel @Inject constructor(
                 }
                 return
             }
+            is WalletKeyReader.Result.KeyInvalidated -> {
+                _uiState.update {
+                    it.copy(
+                        error = "Biometric enrollment changed — re-import this wallet from its recovery phrase to continue",
+                        isLoading = false,
+                    )
+                }
+                return
+            }
             is WalletKeyReader.Result.Success -> {
                 proceedWithSend(amountShannons, capturedAddress, readResult.privateKey)
             }

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/settings/SecuritySettingsScreen.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/settings/SecuritySettingsScreen.kt
@@ -65,6 +65,35 @@ fun SecuritySettingsScreen(
         }
     }
 
+    // V2 Keystore key is invalidated whenever the user adds/removes a
+    // biometric enrollment (setInvalidatedByBiometricEnrollment=true).
+    // Surface this trade-off the first time the user touches the
+    // biometric toggle while wallets exist on the device (#213 sub-PR 6).
+    uiState.biometricEnrollmentWarning?.let { warning ->
+        AlertDialog(
+            onDismissRequest = { viewModel.dismissBiometricEnrollmentWarning() },
+            title = { Text(if (warning.enabling) "Enable biometric unlock?" else "Disable biometric unlock?") },
+            text = {
+                Text(
+                    "Pocket Node binds your wallet keys to your current biometrics. " +
+                    "If you later add or remove a fingerprint or face, the keys on this device are wiped " +
+                    "and the wallet can only be recovered from its recovery phrase.\n\n" +
+                    "Make sure your recovery phrase is written down somewhere safe before you continue."
+                )
+            },
+            confirmButton = {
+                Button(onClick = { viewModel.confirmBiometricEnrollmentWarning() }) {
+                    Text("Continue")
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { viewModel.dismissBiometricEnrollmentWarning() }) {
+                    Text("Cancel")
+                }
+            }
+        )
+    }
+
     if (showRemoveDialog) {
         if (!uiState.canRemovePin) {
             AlertDialog(

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/settings/SecuritySettingsViewModel.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/settings/SecuritySettingsViewModel.kt
@@ -30,7 +30,26 @@ data class SecuritySettingsUiState(
     val canRemovePin: Boolean = false,
     val biometricStatusText: String = "",
     val isAuthBeforeSendEnabled: Boolean = false,
-    val error: String? = null
+    val error: String? = null,
+    /**
+     * Non-null when the user is being asked to confirm that adding or
+     * removing a biometric enrollment will invalidate their V2 wallet
+     * keys. The dialog explains the consequence and offers a
+     * cancel/proceed choice (#213 sub-PR 6). When the user proceeds, the
+     * wallet remains usable only via recovery-phrase re-import.
+     */
+    val biometricEnrollmentWarning: BiometricEnrollmentWarning? = null,
+)
+
+/**
+ * State for the biometric-enrollment warning modal shown when the user
+ * is about to enable biometric on a device that already has wallets.
+ * The V2 Keystore key uses `setInvalidatedByBiometricEnrollment(true)`,
+ * so any future change to enrolled biometrics wipes the key and the
+ * wallet can only be recovered from its mnemonic.
+ */
+data class BiometricEnrollmentWarning(
+    val enabling: Boolean,
 )
 
 @HiltViewModel
@@ -108,6 +127,35 @@ class SecuritySettingsViewModel @Inject constructor(
             _uiState.update { it.copy(error = "Set a PIN first to enable biometric unlock") }
             return
         }
+        // The V2 Keystore key is configured with
+        // setInvalidatedByBiometricEnrollment(true), so any later change
+        // to enrolled biometrics will wipe the key. Warn the user once
+        // here so they understand they MUST keep their recovery phrase
+        // backed up; if they later add or remove a fingerprint, the
+        // wallet becomes unreadable except via re-import (#213 sub-PR 6).
+        viewModelScope.launch {
+            if (walletDao.count() > 0) {
+                _uiState.update {
+                    it.copy(biometricEnrollmentWarning = BiometricEnrollmentWarning(enabled))
+                }
+            } else {
+                applyBiometricToggle(enabled)
+            }
+        }
+    }
+
+    /** Called from the warning dialog when the user accepts the trade-off. */
+    fun confirmBiometricEnrollmentWarning() {
+        val warning = _uiState.value.biometricEnrollmentWarning ?: return
+        applyBiometricToggle(warning.enabling)
+        _uiState.update { it.copy(biometricEnrollmentWarning = null) }
+    }
+
+    fun dismissBiometricEnrollmentWarning() {
+        _uiState.update { it.copy(biometricEnrollmentWarning = null) }
+    }
+
+    private fun applyBiometricToggle(enabled: Boolean) {
         authManager.setBiometricEnabled(enabled)
         _uiState.update { it.copy(isBiometricEnabled = enabled, error = null) }
     }

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/wallet/WalletSettingsViewModel.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/wallet/WalletSettingsViewModel.kt
@@ -264,6 +264,11 @@ class WalletSettingsViewModel @Inject constructor(
                 is WalletKeyReader.MaterialResult.NotAvailable -> {
                     _uiState.update { it.copy(error = "Cannot read wallet key: ${result.reason}") }
                 }
+                is WalletKeyReader.MaterialResult.KeyInvalidated -> {
+                    _uiState.update {
+                        it.copy(error = "Biometric enrollment changed — re-import this wallet to view its recovery phrase")
+                    }
+                }
                 is WalletKeyReader.MaterialResult.Success -> {
                     val keyHex = result.privateKey.joinToString("") { "%02x".format(it) }
                     val words = result.mnemonic?.split(" ")
@@ -311,6 +316,10 @@ class WalletSettingsViewModel @Inject constructor(
                     _uiState.update { it.copy(error = "Authentication cancelled") }
                 is WalletKeyReader.MaterialResult.NotAvailable ->
                     _uiState.update { it.copy(error = "Cannot read parent wallet: ${result.reason}") }
+                is WalletKeyReader.MaterialResult.KeyInvalidated ->
+                    _uiState.update {
+                        it.copy(error = "Biometric enrollment changed — re-import the parent wallet to create sub-accounts")
+                    }
                 is WalletKeyReader.MaterialResult.Success -> {
                     val words = result.mnemonic?.split(" ")
                     if (words.isNullOrEmpty()) {


### PR DESCRIPTION
## Summary

Final sub-PR for [#213](https://github.com/RaheemJnr/pocket-node/issues/213). Closes out the audit Finding High 1 with three user-facing guardrails for the V2 (auth-bound) Keystore key.

1. **KeyPermanentlyInvalidatedException recovery** — Keystore wipes the V2 key when the user changes biometric enrollment. WalletKeyReader detects this, surfaces a new \`KeyInvalidated\` sealed-class variant, and call sites (Send, DAO, mnemonic display) show an error that directs the user to re-import from their recovery phrase.

2. **No-credential device refusal** — OnboardingViewModel refuses wallet creation on devices with no biometric *and* no device lock. Tells the user to set a screen lock first (banking-app pattern).

3. **Biometric enrollment warning** — SecuritySettings shows a modal when toggling biometric while wallets exist, explaining the \`setInvalidatedByBiometricEnrollment(true)\` trade-off so the user knows their recovery phrase is the only fallback.

## Test plan

- [x] \`./gradlew :app:testDebugUnitTest\` → 581/581 pass

Refs #213, #187 Finding High 1