### PR TITLE
feat(contacts): Add/Edit/Detail screens + shared form fields (#194)

### DIFF
--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/contacts/AddContactScreen.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/contacts/AddContactScreen.kt
@@ -1,0 +1,142 @@
+package com.rjnr.pocketnode.ui.screens.contacts
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.Button
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalClipboardManager
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import com.composables.icons.lucide.ArrowLeft
+import com.composables.icons.lucide.Clipboard
+import com.composables.icons.lucide.Lucide
+import com.composables.icons.lucide.ScanLine
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun AddContactScreen(
+    onNavigateBack: () -> Unit = {},
+    onNavigateToScanner: () -> Unit = {},
+    scannedAddress: String? = null,
+    viewModel: AddContactViewModel = hiltViewModel(),
+) {
+    val uiState by viewModel.uiState.collectAsState()
+    val snackbarHostState = remember { SnackbarHostState() }
+    val clipboard = LocalClipboardManager.current
+
+    LaunchedEffect(scannedAddress) {
+        scannedAddress?.takeIf { it.isNotBlank() }?.let { viewModel.onAddressChange(it) }
+    }
+
+    LaunchedEffect(uiState.saved) {
+        if (uiState.saved) onNavigateBack()
+    }
+
+    LaunchedEffect(uiState.error) {
+        uiState.error?.let {
+            snackbarHostState.showSnackbar(it)
+            viewModel.clearError()
+        }
+    }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Add contact") },
+                navigationIcon = {
+                    IconButton(onClick = onNavigateBack) {
+                        Icon(Lucide.ArrowLeft, contentDescription = "Back")
+                    }
+                },
+                colors = TopAppBarDefaults.topAppBarColors(
+                    containerColor = MaterialTheme.colorScheme.surface,
+                ),
+            )
+        },
+        snackbarHost = { SnackbarHost(snackbarHostState) },
+    ) { padding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(padding)
+                .padding(16.dp),
+        ) {
+            ContactFormFields(
+                name = uiState.name,
+                address = uiState.address,
+                notes = uiState.notes,
+                onNameChange = viewModel::onNameChange,
+                onAddressChange = viewModel::onAddressChange,
+                onNotesChange = viewModel::onNotesChange,
+                addressTrailingIcon = {
+                    Box {
+                        IconButton(onClick = onNavigateToScanner) {
+                            Icon(Lucide.ScanLine, contentDescription = "Scan QR")
+                        }
+                    }
+                },
+            )
+
+            Spacer(Modifier.height(8.dp))
+
+            // Paste-from-clipboard affordance — a separate row so the
+            // address field's trailing icon stays the QR scan trigger
+            // (paste is secondary).
+            androidx.compose.material3.TextButton(
+                onClick = {
+                    val text = clipboard.getText()?.text.orEmpty()
+                    if (text.isNotBlank()) viewModel.onAddressChange(text)
+                },
+            ) {
+                Icon(
+                    imageVector = Lucide.Clipboard,
+                    contentDescription = null,
+                    modifier = Modifier.size(16.dp),
+                )
+                Spacer(Modifier.size(8.dp))
+                Text("Paste address from clipboard")
+            }
+
+            Spacer(Modifier.height(24.dp))
+
+            Button(
+                onClick = { viewModel.save() },
+                modifier = Modifier.fillMaxWidth(),
+                enabled = !uiState.isSaving && uiState.name.isNotBlank() && uiState.address.isNotBlank(),
+            ) {
+                if (uiState.isSaving) {
+                    CircularProgressIndicator(
+                        modifier = Modifier.size(20.dp),
+                        strokeWidth = 2.dp,
+                        color = MaterialTheme.colorScheme.onPrimary,
+                    )
+                } else {
+                    Text("Save contact")
+                }
+            }
+        }
+    }
+}

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/contacts/AddContactViewModel.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/contacts/AddContactViewModel.kt
@@ -1,0 +1,71 @@
+package com.rjnr.pocketnode.ui.screens.contacts
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.rjnr.pocketnode.data.contacts.ContactRepository
+import com.rjnr.pocketnode.data.gateway.GatewayRepository
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class AddContactViewModel @Inject constructor(
+    private val contactRepository: ContactRepository,
+    private val gatewayRepository: GatewayRepository,
+) : ViewModel() {
+
+    data class UiState(
+        val name: String = "",
+        val address: String = "",
+        val notes: String = "",
+        val isSaving: Boolean = false,
+        val saved: Boolean = false,
+        val error: String? = null,
+    )
+
+    private val _uiState = MutableStateFlow(UiState())
+    val uiState: StateFlow<UiState> = _uiState.asStateFlow()
+
+    fun onNameChange(v: String) = _uiState.update { it.copy(name = v) }
+    fun onAddressChange(v: String) = _uiState.update { it.copy(address = v.trim()) }
+    fun onNotesChange(v: String) = _uiState.update { it.copy(notes = v) }
+    fun clearError() = _uiState.update { it.copy(error = null) }
+
+    fun save() {
+        val state = _uiState.value
+        if (state.name.isBlank() || state.address.isBlank()) {
+            _uiState.update { it.copy(error = "Name and address are required") }
+            return
+        }
+        _uiState.update { it.copy(isSaving = true, error = null) }
+        viewModelScope.launch {
+            val result = contactRepository.add(
+                name = state.name,
+                address = state.address,
+                notes = state.notes.ifBlank { null },
+                tags = null,
+                activeNetwork = gatewayRepository.currentNetwork,
+            )
+            result
+                .onSuccess { _uiState.update { it.copy(isSaving = false, saved = true) } }
+                .onFailure { e ->
+                    _uiState.update { it.copy(isSaving = false, error = formatError(e)) }
+                }
+        }
+    }
+
+    private fun formatError(e: Throwable): String = when (e) {
+        is ContactRepository.ContactError.InvalidAddress -> "Address could not be decoded — check the format"
+        is ContactRepository.ContactError.WrongNetwork ->
+            "This address is for ${e.actual.name.lowercase()}; switch networks or pick a different address"
+        is ContactRepository.ContactError.DuplicateAddress -> "An existing contact already uses this address"
+        is ContactRepository.ContactError.InvalidName -> "Name must be 1-64 characters"
+        is ContactRepository.ContactError.NotesTooLong -> "Notes must be 256 characters or fewer"
+        is ContactRepository.ContactError.NoActiveWallet -> "No active wallet to scope this contact to"
+        else -> e.message ?: "Could not save contact"
+    }
+}

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/contacts/ContactDetailScreen.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/contacts/ContactDetailScreen.kt
@@ -1,0 +1,229 @@
+package com.rjnr.pocketnode.ui.screens.contacts
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.platform.LocalClipboardManager
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import com.composables.icons.lucide.ArrowLeft
+import com.composables.icons.lucide.Copy
+import com.composables.icons.lucide.Lucide
+import com.composables.icons.lucide.Pencil
+import com.composables.icons.lucide.Send
+import com.composables.icons.lucide.Trash2
+import kotlinx.coroutines.launch
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ContactDetailScreen(
+    onNavigateBack: () -> Unit = {},
+    onSend: (String) -> Unit = {},
+    onEdit: (String) -> Unit = {},
+    viewModel: ContactDetailViewModel = hiltViewModel(),
+) {
+    val uiState by viewModel.uiState.collectAsState()
+    val snackbarHostState = remember { SnackbarHostState() }
+    val clipboard = LocalClipboardManager.current
+    val scope = rememberCoroutineScopeForSnack()
+
+    LaunchedEffect(uiState.deleted) {
+        if (uiState.deleted) onNavigateBack()
+    }
+
+    LaunchedEffect(uiState.error) {
+        uiState.error?.let {
+            snackbarHostState.showSnackbar(it)
+            viewModel.clearError()
+        }
+    }
+
+    if (uiState.showDeleteConfirm) {
+        AlertDialog(
+            onDismissRequest = { viewModel.cancelDelete() },
+            title = { Text("Delete contact?") },
+            text = { Text("This removes the address book entry. Your sent transactions are unaffected.") },
+            confirmButton = {
+                Button(
+                    onClick = { viewModel.confirmDelete() },
+                    colors = ButtonDefaults.buttonColors(
+                        containerColor = MaterialTheme.colorScheme.error,
+                    ),
+                ) { Text("Delete") }
+            },
+            dismissButton = {
+                TextButton(onClick = { viewModel.cancelDelete() }) { Text("Cancel") }
+            },
+        )
+    }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Contact") },
+                navigationIcon = {
+                    IconButton(onClick = onNavigateBack) {
+                        Icon(Lucide.ArrowLeft, contentDescription = "Back")
+                    }
+                },
+                actions = {
+                    val id = uiState.contact?.id
+                    if (id != null) {
+                        IconButton(onClick = { onEdit(id) }) {
+                            Icon(Lucide.Pencil, contentDescription = "Edit")
+                        }
+                        IconButton(onClick = { viewModel.requestDelete() }) {
+                            Icon(
+                                imageVector = Lucide.Trash2,
+                                contentDescription = "Delete",
+                                tint = MaterialTheme.colorScheme.error,
+                            )
+                        }
+                    }
+                },
+                colors = TopAppBarDefaults.topAppBarColors(
+                    containerColor = MaterialTheme.colorScheme.surface,
+                ),
+            )
+        },
+        snackbarHost = { SnackbarHost(snackbarHostState) },
+    ) { padding ->
+        val contact = uiState.contact
+        if (contact == null) {
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(padding),
+                contentAlignment = Alignment.Center,
+            ) {
+                Text(
+                    text = if (uiState.isLoading) "Loading…" else "Contact not found",
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+            return@Scaffold
+        }
+
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(padding)
+                .padding(16.dp),
+        ) {
+            Text(
+                text = contact.name,
+                style = MaterialTheme.typography.headlineSmall,
+                fontWeight = FontWeight.SemiBold,
+            )
+            Spacer(Modifier.height(4.dp))
+            Text(
+                text = "${contact.network.replaceFirstChar { it.uppercase() }} network",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+
+            Spacer(Modifier.height(24.dp))
+
+            Card(
+                modifier = Modifier.fillMaxWidth(),
+                shape = RoundedCornerShape(12.dp),
+                colors = CardDefaults.cardColors(
+                    containerColor = MaterialTheme.colorScheme.surfaceVariant,
+                ),
+            ) {
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(16.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    Text(
+                        text = contact.address,
+                        modifier = Modifier.weight(1f),
+                        style = MaterialTheme.typography.bodySmall,
+                        fontFamily = FontFamily.Monospace,
+                    )
+                    IconButton(onClick = {
+                        clipboard.setText(AnnotatedString(contact.address))
+                        scope.launch { snackbarHostState.showSnackbar("Address copied") }
+                    }) {
+                        Icon(Lucide.Copy, contentDescription = "Copy address")
+                    }
+                }
+            }
+
+            if (!contact.notes.isNullOrBlank()) {
+                Spacer(Modifier.height(16.dp))
+                Text(
+                    text = "Notes",
+                    style = MaterialTheme.typography.labelMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+                Spacer(Modifier.height(4.dp))
+                Text(contact.notes, style = MaterialTheme.typography.bodyMedium)
+            }
+
+            if (contact.useCount > 0) {
+                Spacer(Modifier.height(16.dp))
+                Text(
+                    text = "Sent to ${contact.useCount} time${if (contact.useCount == 1) "" else "s"}",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+
+            Spacer(Modifier.height(32.dp))
+
+            Button(
+                onClick = { onSend(contact.address) },
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                Icon(Lucide.Send, contentDescription = null)
+                Spacer(Modifier.size(8.dp))
+                Text("Send to ${contact.name}")
+            }
+        }
+    }
+}
+
+@Composable
+private fun rememberCoroutineScopeForSnack() = androidx.compose.runtime.rememberCoroutineScope()

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/contacts/ContactDetailViewModel.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/contacts/ContactDetailViewModel.kt
@@ -1,0 +1,61 @@
+package com.rjnr.pocketnode.ui.screens.contacts
+
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.rjnr.pocketnode.data.contacts.ContactRepository
+import com.rjnr.pocketnode.data.database.entity.ContactEntity
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class ContactDetailViewModel @Inject constructor(
+    savedStateHandle: SavedStateHandle,
+    private val contactRepository: ContactRepository,
+) : ViewModel() {
+
+    private val contactId: String = savedStateHandle["id"]
+        ?: error("ContactDetailScreen requires an 'id' nav arg")
+
+    data class UiState(
+        val contact: ContactEntity? = null,
+        val isLoading: Boolean = true,
+        val showDeleteConfirm: Boolean = false,
+        val deleted: Boolean = false,
+        val error: String? = null,
+    )
+
+    private val _uiState = MutableStateFlow(UiState())
+    val uiState: StateFlow<UiState> = _uiState.asStateFlow()
+
+    init { reload() }
+
+    fun reload() {
+        viewModelScope.launch {
+            val c = contactRepository.get(contactId)
+            _uiState.update { it.copy(isLoading = false, contact = c) }
+        }
+    }
+
+    fun requestDelete() = _uiState.update { it.copy(showDeleteConfirm = true) }
+    fun cancelDelete() = _uiState.update { it.copy(showDeleteConfirm = false) }
+
+    fun confirmDelete() {
+        viewModelScope.launch {
+            contactRepository.delete(contactId)
+                .onSuccess { _uiState.update { it.copy(showDeleteConfirm = false, deleted = true) } }
+                .onFailure { e ->
+                    _uiState.update {
+                        it.copy(showDeleteConfirm = false, error = e.message ?: "Could not delete")
+                    }
+                }
+        }
+    }
+
+    fun clearError() = _uiState.update { it.copy(error = null) }
+}

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/contacts/ContactFormFields.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/contacts/ContactFormFields.kt
@@ -1,0 +1,60 @@
+package com.rjnr.pocketnode.ui.screens.contacts
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+
+/**
+ * Shared form fields used by both [AddContactScreen] and
+ * [EditContactScreen]. Address is editable only on add — edit screens
+ * pass [addressEditable] = false to keep the row's identity stable
+ * (the existing useCount/lastUsedAt history is pegged to the address).
+ */
+@Composable
+fun ContactFormFields(
+    name: String,
+    address: String,
+    notes: String,
+    onNameChange: (String) -> Unit,
+    onAddressChange: (String) -> Unit,
+    onNotesChange: (String) -> Unit,
+    addressEditable: Boolean = true,
+    addressTrailingIcon: (@Composable () -> Unit)? = null,
+    modifier: Modifier = Modifier,
+) {
+    Column(modifier = modifier) {
+        OutlinedTextField(
+            value = name,
+            onValueChange = onNameChange,
+            modifier = Modifier.fillMaxWidth(),
+            label = { Text("Name") },
+            singleLine = true,
+        )
+        Spacer(Modifier.height(12.dp))
+        OutlinedTextField(
+            value = address,
+            onValueChange = onAddressChange,
+            modifier = Modifier.fillMaxWidth(),
+            label = { Text("CKB address") },
+            placeholder = { Text("ckb1… or ckt1…") },
+            singleLine = true,
+            enabled = addressEditable,
+            trailingIcon = addressTrailingIcon,
+        )
+        Spacer(Modifier.height(12.dp))
+        OutlinedTextField(
+            value = notes,
+            onValueChange = onNotesChange,
+            modifier = Modifier.fillMaxWidth(),
+            label = { Text("Notes (optional)") },
+            minLines = 2,
+            maxLines = 4,
+        )
+    }
+}

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/contacts/EditContactScreen.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/contacts/EditContactScreen.kt
@@ -1,0 +1,104 @@
+package com.rjnr.pocketnode.ui.screens.contacts
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.Button
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import com.composables.icons.lucide.ArrowLeft
+import com.composables.icons.lucide.Lucide
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun EditContactScreen(
+    onNavigateBack: () -> Unit = {},
+    viewModel: EditContactViewModel = hiltViewModel(),
+) {
+    val uiState by viewModel.uiState.collectAsState()
+    val snackbarHostState = remember { SnackbarHostState() }
+
+    LaunchedEffect(uiState.saved) {
+        if (uiState.saved) onNavigateBack()
+    }
+
+    LaunchedEffect(uiState.error) {
+        uiState.error?.let {
+            snackbarHostState.showSnackbar(it)
+            viewModel.clearError()
+        }
+    }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Edit contact") },
+                navigationIcon = {
+                    IconButton(onClick = onNavigateBack) {
+                        Icon(Lucide.ArrowLeft, contentDescription = "Back")
+                    }
+                },
+                colors = TopAppBarDefaults.topAppBarColors(
+                    containerColor = MaterialTheme.colorScheme.surface,
+                ),
+            )
+        },
+        snackbarHost = { SnackbarHost(snackbarHostState) },
+    ) { padding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(padding)
+                .padding(16.dp),
+        ) {
+            ContactFormFields(
+                name = uiState.name,
+                address = uiState.address,
+                notes = uiState.notes,
+                onNameChange = viewModel::onNameChange,
+                onAddressChange = {}, // address is locked
+                onNotesChange = viewModel::onNotesChange,
+                addressEditable = false,
+            )
+
+            Spacer(Modifier.height(24.dp))
+
+            Button(
+                onClick = { viewModel.save() },
+                modifier = Modifier.fillMaxWidth(),
+                enabled = !uiState.isSaving && uiState.name.isNotBlank(),
+            ) {
+                if (uiState.isSaving) {
+                    CircularProgressIndicator(
+                        modifier = Modifier.size(20.dp),
+                        strokeWidth = 2.dp,
+                        color = MaterialTheme.colorScheme.onPrimary,
+                    )
+                } else {
+                    Text("Save changes")
+                }
+            }
+        }
+    }
+}

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/contacts/EditContactViewModel.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/contacts/EditContactViewModel.kt
@@ -1,0 +1,77 @@
+package com.rjnr.pocketnode.ui.screens.contacts
+
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.rjnr.pocketnode.data.contacts.ContactRepository
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class EditContactViewModel @Inject constructor(
+    savedStateHandle: SavedStateHandle,
+    private val contactRepository: ContactRepository,
+) : ViewModel() {
+
+    private val contactId: String = savedStateHandle["id"]
+        ?: error("EditContactScreen requires an 'id' nav arg")
+
+    data class UiState(
+        val name: String = "",
+        val address: String = "",
+        val notes: String = "",
+        val isLoading: Boolean = true,
+        val isSaving: Boolean = false,
+        val saved: Boolean = false,
+        val error: String? = null,
+    )
+
+    private val _uiState = MutableStateFlow(UiState())
+    val uiState: StateFlow<UiState> = _uiState.asStateFlow()
+
+    init {
+        viewModelScope.launch {
+            val contact = contactRepository.get(contactId)
+            if (contact == null) {
+                _uiState.update { it.copy(isLoading = false, error = "Contact not found") }
+                return@launch
+            }
+            _uiState.update {
+                it.copy(
+                    isLoading = false,
+                    name = contact.name,
+                    address = contact.address,
+                    notes = contact.notes.orEmpty(),
+                )
+            }
+        }
+    }
+
+    fun onNameChange(v: String) = _uiState.update { it.copy(name = v) }
+    fun onNotesChange(v: String) = _uiState.update { it.copy(notes = v) }
+    fun clearError() = _uiState.update { it.copy(error = null) }
+
+    fun save() {
+        val state = _uiState.value
+        _uiState.update { it.copy(isSaving = true, error = null) }
+        viewModelScope.launch {
+            contactRepository.update(
+                id = contactId,
+                name = state.name,
+                notes = state.notes.ifBlank { null },
+                tags = null,
+            )
+                .onSuccess { _uiState.update { it.copy(isSaving = false, saved = true) } }
+                .onFailure { e ->
+                    _uiState.update {
+                        it.copy(isSaving = false, error = e.message ?: "Could not save")
+                    }
+                }
+        }
+    }
+}


### PR DESCRIPTION
Contact CRUD UI. Three screens + three ViewModels + a shared `ContactFormFields` composable.

- **AddContactScreen**: form, QR scan trigger, paste-from-clipboard, ContactError → user-facing message formatter
- **EditContactScreen**: prefilled form, address field locked (preserves `useCount`/`lastUsedAt` history)
- **ContactDetailScreen**: name, copyable monospace address, network badge, notes, usage count, edit/delete actions, Send CTA

Nav routes + Settings entry land in #195.

Refs #194

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Contact management system: Create new contacts, view details, edit information, and delete with confirmation
  * Flexible contact form with name, CKB address, and optional notes fields
  * QR code scanner integration for quick address input
  * Clipboard features: paste from clipboard and copy addresses with visual feedback
  * Comprehensive error handling and loading states

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/RaheemJnr/pocket-node/pull/236?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->