### PR TITLE
feat(contacts): ContactsScreen + ContactsViewModel (#193)

### DIFF
--- a/android/app/src/main/java/com/rjnr/pocketnode/data/contacts/ContactRepository.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/contacts/ContactRepository.kt
@@ -6,6 +6,7 @@ import com.rjnr.pocketnode.data.database.entity.ContactEntity
 import com.rjnr.pocketnode.data.gateway.models.NetworkType
 import com.rjnr.pocketnode.data.wallet.AddressUtils
 import com.rjnr.pocketnode.data.wallet.WalletRepository
+import androidx.annotation.VisibleForTesting
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOf
@@ -38,8 +39,18 @@ import javax.inject.Singleton
 class ContactRepository @Inject constructor(
     private val contactDao: ContactDao,
     private val walletRepository: WalletRepository,
-    private val nowProvider: () -> Long = { System.currentTimeMillis() },
 ) {
+
+    /**
+     * Clock injection point for unit tests. Hilt always uses the default
+     * (system clock); tests overwrite this via [setClockForTest] to make
+     * `createdAt`/`updatedAt`/`lastUsedAt` assertions deterministic.
+     */
+    @VisibleForTesting
+    internal var nowProvider: () -> Long = { System.currentTimeMillis() }
+
+    @VisibleForTesting
+    internal fun setClockForTest(provider: () -> Long) { nowProvider = provider }
 
     sealed class ContactError(message: String) : Exception(message) {
         object InvalidAddress : ContactError("Address cannot be decoded")

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/contacts/ContactsScreen.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/contacts/ContactsScreen.kt
@@ -1,0 +1,229 @@
+package com.rjnr.pocketnode.ui.screens.contacts
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FloatingActionButton
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import com.composables.icons.lucide.ArrowLeft
+import com.composables.icons.lucide.Lucide
+import com.composables.icons.lucide.Plus
+import com.composables.icons.lucide.Search
+import com.composables.icons.lucide.Send
+import com.composables.icons.lucide.Users
+import com.rjnr.pocketnode.data.database.entity.ContactEntity
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ContactsScreen(
+    onNavigateBack: () -> Unit = {},
+    onNavigateToAdd: () -> Unit = {},
+    onNavigateToDetail: (String) -> Unit = {},
+    onSendToContact: (String) -> Unit = {},
+    viewModel: ContactsViewModel = hiltViewModel(),
+) {
+    val uiState by viewModel.uiState.collectAsState()
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Address Book") },
+                navigationIcon = {
+                    IconButton(onClick = onNavigateBack) {
+                        Icon(Lucide.ArrowLeft, contentDescription = "Back")
+                    }
+                },
+                colors = TopAppBarDefaults.topAppBarColors(
+                    containerColor = MaterialTheme.colorScheme.surface,
+                ),
+            )
+        },
+        floatingActionButton = {
+            FloatingActionButton(onClick = onNavigateToAdd) {
+                Icon(Lucide.Plus, contentDescription = "Add contact")
+            }
+        },
+    ) { padding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(padding),
+        ) {
+            OutlinedTextField(
+                value = uiState.query,
+                onValueChange = viewModel::onQueryChange,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp, vertical = 8.dp),
+                placeholder = { Text("Search name or address") },
+                leadingIcon = { Icon(Lucide.Search, contentDescription = null) },
+                singleLine = true,
+            )
+
+            when {
+                uiState.isLoading -> {
+                    // Subtle empty state during the initial Flow tick — usually
+                    // resolves in one frame because the in-memory DB read is fast.
+                    Spacer(Modifier.fillMaxSize())
+                }
+                uiState.contacts.isEmpty() && uiState.query.isBlank() -> {
+                    EmptyContacts(onAdd = onNavigateToAdd)
+                }
+                uiState.contacts.isEmpty() -> {
+                    NoSearchMatches(query = uiState.query)
+                }
+                else -> {
+                    LazyColumn(modifier = Modifier.fillMaxSize()) {
+                        items(uiState.contacts, key = { it.id }) { contact ->
+                            ContactRow(
+                                contact = contact,
+                                onClick = { onNavigateToDetail(contact.id) },
+                                onSend = { onSendToContact(contact.address) },
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun ContactRow(
+    contact: ContactEntity,
+    onClick: () -> Unit,
+    onSend: () -> Unit,
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(onClick = onClick)
+            .padding(horizontal = 16.dp, vertical = 12.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        ContactAvatar(name = contact.name)
+        Spacer(Modifier.size(12.dp))
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                text = contact.name,
+                style = MaterialTheme.typography.bodyLarge,
+                fontWeight = FontWeight.Medium,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+            Text(
+                text = truncateAddress(contact.address),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+        }
+        IconButton(onClick = onSend) {
+            Icon(
+                imageVector = Lucide.Send,
+                contentDescription = "Send to ${contact.name}",
+                tint = MaterialTheme.colorScheme.primary,
+            )
+        }
+    }
+}
+
+@Composable
+private fun ContactAvatar(name: String) {
+    val initial = name.firstOrNull()?.uppercaseChar()?.toString() ?: "?"
+    Box(
+        modifier = Modifier
+            .size(40.dp)
+            .clip(CircleShape)
+            .background(MaterialTheme.colorScheme.primaryContainer),
+        contentAlignment = Alignment.Center,
+    ) {
+        Text(
+            text = initial,
+            color = MaterialTheme.colorScheme.onPrimaryContainer,
+            fontWeight = FontWeight.SemiBold,
+        )
+    }
+}
+
+@Composable
+private fun EmptyContacts(onAdd: () -> Unit) {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(32.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center,
+    ) {
+        Icon(
+            imageVector = Lucide.Users,
+            contentDescription = null,
+            modifier = Modifier.size(64.dp),
+            tint = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        Spacer(Modifier.height(16.dp))
+        Text(
+            text = "No contacts yet",
+            style = MaterialTheme.typography.titleMedium,
+        )
+        Spacer(Modifier.height(8.dp))
+        Text(
+            text = "Save addresses you send to often. Tap the + button to add your first contact.",
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+    }
+}
+
+@Composable
+private fun NoSearchMatches(query: String) {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(32.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center,
+    ) {
+        Text(
+            text = "No contacts match \"$query\"",
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+    }
+}
+
+private fun truncateAddress(address: String): String {
+    if (address.length <= 18) return address
+    return address.take(10) + "…" + address.takeLast(6)
+}

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/contacts/ContactsViewModel.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/contacts/ContactsViewModel.kt
@@ -1,0 +1,79 @@
+package com.rjnr.pocketnode.ui.screens.contacts
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.rjnr.pocketnode.data.contacts.ContactRepository
+import com.rjnr.pocketnode.data.database.entity.ContactEntity
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.FlowPreview
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.debounce
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+/**
+ * Address book list screen ([#193](https://github.com/RaheemJnr/pocket-node/issues/193)).
+ *
+ * Observes the wallet-scoped contact list from [ContactRepository] and
+ * exposes a search query that filters in-memory. Search is debounced
+ * 200ms so each keystroke doesn't trigger a new Room query during
+ * fast typing. The Flow is hot — Room emits a new list when any row
+ * changes, so deletions or post-send `markUsed` bumps propagate
+ * without a manual refresh.
+ */
+@HiltViewModel
+class ContactsViewModel @Inject constructor(
+    private val contactRepository: ContactRepository,
+) : ViewModel() {
+
+    data class UiState(
+        val contacts: List<ContactEntity> = emptyList(),
+        val query: String = "",
+        val isLoading: Boolean = true,
+    )
+
+    private val _uiState = MutableStateFlow(UiState())
+    val uiState: StateFlow<UiState> = _uiState.asStateFlow()
+
+    private val queryFlow = MutableStateFlow("")
+
+    @OptIn(ExperimentalCoroutinesApi::class, FlowPreview::class)
+    private val contactsFlow = queryFlow
+        .debounce(200)
+        .distinctUntilChanged()
+        .flatMapLatest { q ->
+            if (q.isBlank()) {
+                contactRepository.observe()
+            } else {
+                flowOf(contactRepository.search(q))
+            }
+        }
+
+    init {
+        contactsFlow
+            .onEach { list ->
+                _uiState.update { it.copy(contacts = list, isLoading = false) }
+            }
+            .launchIn(viewModelScope)
+    }
+
+    fun onQueryChange(q: String) {
+        _uiState.update { it.copy(query = q) }
+        queryFlow.value = q
+    }
+
+    fun delete(id: String) {
+        viewModelScope.launch {
+            contactRepository.delete(id)
+        }
+    }
+}

--- a/android/app/src/test/java/com/rjnr/pocketnode/data/contacts/ContactRepositoryTest.kt
+++ b/android/app/src/test/java/com/rjnr/pocketnode/data/contacts/ContactRepositoryTest.kt
@@ -57,7 +57,9 @@ class ContactRepositoryTest {
         contactDao = db.contactDao()
         walletRepository = mockk(relaxed = true)
         every { walletRepository.activeWalletIdSnapshot() } returns "wallet-1"
-        repo = ContactRepository(contactDao, walletRepository, nowProvider = { fakeNow })
+        repo = ContactRepository(contactDao, walletRepository).apply {
+            setClockForTest { fakeNow }
+        }
     }
 
     @After


### PR DESCRIPTION
Address book list view. Fourth Phase 2 PR; first UI piece.

- Scaffold + TopAppBar + FAB
- Search bar with 200ms debounce
- LazyColumn rows: avatar (first letter), name, truncated address, Send trailing icon
- Empty state and no-match state
- Search query switches Flow source between `observe()` and `search()` snapshot

`ContactRepository.nowProvider` moved to @VisibleForTesting field (Hilt couldn't inject `Function0<Long>`).

Refs #193