### PR TITLE
feat(contacts): NavGraph routes + Settings entry (#195)

### DIFF
--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/MainScreen.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/MainScreen.kt
@@ -47,6 +47,7 @@ fun MainScreen(
     onNavigateToPinVerify: () -> Unit = {},
     onNavigateToSecurityChecklist: () -> Unit = {},
     onNavigateToWalletManager: () -> Unit = {},
+    onNavigateToContacts: () -> Unit = {},
     onNavigateToFaq: (anchor: String?) -> Unit = {},
     daoPinVerified: Boolean = false,
 ) {
@@ -169,6 +170,7 @@ fun MainScreen(
                     onNavigateToSecuritySettings = onNavigateToSecuritySettings,
                     onNavigateToImport = onNavigateToImport,
                     onNavigateToWalletManager = onNavigateToWalletManager,
+                    onNavigateToContacts = onNavigateToContacts,
                     onNavigateToFaq = onNavigateToFaq,
                 )
             }

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/navigation/NavGraph.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/navigation/NavGraph.kt
@@ -38,7 +38,22 @@ import com.rjnr.pocketnode.ui.screens.wallet.WalletSettingsViewModel
 sealed class Screen(val route: String) {
     object Home : Screen("home")
     object Main : Screen("main")
-    object Send : Screen("send")
+    object Send : Screen("send") {
+        /** Build a Send route with optional recipient/amount prefill query args. */
+        fun routeWithPrefill(recipient: String?, amountShannons: Long?): String {
+            if (recipient == null && amountShannons == null) return route
+            val r = recipient?.let { android.net.Uri.encode(it) }
+            return buildString {
+                append(route)
+                append("?")
+                if (r != null) append("recipient=$r")
+                if (amountShannons != null) {
+                    if (r != null) append("&")
+                    append("amountShannons=$amountShannons")
+                }
+            }
+        }
+    }
     object Receive : Screen("receive")
     object Scanner : Screen("scanner")
     object NodeStatus : Screen("node_status")
@@ -66,6 +81,14 @@ sealed class Screen(val route: String) {
     object Faq : Screen("faq?anchor={anchor}") {
         fun routeWithAnchor(anchor: String?): String =
             if (anchor.isNullOrBlank()) "faq" else "faq?anchor=$anchor"
+    }
+    object Contacts : Screen("contacts")
+    object AddContact : Screen("contacts/add")
+    object EditContact : Screen("contacts/edit/{id}") {
+        fun createRoute(id: String) = "contacts/edit/$id"
+    }
+    object ContactDetail : Screen("contacts/detail/{id}") {
+        fun createRoute(id: String) = "contacts/detail/$id"
     }
 }
 
@@ -325,6 +348,9 @@ fun CkbNavGraph(
                 onNavigateToWalletManager = {
                     navController.navigate(Screen.WalletManager.route)
                 },
+                onNavigateToContacts = {
+                    navController.navigate(Screen.Contacts.route)
+                },
                 onNavigateToFaq = { anchor ->
                     navController.navigate(Screen.Faq.routeWithAnchor(anchor))
                 },
@@ -527,6 +553,57 @@ fun CkbNavGraph(
             ),
         ) {
             FaqScreen(onBack = { navController.popBackStack() })
+        }
+
+        // -- Address book (#193, #194, #195) --
+
+        composable(Screen.Contacts.route) {
+            com.rjnr.pocketnode.ui.screens.contacts.ContactsScreen(
+                onNavigateBack = { navController.popBackStack() },
+                onNavigateToAdd = { navController.navigate(Screen.AddContact.route) },
+                onNavigateToDetail = { id ->
+                    navController.navigate(Screen.ContactDetail.createRoute(id))
+                },
+                onSendToContact = { address ->
+                    navController.navigate(Screen.Send.routeWithPrefill(address, null))
+                },
+            )
+        }
+
+        composable(Screen.AddContact.route) { backStackEntry ->
+            // Scanner returns to AddContact the same way it returns to Send:
+            // via the previous back stack entry's savedStateHandle.
+            com.rjnr.pocketnode.ui.screens.contacts.AddContactScreen(
+                onNavigateBack = { navController.popBackStack() },
+                onNavigateToScanner = { navController.navigate(Screen.Scanner.route) },
+                scannedAddress = backStackEntry.savedStateHandle.get<String>("scanned_address"),
+            )
+        }
+
+        composable(
+            route = Screen.EditContact.route,
+            arguments = listOf(navArgument("id") { type = NavType.StringType }),
+        ) {
+            com.rjnr.pocketnode.ui.screens.contacts.EditContactScreen(
+                onNavigateBack = { navController.popBackStack() },
+            )
+        }
+
+        composable(
+            route = Screen.ContactDetail.route,
+            arguments = listOf(navArgument("id") { type = NavType.StringType }),
+        ) {
+            com.rjnr.pocketnode.ui.screens.contacts.ContactDetailScreen(
+                onNavigateBack = { navController.popBackStack() },
+                onEdit = { id -> navController.navigate(Screen.EditContact.createRoute(id)) },
+                onSend = { address ->
+                    // Pop back to Contacts then push Send so the back stack
+                    // is Contacts → Send rather than Contacts → Detail → Send.
+                    navController.navigate(Screen.Send.routeWithPrefill(address, null)) {
+                        popUpTo(Screen.ContactDetail.route) { inclusive = true }
+                    }
+                },
+            )
         }
     }
 }

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/settings/SettingsScreen.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/settings/SettingsScreen.kt
@@ -72,6 +72,7 @@ import com.composables.icons.lucide.RefreshCw
 import com.composables.icons.lucide.Shield
 import com.composables.icons.lucide.ShieldCheck
 import com.composables.icons.lucide.Terminal
+import com.composables.icons.lucide.Users
 import com.composables.icons.lucide.Wallet
 import com.rjnr.pocketnode.BuildConfig
 import com.rjnr.pocketnode.data.gateway.models.NetworkType
@@ -99,6 +100,7 @@ fun SettingsScreen(
     onNavigateToSecuritySettings: () -> Unit = {},
     onNavigateToImport: () -> Unit = {},
     onNavigateToWalletManager: () -> Unit = {},
+    onNavigateToContacts: () -> Unit = {},
     onNavigateToFaq: (anchor: String?) -> Unit = {},
     viewModel: SettingsViewModel = hiltViewModel()
 ) {
@@ -340,6 +342,7 @@ fun SettingsScreen(
         onNavigateToNodeStatus,
         context,
         onNavigateToWalletManager = onNavigateToWalletManager,
+        onNavigateToContacts = onNavigateToContacts,
         onNavigateToFaq = { onNavigateToFaq(null) },
         showSyncDialog = { viewModel.showSyncDialog() },
         showSyncStrategyDialog = { viewModel.showSyncStrategyDialog() },
@@ -373,6 +376,7 @@ private fun SettingsScreenUI(
     onNavigateToNodeStatus: () -> Unit,
     context: Context,
     onNavigateToWalletManager: () -> Unit = {},
+    onNavigateToContacts: () -> Unit = {},
     onNavigateToFaq: () -> Unit = {},
     showSyncDialog: () -> Unit,
     showSyncStrategyDialog: () -> Unit = {},
@@ -419,6 +423,14 @@ private fun SettingsScreenUI(
                     icon = Lucide.Wallet,
                     title = "Manage Wallets",
                     onClick = onNavigateToWalletManager
+                )
+            }
+
+            item {
+                SettingsLinkRow(
+                    icon = Lucide.Users,
+                    title = "Address Book",
+                    onClick = onNavigateToContacts,
                 )
             }
 


### PR DESCRIPTION
Wires the four address-book screens into navigation and adds the Settings entry point.

- 4 new routes (Contacts / AddContact / EditContact / ContactDetail)
- `Screen.Send.routeWithPrefill` helper factored out so the contacts flow can reuse the prefill path Send already supports
- ContactDetail → Send pops the detail entry so back returns to the Contacts list
- Settings gains an "Address Book" row (Users icon)

Refs #195