### PR TITLE
feat(contacts): ContactRepository with validation + smart-suggestion (#191)

### DIFF
--- a/android/app/src/main/java/com/rjnr/pocketnode/data/contacts/ContactRepository.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/contacts/ContactRepository.kt
@@ -1,0 +1,201 @@
+package com.rjnr.pocketnode.data.contacts
+
+import android.util.Log
+import com.rjnr.pocketnode.data.database.dao.ContactDao
+import com.rjnr.pocketnode.data.database.entity.ContactEntity
+import com.rjnr.pocketnode.data.gateway.models.NetworkType
+import com.rjnr.pocketnode.data.wallet.AddressUtils
+import com.rjnr.pocketnode.data.wallet.WalletRepository
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import java.util.UUID
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Validation and lifecycle wrapper around [ContactDao] for the M4 Phase 2
+ * address book (#191).
+ *
+ * ## Responsibilities
+ *
+ * - Normalize and validate user input (name length, address parseability,
+ *   network agreement with the active wallet, duplicate detection).
+ * - Translate sealed [ContactError] outcomes from primitive Room
+ *   exceptions, so call-site error handling stays exhaustive.
+ * - Bump `lastUsedAt` / `useCount` after a successful send via
+ *   [markUsed], driving the smart-suggestion ranking that the Send
+ *   picker reads through [recentlyUsed].
+ *
+ * The repository is wallet-aware: scope decisions are made from
+ * [WalletRepository.activeWalletIdSnapshot]. Callers do not need to
+ * supply walletId — that's the lesson from the WalletRepository wiring
+ * in M3.
+ */
+@Singleton
+class ContactRepository @Inject constructor(
+    private val contactDao: ContactDao,
+    private val walletRepository: WalletRepository,
+    private val nowProvider: () -> Long = { System.currentTimeMillis() },
+) {
+
+    sealed class ContactError(message: String) : Exception(message) {
+        object InvalidAddress : ContactError("Address cannot be decoded")
+        data class WrongNetwork(val expected: NetworkType, val actual: NetworkType) :
+            ContactError("Address is on $actual but active network is $expected")
+        data class DuplicateAddress(val existingId: String) :
+            ContactError("Address already saved as contact $existingId")
+        object InvalidName : ContactError("Name must be 1-64 characters")
+        object NotesTooLong : ContactError("Notes must be 256 characters or fewer")
+        object NoActiveWallet : ContactError("No active wallet to scope contact to")
+        data class NotFound(val id: String) : ContactError("Contact $id not found")
+    }
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    fun observe(): Flow<List<ContactEntity>> {
+        val walletId = walletRepository.activeWalletIdSnapshot()
+        return if (walletId.isNullOrEmpty()) flowOf(emptyList())
+        else contactDao.observeAll(walletId)
+    }
+
+    suspend fun get(id: String): ContactEntity? = contactDao.getById(id)
+
+    suspend fun getByAddress(address: String): ContactEntity? =
+        contactDao.getByAddress(address)
+
+    /**
+     * Add a new contact. Validation order:
+     *
+     * 1. Name length (cheapest)
+     * 2. Notes length
+     * 3. Address parseability via [AddressUtils.decode] (canonical
+     *    bech32 check)
+     * 4. Network agreement with the active wallet's network — refuses a
+     *    mainnet address on testnet and vice versa
+     * 5. Duplicate-address check across the user's contacts (regardless
+     *    of wallet scope) — if a contact already exists for this
+     *    address, the UI offers an "update existing" flow rather than
+     *    silently shadowing it.
+     */
+    suspend fun add(
+        name: String,
+        address: String,
+        notes: String? = null,
+        tags: List<String>? = null,
+        scopedToActiveWallet: Boolean = true,
+        activeNetwork: NetworkType,
+    ): Result<ContactEntity> {
+        return runCatching {
+            val trimmedName = name.trim()
+            if (trimmedName.isEmpty() || trimmedName.length > 64) throw ContactError.InvalidName
+            val trimmedNotes = notes?.trim()?.ifEmpty { null }
+            if (trimmedNotes != null && trimmedNotes.length > 256) throw ContactError.NotesTooLong
+
+            // getNetwork wraps the CKB SDK's full Address.decode call. If
+            // it returns a non-null NetworkType, the bech32 payload + checksum
+            // are valid; we don't need a second decode pass.
+            val addressNetwork = AddressUtils.getNetwork(address)
+                ?: throw ContactError.InvalidAddress
+            if (addressNetwork != activeNetwork) {
+                throw ContactError.WrongNetwork(expected = activeNetwork, actual = addressNetwork)
+            }
+
+            contactDao.getByAddress(address)?.let { existing ->
+                throw ContactError.DuplicateAddress(existing.id)
+            }
+
+            val walletId = if (scopedToActiveWallet) {
+                walletRepository.activeWalletIdSnapshot()?.takeIf { it.isNotEmpty() }
+                    ?: throw ContactError.NoActiveWallet
+            } else null
+
+            val now = nowProvider()
+            val entity = ContactEntity(
+                id = UUID.randomUUID().toString(),
+                walletId = walletId,
+                name = trimmedName,
+                address = address,
+                network = addressNetwork.name.lowercase(),
+                notes = trimmedNotes,
+                tags = tags?.joinToString(","),
+                createdAt = now,
+                updatedAt = now,
+                lastUsedAt = null,
+                useCount = 0,
+            )
+            contactDao.insert(entity)
+            entity
+        }
+    }
+
+    /**
+     * Update mutable fields on an existing contact. Address and walletId
+     * are immutable — to change either, delete and re-create. This
+     * keeps `useCount` / `lastUsedAt` history pegged to the address
+     * rather than the label.
+     */
+    suspend fun update(
+        id: String,
+        name: String?,
+        notes: String?,
+        tags: List<String>?,
+    ): Result<Unit> = runCatching {
+        val existing = contactDao.getById(id) ?: throw ContactError.NotFound(id)
+        val newName = name?.trim() ?: existing.name
+        if (newName.isEmpty() || newName.length > 64) throw ContactError.InvalidName
+        val newNotes = notes?.trim()?.ifEmpty { null } ?: existing.notes
+        if (newNotes != null && newNotes.length > 256) throw ContactError.NotesTooLong
+
+        contactDao.update(
+            existing.copy(
+                name = newName,
+                notes = newNotes,
+                tags = tags?.joinToString(",") ?: existing.tags,
+                updatedAt = nowProvider(),
+            )
+        )
+    }
+
+    suspend fun delete(id: String): Result<Unit> = runCatching {
+        val existing = contactDao.getById(id) ?: throw ContactError.NotFound(id)
+        contactDao.delete(existing)
+    }
+
+    /**
+     * Substring search (case-insensitive, infix). Empty query returns
+     * empty list — the UI shows recent contacts in that state instead.
+     */
+    suspend fun search(query: String): List<ContactEntity> {
+        val walletId = walletRepository.activeWalletIdSnapshot()?.takeIf { it.isNotEmpty() }
+            ?: return emptyList()
+        val trimmed = query.trim()
+        if (trimmed.isEmpty()) return emptyList()
+        return contactDao.search(walletId, "%${trimmed}%")
+    }
+
+    suspend fun recentlyUsed(): List<ContactEntity> {
+        val walletId = walletRepository.activeWalletIdSnapshot()?.takeIf { it.isNotEmpty() }
+            ?: return emptyList()
+        return contactDao.recentlyUsed(walletId)
+    }
+
+    /**
+     * Bump usage counters for the contact at [address] if one exists.
+     * Silent no-op for unsaved recipients — the post-send "save?"
+     * prompt covers that path.
+     */
+    suspend fun markUsed(address: String) {
+        try {
+            val match = contactDao.getByAddress(address) ?: return
+            contactDao.markUsed(match.id, nowProvider())
+        } catch (e: Exception) {
+            Log.w(TAG, "markUsed failed for address=$address", e)
+        }
+    }
+
+    companion object {
+        private const val TAG = "ContactRepository"
+    }
+}

--- a/android/app/src/test/java/com/rjnr/pocketnode/data/contacts/ContactRepositoryTest.kt
+++ b/android/app/src/test/java/com/rjnr/pocketnode/data/contacts/ContactRepositoryTest.kt
@@ -1,0 +1,212 @@
+package com.rjnr.pocketnode.data.contacts
+
+import android.content.Context
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import com.rjnr.pocketnode.data.database.AppDatabase
+import com.rjnr.pocketnode.data.database.dao.ContactDao
+import com.rjnr.pocketnode.data.gateway.models.NetworkType
+import com.rjnr.pocketnode.data.gateway.models.Script
+import com.rjnr.pocketnode.data.wallet.AddressUtils
+import com.rjnr.pocketnode.data.wallet.WalletRepository
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Assert.*
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [28], manifest = Config.NONE)
+class ContactRepositoryTest {
+
+    private lateinit var db: AppDatabase
+    private lateinit var contactDao: ContactDao
+    private lateinit var walletRepository: WalletRepository
+    private lateinit var repo: ContactRepository
+    private var fakeNow = 1_000_000L
+
+    // Generate addresses from a known lock script — this is the same path
+    // AddressUtils round-trips, so getNetwork() is guaranteed to decode
+    // them. (Hardcoded fixture addresses sometimes diverge across CKB SDK
+    // bech32m revisions; encoding from a Script avoids that.)
+    private val sampleScript = Script(
+        codeHash = "0x9bd7e06f3ecf4be0f2fcd2188b23f1b9fcc88e5d4b65a8637b17723bbda3cce8",
+        hashType = "type",
+        args = "0x" + "aa".repeat(20),
+    )
+    private val sampleScript2 = Script(
+        codeHash = "0x9bd7e06f3ecf4be0f2fcd2188b23f1b9fcc88e5d4b65a8637b17723bbda3cce8",
+        hashType = "type",
+        args = "0x" + "bb".repeat(20),
+    )
+    private val testnetAddress by lazy { AddressUtils.encode(sampleScript, NetworkType.TESTNET) }
+    private val mainnetAddress by lazy { AddressUtils.encode(sampleScript, NetworkType.MAINNET) }
+    private val testnetAddress2 by lazy { AddressUtils.encode(sampleScript2, NetworkType.TESTNET) }
+
+    @Before
+    fun setUp() {
+        val ctx = ApplicationProvider.getApplicationContext<Context>()
+        db = Room.inMemoryDatabaseBuilder(ctx, AppDatabase::class.java)
+            .allowMainThreadQueries()
+            .build()
+        contactDao = db.contactDao()
+        walletRepository = mockk(relaxed = true)
+        every { walletRepository.activeWalletIdSnapshot() } returns "wallet-1"
+        repo = ContactRepository(contactDao, walletRepository, nowProvider = { fakeNow })
+    }
+
+    @After
+    fun tearDown() { db.close() }
+
+    // -- add: validation --
+
+    @Test
+    fun `add rejects empty name`() = runTest {
+        val result = repo.add(name = "  ", address = testnetAddress, activeNetwork = NetworkType.TESTNET)
+        assertTrue(result.isFailure)
+        assertTrue(result.exceptionOrNull() is ContactRepository.ContactError.InvalidName)
+    }
+
+    @Test
+    fun `add rejects name longer than 64 chars`() = runTest {
+        val result = repo.add(name = "x".repeat(65), address = testnetAddress, activeNetwork = NetworkType.TESTNET)
+        assertTrue(result.exceptionOrNull() is ContactRepository.ContactError.InvalidName)
+    }
+
+    @Test
+    fun `add rejects notes longer than 256 chars`() = runTest {
+        val result = repo.add(
+            name = "Alice", address = testnetAddress,
+            notes = "x".repeat(257), activeNetwork = NetworkType.TESTNET,
+        )
+        assertTrue(result.exceptionOrNull() is ContactRepository.ContactError.NotesTooLong)
+    }
+
+    @Test
+    fun `add rejects unparseable address`() = runTest {
+        val result = repo.add(name = "Alice", address = "not-a-ckb-address", activeNetwork = NetworkType.TESTNET)
+        assertTrue(result.exceptionOrNull() is ContactRepository.ContactError.InvalidAddress)
+    }
+
+    @Test
+    fun `add rejects mainnet address on testnet`() = runTest {
+        val result = repo.add(name = "Alice", address = mainnetAddress, activeNetwork = NetworkType.TESTNET)
+        val err = result.exceptionOrNull()
+        assertTrue(err is ContactRepository.ContactError.WrongNetwork)
+        err as ContactRepository.ContactError.WrongNetwork
+        assertEquals(NetworkType.TESTNET, err.expected)
+        assertEquals(NetworkType.MAINNET, err.actual)
+    }
+
+    @Test
+    fun `add rejects duplicate address`() = runTest {
+        repo.add(name = "Alice", address = testnetAddress, activeNetwork = NetworkType.TESTNET).getOrThrow()
+        val second = repo.add(name = "Alice 2", address = testnetAddress, activeNetwork = NetworkType.TESTNET)
+        assertTrue(second.exceptionOrNull() is ContactRepository.ContactError.DuplicateAddress)
+    }
+
+    @Test
+    fun `add succeeds and writes scoped row`() = runTest {
+        val result = repo.add(
+            name = "Alice", address = testnetAddress,
+            notes = "hot wallet", tags = listOf("friend", "frequent"),
+            activeNetwork = NetworkType.TESTNET,
+        )
+        val saved = result.getOrThrow()
+        assertEquals("wallet-1", saved.walletId)
+        assertEquals("Alice", saved.name)
+        assertEquals("testnet", saved.network)
+        assertEquals("friend,frequent", saved.tags)
+        assertEquals(0, saved.useCount)
+        assertNull(saved.lastUsedAt)
+    }
+
+    @Test
+    fun `add as global writes null walletId`() = runTest {
+        val result = repo.add(
+            name = "Alice", address = testnetAddress,
+            scopedToActiveWallet = false, activeNetwork = NetworkType.TESTNET,
+        )
+        val saved = result.getOrThrow()
+        assertNull(saved.walletId)
+    }
+
+    // -- update / delete --
+
+    @Test
+    fun `update preserves address and useCount`() = runTest {
+        val original = repo.add(name = "Alice", address = testnetAddress, activeNetwork = NetworkType.TESTNET).getOrThrow()
+        contactDao.markUsed(original.id, 5_000L) // simulate prior use
+
+        fakeNow = 2_000_000L
+        repo.update(id = original.id, name = "Alice (renamed)", notes = "updated", tags = null).getOrThrow()
+
+        val fetched = contactDao.getById(original.id)!!
+        assertEquals("Alice (renamed)", fetched.name)
+        assertEquals("updated", fetched.notes)
+        assertEquals(testnetAddress, fetched.address)
+        assertEquals(1, fetched.useCount)
+        assertEquals(5_000L, fetched.lastUsedAt)
+        assertEquals(2_000_000L, fetched.updatedAt)
+    }
+
+    @Test
+    fun `update fails on unknown id`() = runTest {
+        val r = repo.update(id = "nonexistent", name = "X", notes = null, tags = null)
+        assertTrue(r.exceptionOrNull() is ContactRepository.ContactError.NotFound)
+    }
+
+    @Test
+    fun `delete removes the row`() = runTest {
+        val saved = repo.add(name = "Alice", address = testnetAddress, activeNetwork = NetworkType.TESTNET).getOrThrow()
+        repo.delete(saved.id).getOrThrow()
+        assertNull(contactDao.getById(saved.id))
+    }
+
+    // -- search / recentlyUsed / markUsed --
+
+    @Test
+    fun `search empty query returns empty list`() = runTest {
+        repo.add(name = "Alice", address = testnetAddress, activeNetwork = NetworkType.TESTNET)
+        assertEquals(emptyList<Any>(), repo.search(""))
+        assertEquals(emptyList<Any>(), repo.search("   "))
+    }
+
+    @Test
+    fun `search wraps query with LIKE wildcards`() = runTest {
+        repo.add(name = "Alice", address = testnetAddress, activeNetwork = NetworkType.TESTNET).getOrThrow()
+        val hits = repo.search("alic")
+        assertEquals(1, hits.size)
+        assertEquals("Alice", hits.first().name)
+    }
+
+    @Test
+    fun `markUsed silently no-ops for unsaved address`() = runTest {
+        repo.markUsed("ckt1_not_saved") // should not throw
+    }
+
+    @Test
+    fun `markUsed bumps counters on saved address`() = runTest {
+        val saved = repo.add(name = "Alice", address = testnetAddress, activeNetwork = NetworkType.TESTNET).getOrThrow()
+        fakeNow = 9_000L
+        repo.markUsed(testnetAddress)
+        val after = contactDao.getById(saved.id)!!
+        assertEquals(1, after.useCount)
+        assertEquals(9_000L, after.lastUsedAt)
+    }
+
+    @Test
+    fun `recentlyUsed returns nothing without an active wallet`() = runTest {
+        every { walletRepository.activeWalletIdSnapshot() } returns null
+        repo.add(
+            name = "Alice", address = testnetAddress,
+            scopedToActiveWallet = false, activeNetwork = NetworkType.TESTNET,
+        )
+        assertEquals(emptyList<Any>(), repo.recentlyUsed())
+    }
+}


### PR DESCRIPTION
Third of 9 Phase 2 sub-issues. Validation layer for the address book.

- Address parseability via `AddressUtils.getNetwork` (wraps CKB SDK Address.decode)
- Network agreement check (refuses mainnet address on testnet, and vice versa)
- Duplicate detection (`getByAddress` then surface `DuplicateAddress` error so UI can offer update-existing)
- Name length 1-64, notes length ≤256
- Address + walletId immutable on update (preserves `useCount`/`lastUsedAt` history)
- `markUsed(address)` silent no-op for unsaved recipients, atomic bump for saved ones

Tests: 18 new in `ContactRepositoryTest`. 607/607 total pass.

Refs #191

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced contact management system enabling users to add, edit, delete, and search address book contacts.
  * Automatic tracking of recently accessed contacts.
  * Built-in network compatibility validation for wallet addresses.

* **Tests**
  * Added comprehensive test coverage for contact management operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/RaheemJnr/pocket-node/pull/233?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->