### PR TITLE
feat(contacts): ContactEntity + MIGRATION_10_11 (#189)

### DIFF
--- a/android/app/src/main/java/com/rjnr/pocketnode/data/database/AppDatabase.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/database/AppDatabase.kt
@@ -11,6 +11,7 @@ import com.rjnr.pocketnode.data.database.dao.SyncProgressDao
 import com.rjnr.pocketnode.data.database.dao.TransactionDao
 import com.rjnr.pocketnode.data.database.dao.WalletDao
 import com.rjnr.pocketnode.data.database.entity.BalanceCacheEntity
+import com.rjnr.pocketnode.data.database.entity.ContactEntity
 import com.rjnr.pocketnode.data.database.entity.DaoCellEntity
 import com.rjnr.pocketnode.data.database.entity.HeaderCacheEntity
 import com.rjnr.pocketnode.data.database.entity.KeyMaterialEntity
@@ -28,7 +29,8 @@ import com.rjnr.pocketnode.data.database.entity.WalletEntity
         WalletEntity::class,
         KeyMaterialEntity::class,
         SyncProgressEntity::class,
-        PendingBroadcastEntity::class
+        PendingBroadcastEntity::class,
+        ContactEntity::class,
     ],
     // Bumped from 8 to 9 in v1.5.2 because TransactionEntity / BalanceCacheEntity
     // / DaoCellEntity gained @Index(idx_tx_pending) + @ColumnInfo(defaultValue)
@@ -42,7 +44,12 @@ import com.rjnr.pocketnode.data.database.entity.WalletEntity
     // (legacy unrestricted V1 keystore key); the v1.6.x → v1.7.0 migration
     // re-encrypts them under the auth-bound V2 keystore key and bumps each
     // row to version 2. See `KeystoreV2MigrationHelper` and #213.
-    version = 10,
+    //
+    // Bumped from 10 to 11 for the M4 Phase 2 address book (#189). Adds
+    // the `contacts` table with indices on address and walletId. No
+    // existing column changed; MIGRATION_10_11 is a single CREATE TABLE
+    // + 2 CREATE INDEX.
+    version = 11,
     // Schema export deliberately OFF until the Room 2.8.4 / kotlinx-serialization
     // 1.8.0 binary incompatibility is resolved (tracked in #149). Enabling it
     // crashes KSP with AbstractMethodError in Room's bundled
@@ -62,4 +69,5 @@ abstract class AppDatabase : RoomDatabase() {
     abstract fun keyMaterialDao(): KeyMaterialDao
     abstract fun syncProgressDao(): SyncProgressDao
     abstract fun pendingBroadcastDao(): PendingBroadcastDao
+    // contactDao() added in #190 alongside the ContactDao interface.
 }

--- a/android/app/src/main/java/com/rjnr/pocketnode/data/database/Migrations.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/database/Migrations.kt
@@ -416,3 +416,37 @@ val MIGRATION_9_10 = object : Migration(9, 10) {
         )
     }
 }
+
+/**
+ * Adds the `contacts` table for the M4 Phase 2 address book (#189).
+ *
+ * The schema mirrors the [com.rjnr.pocketnode.data.database.entity.ContactEntity]
+ * declaration exactly: PK on `id`, two single-column indices on
+ * `address` and `walletId`, and defaults for `lastUsedAt` / `useCount`
+ * so smart-suggestion ranking has stable starting values. Existing
+ * rows are unaffected — this is a pure additive migration.
+ */
+val MIGRATION_10_11 = object : Migration(10, 11) {
+    override fun migrate(db: SupportSQLiteDatabase) {
+        db.execSQL(
+            """
+            CREATE TABLE IF NOT EXISTS `contacts` (
+                `id` TEXT NOT NULL,
+                `walletId` TEXT,
+                `name` TEXT NOT NULL,
+                `address` TEXT NOT NULL,
+                `network` TEXT NOT NULL,
+                `notes` TEXT,
+                `tags` TEXT,
+                `createdAt` INTEGER NOT NULL,
+                `updatedAt` INTEGER NOT NULL,
+                `lastUsedAt` INTEGER DEFAULT NULL,
+                `useCount` INTEGER NOT NULL DEFAULT 0,
+                PRIMARY KEY(`id`)
+            )
+            """.trimIndent()
+        )
+        db.execSQL("CREATE INDEX IF NOT EXISTS `idx_contacts_address` ON `contacts` (`address`)")
+        db.execSQL("CREATE INDEX IF NOT EXISTS `idx_contacts_walletId` ON `contacts` (`walletId`)")
+    }
+}

--- a/android/app/src/main/java/com/rjnr/pocketnode/data/database/entity/ContactEntity.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/database/entity/ContactEntity.kt
@@ -1,0 +1,49 @@
+package com.rjnr.pocketnode.data.database.entity
+
+import androidx.room.ColumnInfo
+import androidx.room.Entity
+import androidx.room.Index
+import androidx.room.PrimaryKey
+
+/**
+ * Address book entry for the M4 Phase 2 contacts feature (#189).
+ *
+ * ## Scope
+ *
+ * - `walletId == null`: global contact, visible from every wallet.
+ * - `walletId != null`: wallet-scoped contact, only visible when that
+ *   wallet is active. Used for per-wallet labels (e.g. "Alice's hot
+ *   wallet" vs "Alice's cold wallet" stored under different parent
+ *   wallets).
+ *
+ * The `network` field is denormalized from the bech32 prefix on
+ * `address` (`ckb1` → mainnet, `ckt1` → testnet) so queries can filter
+ * by network without parsing the address. `ContactRepository` rejects
+ * any contact whose address prefix disagrees with `network`.
+ *
+ * ## Smart suggestions
+ *
+ * `useCount` and `lastUsedAt` are bumped by [com.rjnr.pocketnode.data.database.dao.ContactDao.markUsed]
+ * after a successful Send. The Send autocomplete sorts by
+ * `lastUsedAt DESC` so frequently-used recipients surface first.
+ */
+@Entity(
+    tableName = "contacts",
+    indices = [
+        Index(value = ["address"], name = "idx_contacts_address"),
+        Index(value = ["walletId"], name = "idx_contacts_walletId"),
+    ],
+)
+data class ContactEntity(
+    @PrimaryKey val id: String,
+    val walletId: String?,
+    val name: String,
+    val address: String,
+    val network: String,
+    val notes: String?,
+    val tags: String?,
+    val createdAt: Long,
+    val updatedAt: Long,
+    @ColumnInfo(defaultValue = "NULL") val lastUsedAt: Long?,
+    @ColumnInfo(defaultValue = "0") val useCount: Int,
+)

--- a/android/app/src/main/java/com/rjnr/pocketnode/di/AppModule.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/di/AppModule.kt
@@ -17,6 +17,7 @@ import com.rjnr.pocketnode.data.database.MIGRATION_6_7
 import com.rjnr.pocketnode.data.database.MIGRATION_7_8
 import com.rjnr.pocketnode.data.database.MIGRATION_8_9
 import com.rjnr.pocketnode.data.database.MIGRATION_9_10
+import com.rjnr.pocketnode.data.database.MIGRATION_10_11
 import com.rjnr.pocketnode.data.database.dao.BalanceCacheDao
 import com.rjnr.pocketnode.data.database.dao.DaoCellDao
 import com.rjnr.pocketnode.data.database.dao.HeaderCacheDao
@@ -127,7 +128,7 @@ object AppModule {
     fun provideAppDatabase(@ApplicationContext context: Context): AppDatabase =
         Room.databaseBuilder(context, AppDatabase::class.java, "pocket_node.db")
             .setJournalMode(RoomDatabase.JournalMode.WRITE_AHEAD_LOGGING)
-            .addMigrations(MIGRATION_1_2, MIGRATION_2_3, MIGRATION_3_4, MIGRATION_4_5, MIGRATION_5_6, MIGRATION_6_7, MIGRATION_7_8, MIGRATION_8_9, MIGRATION_9_10)
+            .addMigrations(MIGRATION_1_2, MIGRATION_2_3, MIGRATION_3_4, MIGRATION_4_5, MIGRATION_5_6, MIGRATION_6_7, MIGRATION_7_8, MIGRATION_8_9, MIGRATION_9_10, MIGRATION_10_11)
             .build()
 
     @Provides

--- a/android/app/src/test/java/com/rjnr/pocketnode/data/database/WalkingMigrationTest.kt
+++ b/android/app/src/test/java/com/rjnr/pocketnode/data/database/WalkingMigrationTest.kt
@@ -85,6 +85,27 @@ class WalkingMigrationTest {
     }
 
     /**
+     * v10 → v11 path (#189 address book): bootstrap a v10 SQLite file
+     * and confirm MIGRATION_10_11 creates the contacts table with both
+     * indices, after which schema validation passes.
+     */
+    @Test
+    fun `v10 walks to v11 successfully and creates contacts table`() {
+        bootstrapV10()
+        openViaRoomAndValidate()
+        val db = openedRoomDb!!.openHelper.readableDatabase
+        db.query("SELECT name FROM sqlite_master WHERE type='table' AND name='contacts'").use { c ->
+            assertTrue("contacts table missing after MIGRATION_10_11", c.moveToNext())
+        }
+        db.query("SELECT name FROM sqlite_master WHERE type='index' AND name='idx_contacts_address'").use { c ->
+            assertTrue("idx_contacts_address missing", c.moveToNext())
+        }
+        db.query("SELECT name FROM sqlite_master WHERE type='index' AND name='idx_contacts_walletId'").use { c ->
+            assertTrue("idx_contacts_walletId missing", c.moveToNext())
+        }
+    }
+
+    /**
      * v1.6.x → v1.7.0 path: bootstrap a v9 SQLite file (no `kdfVersion`
      * column on `key_material`) and confirm MIGRATION_9_10 adds the
      * column with default 1, then Room schema validation passes.
@@ -129,7 +150,7 @@ class WalkingMigrationTest {
                 .addMigrations(
                     MIGRATION_1_2, MIGRATION_2_3, MIGRATION_3_4, MIGRATION_4_5,
                     MIGRATION_5_6, MIGRATION_6_7, MIGRATION_7_8, noOpMigration8To9,
-                    MIGRATION_9_10,
+                    MIGRATION_9_10, MIGRATION_10_11,
                 )
                 .build()
             openedRoomDb = db
@@ -159,7 +180,7 @@ class WalkingMigrationTest {
             .addMigrations(
                 MIGRATION_1_2, MIGRATION_2_3, MIGRATION_3_4, MIGRATION_4_5,
                 MIGRATION_5_6, MIGRATION_6_7, MIGRATION_7_8, MIGRATION_8_9,
-                MIGRATION_9_10,
+                MIGRATION_9_10, MIGRATION_10_11,
             )
             .build()
         openedRoomDb = db
@@ -175,6 +196,33 @@ class WalkingMigrationTest {
      * version 8 so when Room subsequently opens it at version 9,
      * `onUpgrade` fires and runs MIGRATION_8_9.
      */
+    /**
+     * Bootstrap a v10 SQLite file: applies MIGRATION_8_9 + MIGRATION_9_10
+     * over the v8 shape so the on-disk DB matches what a real
+     * upgraded-to-v10 user has. The key thing for MIGRATION_10_11
+     * coverage is that the `contacts` table does NOT exist yet.
+     */
+    private fun bootstrapV10() {
+        val factory = FrameworkSQLiteOpenHelperFactory()
+        val callback = object : SupportSQLiteOpenHelper.Callback(10) {
+            override fun onCreate(db: SupportSQLiteDatabase) {
+                createV8Tables(db, pathA = true)
+                MIGRATION_8_9.migrate(db)
+                MIGRATION_9_10.migrate(db)
+                db.execSQL("CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)")
+                db.execSQL("INSERT OR REPLACE INTO room_master_table VALUES(42, 'bootstrap-v10')")
+            }
+            override fun onUpgrade(db: SupportSQLiteDatabase, oldV: Int, newV: Int) = Unit
+        }
+        val config = SupportSQLiteOpenHelper.Configuration.builder(ctx)
+            .name(dbName)
+            .callback(callback)
+            .build()
+        val helper = factory.create(config)
+        helper.writableDatabase.close()
+        helper.close()
+    }
+
     /**
      * Bootstrap a v9 SQLite file: same as `bootstrapV8(pathA = true)` but
      * also applies the MIGRATION_8_9 changes inline so the on-disk shape


### PR DESCRIPTION
## Summary

M4 Phase 2 data foundation. First of 9 sub-issues for the address book feature ([#189-#197](https://github.com/RaheemJnr/pocket-node/issues/189)).

- \`ContactEntity\` with PK + walletId (nullable for global contacts) + smart-suggestion fields (\`useCount\`, \`lastUsedAt\`)
- Indices on \`address\` and \`walletId\`
- \`MIGRATION_10_11\` (single CREATE TABLE + 2 CREATE INDEX, pure additive)
- Schema bump 10 → 11
- Walking migration test for v10 → v11

\`ContactDao\` and \`AppDatabase.contactDao()\` ship in #190 so this PR stays focused.

## Test plan

- [x] \`./gradlew :app:testDebugUnitTest\` → 582/582 pass (1 new walking migration test)

Refs #189