### PR TITLE
feat(contacts): ContactDao with search + smart-suggestion queries (#190)

### DIFF
--- a/android/app/src/main/java/com/rjnr/pocketnode/data/database/AppDatabase.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/database/AppDatabase.kt
@@ -3,6 +3,7 @@ package com.rjnr.pocketnode.data.database
 import androidx.room.Database
 import androidx.room.RoomDatabase
 import com.rjnr.pocketnode.data.database.dao.BalanceCacheDao
+import com.rjnr.pocketnode.data.database.dao.ContactDao
 import com.rjnr.pocketnode.data.database.dao.DaoCellDao
 import com.rjnr.pocketnode.data.database.dao.HeaderCacheDao
 import com.rjnr.pocketnode.data.database.dao.KeyMaterialDao
@@ -69,5 +70,5 @@ abstract class AppDatabase : RoomDatabase() {
     abstract fun keyMaterialDao(): KeyMaterialDao
     abstract fun syncProgressDao(): SyncProgressDao
     abstract fun pendingBroadcastDao(): PendingBroadcastDao
-    // contactDao() added in #190 alongside the ContactDao interface.
+    abstract fun contactDao(): ContactDao
 }

--- a/android/app/src/main/java/com/rjnr/pocketnode/data/database/dao/ContactDao.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/database/dao/ContactDao.kt
@@ -1,0 +1,98 @@
+package com.rjnr.pocketnode.data.database.dao
+
+import androidx.room.Dao
+import androidx.room.Delete
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import androidx.room.Update
+import com.rjnr.pocketnode.data.database.entity.ContactEntity
+import kotlinx.coroutines.flow.Flow
+
+/**
+ * Room DAO for the M4 Phase 2 address book (#190).
+ *
+ * ## Scoping
+ *
+ * Every read query takes a `walletId` and returns rows where
+ * `walletId = :walletId OR walletId IS NULL`. The null branch surfaces
+ * global contacts that should appear regardless of which wallet is
+ * active. Writes always set the walletId explicitly — there's no
+ * "current wallet" fallback at this layer.
+ *
+ * ## Insertion conflict
+ *
+ * `insert` uses `OnConflictStrategy.ABORT` so duplicate PKs surface as
+ * a `SQLiteConstraintException`. The repository layer (#191) treats
+ * this as a `DuplicateAddress` validation error and offers the user an
+ * update-existing flow rather than silently replacing the row.
+ */
+@Dao
+interface ContactDao {
+
+    /**
+     * Observe every contact visible to [walletId] — both wallet-scoped
+     * rows and globally-scoped (`walletId IS NULL`) rows — sorted by
+     * name (case-insensitive) for the address book list view.
+     */
+    @Query(
+        "SELECT * FROM contacts " +
+            "WHERE walletId = :walletId OR walletId IS NULL " +
+            "ORDER BY name COLLATE NOCASE ASC"
+    )
+    fun observeAll(walletId: String): Flow<List<ContactEntity>>
+
+    @Query("SELECT * FROM contacts WHERE id = :id")
+    suspend fun getById(id: String): ContactEntity?
+
+    /** Used by the Send flow to check whether a recipient address is already saved. */
+    @Query("SELECT * FROM contacts WHERE address = :address LIMIT 1")
+    suspend fun getByAddress(address: String): ContactEntity?
+
+    /**
+     * Substring search across name and address. `q` is expected to
+     * already include `%` wildcards on both sides — the caller controls
+     * the match shape (prefix-only, infix, etc.). Capped at 20 results
+     * to keep dropdown UIs responsive.
+     */
+    @Query(
+        "SELECT * FROM contacts " +
+            "WHERE (walletId = :walletId OR walletId IS NULL) " +
+            "AND (name LIKE :q OR address LIKE :q) " +
+            "ORDER BY lastUsedAt DESC NULLS LAST " +
+            "LIMIT 20"
+    )
+    suspend fun search(walletId: String, q: String): List<ContactEntity>
+
+    /**
+     * Top 5 most-used contacts for the active wallet. Drives the
+     * "recent recipients" section of the Send picker.
+     */
+    @Query(
+        "SELECT * FROM contacts " +
+            "WHERE walletId = :walletId AND useCount > 0 " +
+            "ORDER BY useCount DESC, lastUsedAt DESC " +
+            "LIMIT 5"
+    )
+    suspend fun recentlyUsed(walletId: String): List<ContactEntity>
+
+    @Insert(onConflict = OnConflictStrategy.ABORT)
+    suspend fun insert(entity: ContactEntity)
+
+    @Update
+    suspend fun update(entity: ContactEntity)
+
+    @Delete
+    suspend fun delete(entity: ContactEntity)
+
+    /**
+     * Atomic counter bump called after a successful send. Both the
+     * count and the timestamp move in the same write so the
+     * `recentlyUsed` ordering stays consistent.
+     */
+    @Query("UPDATE contacts SET useCount = useCount + 1, lastUsedAt = :now WHERE id = :id")
+    suspend fun markUsed(id: String, now: Long)
+
+    @Query("SELECT COUNT(*) FROM contacts")
+    suspend fun count(): Int
+}

--- a/android/app/src/test/java/com/rjnr/pocketnode/data/database/dao/ContactDaoTest.kt
+++ b/android/app/src/test/java/com/rjnr/pocketnode/data/database/dao/ContactDaoTest.kt
@@ -1,0 +1,155 @@
+package com.rjnr.pocketnode.data.database.dao
+
+import android.content.Context
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import com.rjnr.pocketnode.data.database.AppDatabase
+import com.rjnr.pocketnode.data.database.entity.ContactEntity
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Assert.*
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import java.util.UUID
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [28], manifest = Config.NONE)
+class ContactDaoTest {
+
+    private lateinit var db: AppDatabase
+    private lateinit var dao: ContactDao
+
+    private fun contact(
+        id: String = UUID.randomUUID().toString(),
+        walletId: String? = "wallet-1",
+        name: String,
+        address: String,
+        network: String = "testnet",
+        useCount: Int = 0,
+        lastUsedAt: Long? = null,
+        now: Long = 1_000_000L,
+    ) = ContactEntity(
+        id = id,
+        walletId = walletId,
+        name = name,
+        address = address,
+        network = network,
+        notes = null,
+        tags = null,
+        createdAt = now,
+        updatedAt = now,
+        lastUsedAt = lastUsedAt,
+        useCount = useCount,
+    )
+
+    @Before
+    fun setUp() {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        db = Room.inMemoryDatabaseBuilder(context, AppDatabase::class.java)
+            .allowMainThreadQueries()
+            .build()
+        dao = db.contactDao()
+    }
+
+    @After
+    fun tearDown() { db.close() }
+
+    @Test
+    fun `insert and getById round-trips`() = runTest {
+        val c = contact(name = "Alice", address = "ckt1_alice")
+        dao.insert(c)
+        val fetched = dao.getById(c.id)
+        assertNotNull(fetched)
+        assertEquals("Alice", fetched!!.name)
+        assertEquals("ckt1_alice", fetched.address)
+    }
+
+    @Test
+    fun `getByAddress returns the first matching row`() = runTest {
+        dao.insert(contact(name = "Alice", address = "ckt1_alice"))
+        val found = dao.getByAddress("ckt1_alice")
+        assertNotNull(found)
+        assertEquals("Alice", found!!.name)
+    }
+
+    @Test
+    fun `getByAddress returns null for unknown address`() = runTest {
+        assertNull(dao.getByAddress("ckt1_missing"))
+    }
+
+    @Test
+    fun `observeAll returns wallet-scoped and global contacts sorted by name`() = runTest {
+        dao.insert(contact(walletId = "wallet-1", name = "bob", address = "ckt1_bob"))
+        dao.insert(contact(walletId = null, name = "alice", address = "ckt1_alice")) // global
+        dao.insert(contact(walletId = "wallet-1", name = "Carol", address = "ckt1_carol"))
+        // Contact for a different wallet — must NOT appear in wallet-1's list.
+        dao.insert(contact(walletId = "wallet-2", name = "eve", address = "ckt1_eve"))
+
+        val list = dao.observeAll("wallet-1").first()
+        assertEquals(listOf("alice", "bob", "Carol"), list.map { it.name })
+    }
+
+    @Test
+    fun `search matches by name OR address with LIKE wildcards`() = runTest {
+        dao.insert(contact(name = "Alice", address = "ckt1_alice"))
+        dao.insert(contact(name = "Alicia", address = "ckt1_alicia"))
+        dao.insert(contact(name = "Bob", address = "ckt1_bob"))
+
+        // The DAO does NOT add wildcards itself — repository is in charge.
+        val nameHit = dao.search("wallet-1", "%Ali%")
+        assertEquals(2, nameHit.size)
+
+        val addrHit = dao.search("wallet-1", "%bob%")
+        assertEquals(1, addrHit.size)
+        assertEquals("Bob", addrHit.first().name)
+    }
+
+    @Test
+    fun `recentlyUsed sorts by useCount desc and excludes unused`() = runTest {
+        dao.insert(contact(name = "Cold", address = "ckt1_cold", useCount = 0))
+        dao.insert(contact(name = "Warm", address = "ckt1_warm", useCount = 2, lastUsedAt = 200L))
+        dao.insert(contact(name = "Hot", address = "ckt1_hot", useCount = 5, lastUsedAt = 100L))
+
+        val recent = dao.recentlyUsed("wallet-1")
+        assertEquals(listOf("Hot", "Warm"), recent.map { it.name })
+    }
+
+    @Test
+    fun `markUsed bumps count and timestamp atomically`() = runTest {
+        val c = contact(name = "Alice", address = "ckt1_alice", useCount = 0, lastUsedAt = null)
+        dao.insert(c)
+
+        dao.markUsed(c.id, now = 5_000L)
+        var after = dao.getById(c.id)!!
+        assertEquals(1, after.useCount)
+        assertEquals(5_000L, after.lastUsedAt)
+
+        dao.markUsed(c.id, now = 6_000L)
+        after = dao.getById(c.id)!!
+        assertEquals(2, after.useCount)
+        assertEquals(6_000L, after.lastUsedAt)
+    }
+
+    @Test
+    fun `update writes new fields without touching id`() = runTest {
+        val c = contact(name = "Alice", address = "ckt1_alice")
+        dao.insert(c)
+        dao.update(c.copy(name = "Alice (new)", notes = "moved"))
+
+        val fetched = dao.getById(c.id)!!
+        assertEquals("Alice (new)", fetched.name)
+        assertEquals("moved", fetched.notes)
+    }
+
+    @Test
+    fun `delete removes the row`() = runTest {
+        val c = contact(name = "Alice", address = "ckt1_alice")
+        dao.insert(c)
+        dao.delete(c)
+        assertNull(dao.getById(c.id))
+    }
+}


### PR DESCRIPTION
M4 Phase 2 data layer continues. Second of 9 sub-issues.

- `observeAll` Flow for wallet-scoped + global contacts
- `getByAddress` for Send-time matching
- `search(walletId, q)` LIKE-wildcarded, ordered by `lastUsedAt DESC NULLS LAST`
- `recentlyUsed(walletId)` top 5 by useCount DESC for the picker
- `markUsed` atomic counter bump for post-send

Refs #190