### PR TITLE
feat(send): contact autocomplete + picker sheet (#196)

### DIFF
--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/send/ContactPickerSheet.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/send/ContactPickerSheet.kt
@@ -1,0 +1,173 @@
+package com.rjnr.pocketnode.ui.screens.send
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.SheetState
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import com.composables.icons.lucide.Lucide
+import com.composables.icons.lucide.Search
+import com.rjnr.pocketnode.data.database.entity.ContactEntity
+
+/**
+ * Modal bottom sheet that surfaces the user's saved contacts during
+ * Send. Empty query shows the top-N recently-used contacts; non-empty
+ * query falls through to the same LIKE-wildcarded search the Send
+ * autocomplete uses, but with no result cap and a scrollable list.
+ *
+ * The picker pulls fresh data on every query change rather than
+ * observing a Flow — Send is a short-lived screen and Contacts edits
+ * during a send are rare. Snapshot reads keep the implementation
+ * straightforward.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ContactPickerSheet(
+    sheetState: SheetState,
+    onDismiss: () -> Unit,
+    onContactPicked: (ContactEntity) -> Unit,
+    loadContacts: suspend (String) -> List<ContactEntity>,
+) {
+    var query by remember { mutableStateOf("") }
+    var contacts by remember { mutableStateOf<List<ContactEntity>>(emptyList()) }
+
+    LaunchedEffect(query) {
+        contacts = loadContacts(query)
+    }
+
+    ModalBottomSheet(
+        onDismissRequest = onDismiss,
+        sheetState = sheetState,
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp, vertical = 8.dp),
+        ) {
+            Text(
+                text = "Send to contact",
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.SemiBold,
+            )
+            Spacer(Modifier.height(12.dp))
+
+            OutlinedTextField(
+                value = query,
+                onValueChange = { query = it },
+                modifier = Modifier.fillMaxWidth(),
+                placeholder = { Text("Search name or address") },
+                leadingIcon = { Icon(Lucide.Search, contentDescription = null) },
+                singleLine = true,
+            )
+
+            Spacer(Modifier.height(8.dp))
+
+            if (contacts.isEmpty()) {
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .heightIn(min = 120.dp)
+                        .padding(24.dp),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    Text(
+                        text = if (query.isBlank())
+                            "No saved contacts yet. Add one from Settings → Address Book."
+                        else
+                            "No matches for \"$query\"",
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+            } else {
+                LazyColumn(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .heightIn(max = 320.dp),
+                ) {
+                    items(contacts, key = { it.id }) { contact ->
+                        ContactPickerRow(
+                            contact = contact,
+                            onClick = { onContactPicked(contact) },
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun ContactPickerRow(contact: ContactEntity, onClick: () -> Unit) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(onClick = onClick)
+            .padding(vertical = 12.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        val initial = contact.name.firstOrNull()?.uppercaseChar()?.toString() ?: "?"
+        Box(
+            modifier = Modifier
+                .size(36.dp)
+                .clip(CircleShape)
+                .background(MaterialTheme.colorScheme.primaryContainer),
+            contentAlignment = Alignment.Center,
+        ) {
+            Text(
+                text = initial,
+                color = MaterialTheme.colorScheme.onPrimaryContainer,
+                fontWeight = FontWeight.SemiBold,
+            )
+        }
+        Spacer(Modifier.size(12.dp))
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                text = contact.name,
+                style = MaterialTheme.typography.bodyLarge,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+            Text(
+                text = truncateAddress(contact.address),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+        }
+    }
+}
+
+private fun truncateAddress(address: String): String {
+    if (address.length <= 18) return address
+    return address.take(10) + "…" + address.takeLast(6)
+}

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/send/SendScreen.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/send/SendScreen.kt
@@ -77,6 +77,7 @@ import com.composables.icons.lucide.CircleCheck
 import com.composables.icons.lucide.Lucide
 import com.composables.icons.lucide.ScanLine
 import com.composables.icons.lucide.TriangleAlert
+import com.composables.icons.lucide.Users
 import com.composables.icons.lucide.X
 import com.rjnr.pocketnode.data.database.entity.WalletEntity
 import com.rjnr.pocketnode.data.gateway.models.NetworkType
@@ -204,10 +205,27 @@ fun SendScreen(
         )
     }
 
+    var showContactPicker by remember { mutableStateOf(false) }
+    val pickerSheetState = androidx.compose.material3.rememberModalBottomSheetState(skipPartiallyExpanded = true)
+
+    if (showContactPicker) {
+        ContactPickerSheet(
+            sheetState = pickerSheetState,
+            onDismiss = { showContactPicker = false },
+            onContactPicked = { contact ->
+                viewModel.selectContact(contact)
+                showContactPicker = false
+            },
+            loadContacts = { q -> viewModel.searchContacts(q) },
+        )
+    }
+
     SendScreenUI(
         onNavigateBack = onNavigateBack,
         uiState = uiState,
         onNavigateToScanner = onNavigateToScanner,
+        onOpenContactPicker = { showContactPicker = true },
+        onSuggestionPicked = { viewModel.selectContact(it) },
         updateRecipient = viewModel::updateRecipient,
         updateAmount = viewModel::updateAmount,
         setMaxAmount = viewModel::setMaxAmount,
@@ -234,10 +252,12 @@ private fun SendScreenUI(
     onNavigateBack: () -> Unit,
     uiState: SendUiState,
     onNavigateToScanner: () -> Unit,
+    onOpenContactPicker: () -> Unit = {},
+    onSuggestionPicked: (com.rjnr.pocketnode.data.database.entity.ContactEntity) -> Unit = {},
     updateRecipient: (recipientAddress: String) -> Unit,
     updateAmount: (amount: String) -> Unit,
     setMaxAmount: () -> Unit,
-    sendTransaction: () -> Unit
+    sendTransaction: () -> Unit,
 ) {
     Scaffold(
         containerColor = MaterialTheme.colorScheme.surface,
@@ -338,9 +358,63 @@ private fun SendScreenUI(
                     }
                 )
                 Icon(
+                    imageVector = Lucide.Users,
+                    contentDescription = "Pick from contacts",
+                    modifier = Modifier.clickable { onOpenContactPicker() }
+                )
+                Icon(
                     imageVector = Lucide.ScanLine,
                     contentDescription = "Scan",
                     modifier = Modifier.clickable{onNavigateToScanner()}
+                )
+            }
+
+            // Autocomplete suggestions (#196). Hidden when the field has an
+            // exact-match contact or when the user hasn't typed anything yet.
+            if (uiState.recipientSuggestions.isNotEmpty()) {
+                Spacer(modifier = Modifier.height(4.dp))
+                Column(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .background(
+                            MaterialTheme.colorScheme.surfaceVariant,
+                            RoundedCornerShape(8.dp),
+                        ),
+                ) {
+                    uiState.recipientSuggestions.forEach { contact ->
+                        Row(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .clickable { onSuggestionPicked(contact) }
+                                .padding(horizontal = 12.dp, vertical = 8.dp),
+                            verticalAlignment = Alignment.CenterVertically,
+                        ) {
+                            Column(modifier = Modifier.weight(1f)) {
+                                Text(
+                                    text = contact.name,
+                                    style = MaterialTheme.typography.bodyMedium,
+                                    fontWeight = FontWeight.Medium,
+                                )
+                                Text(
+                                    text = contact.address.take(20) + "…",
+                                    style = MaterialTheme.typography.bodySmall,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                )
+                            }
+                        }
+                    }
+                }
+            }
+
+            // Saved-contact inline hint. Shown when the recipient address
+            // exactly matches a contact — useful confirmation that the user
+            // is sending to someone they know.
+            uiState.matchedContact?.let { contact ->
+                Spacer(modifier = Modifier.height(4.dp))
+                Text(
+                    text = "Saved as ${contact.name}",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.primary,
                 )
             }
 

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/send/SendViewModel.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/send/SendViewModel.kt
@@ -6,7 +6,9 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.rjnr.pocketnode.data.auth.AuthManager
 import com.rjnr.pocketnode.data.auth.PinManager
+import com.rjnr.pocketnode.data.contacts.ContactRepository
 import com.rjnr.pocketnode.data.database.dao.KeyMaterialDao
+import com.rjnr.pocketnode.data.database.entity.ContactEntity
 import com.rjnr.pocketnode.data.database.entity.WalletEntity
 import com.rjnr.pocketnode.data.gateway.GatewayRepository
 import com.rjnr.pocketnode.data.gateway.models.NetworkType
@@ -50,7 +52,15 @@ data class SendUiState(
     val burnWarning: String? = null,
     val requiresAuth: Boolean = false,
     val authMethod: AuthMethod? = null,
-    val otherWallets: List<WalletEntity> = emptyList()
+    val otherWallets: List<WalletEntity> = emptyList(),
+    /**
+     * Autocomplete suggestions matching the current recipient field.
+     * Populated 200ms after the user stops typing. Empty when the
+     * field is blank or the user has tapped a suggestion. (#196)
+     */
+    val recipientSuggestions: List<ContactEntity> = emptyList(),
+    /** Contact whose address exactly matches the typed recipient. */
+    val matchedContact: ContactEntity? = null,
 )
 
 @HiltViewModel
@@ -63,6 +73,7 @@ class SendViewModel @Inject constructor(
     private val walletRepository: WalletRepository,
     private val walletKeyReader: WalletKeyReader,
     private val keyMaterialDao: KeyMaterialDao,
+    private val contactRepository: ContactRepository,
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow(SendUiState())
@@ -117,9 +128,54 @@ class SendViewModel @Inject constructor(
         }
     }
 
+    private var suggestionsJob: kotlinx.coroutines.Job? = null
+
     fun updateRecipient(address: String) {
         _uiState.update { it.copy(recipientAddress = address, error = null) }
+        // Debounced autocomplete + saved-contact lookup. Cancel any in-flight
+        // search so each keystroke supersedes the previous one. (#196)
+        suggestionsJob?.cancel()
+        if (address.isBlank()) {
+            _uiState.update { it.copy(recipientSuggestions = emptyList(), matchedContact = null) }
+            return
+        }
+        suggestionsJob = viewModelScope.launch {
+            kotlinx.coroutines.delay(200)
+            val matches = contactRepository.search(address).take(5)
+            val exactMatch = matches.firstOrNull { it.address == address }
+                ?: contactRepository.getByAddress(address)
+            _uiState.update {
+                it.copy(
+                    recipientSuggestions = if (exactMatch != null) emptyList() else matches,
+                    matchedContact = exactMatch,
+                )
+            }
+        }
     }
+
+    /**
+     * Pick a contact from the autocomplete dropdown or the picker sheet.
+     * Fills the recipient field and clears suggestions so the dropdown
+     * dismisses.
+     */
+    fun selectContact(contact: ContactEntity) {
+        suggestionsJob?.cancel()
+        _uiState.update {
+            it.copy(
+                recipientAddress = contact.address,
+                recipientSuggestions = emptyList(),
+                matchedContact = contact,
+                error = null,
+            )
+        }
+    }
+
+    /** Snapshot of recent contacts for the picker sheet's empty-query state. */
+    suspend fun recentContacts(): List<ContactEntity> = contactRepository.recentlyUsed()
+
+    /** Snapshot of contacts matching [query] for the picker sheet search. */
+    suspend fun searchContacts(query: String): List<ContactEntity> =
+        if (query.isBlank()) recentContacts() else contactRepository.search(query)
 
     fun updateAmount(amount: String) {
         val sanitized = sanitizeAmount(amount) ?: return  // silently reject invalid chars


### PR DESCRIPTION
Two interaction modes for picking a recipient from saved contacts:

1. **Inline autocomplete** — 200ms debounced `ContactRepository.search`, up to 5 matches in a dropdown below the recipient field
2. **Picker sheet** — Users icon next to Scan opens a ModalBottomSheet with the user's contacts; empty query shows `recentlyUsed()` top-5

Exact-match address shows a "Saved as [Name]" inline hint.

Refs #196