### PR TITLE
feat(send): save-to-contacts prompt + markUsed after broadcast (#197)

### DIFF
--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/send/SaveContactDialog.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/send/SaveContactDialog.kt
@@ -1,0 +1,93 @@
+package com.rjnr.pocketnode.ui.screens.send
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.unit.dp
+
+/**
+ * Dialog shown after a successful send to a previously-unsaved address
+ * ([#197](https://github.com/RaheemJnr/pocket-node/issues/197)).
+ *
+ * The address is read-only — saving here means "this address I just
+ * sent to". The name field is blank by default rather than guessing
+ * from any transaction metadata (there is none, and a wrong guess is
+ * worse than no guess for an address book entry).
+ *
+ * Dismissal is sticky per-address: once the user picks "Not now", the
+ * prompt does not re-appear for the same recipient within the current
+ * process lifetime. After a process restart the prompt can fire again
+ * — that's a tolerable second chance rather than a permanent block.
+ */
+@Composable
+fun SaveContactDialog(
+    address: String,
+    onSave: (name: String, notes: String?) -> Unit,
+    onDismiss: () -> Unit,
+) {
+    var name by remember { mutableStateOf("") }
+    var notes by remember { mutableStateOf("") }
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text("Save to contacts?") },
+        text = {
+            Column {
+                Text(
+                    text = "Add this recipient to your address book to send to them faster next time.",
+                    style = MaterialTheme.typography.bodyMedium,
+                )
+                Spacer(Modifier.height(12.dp))
+                OutlinedTextField(
+                    value = name,
+                    onValueChange = { name = it },
+                    modifier = Modifier.fillMaxWidth(),
+                    label = { Text("Name") },
+                    placeholder = { Text("e.g. Alice") },
+                    singleLine = true,
+                )
+                Spacer(Modifier.height(8.dp))
+                OutlinedTextField(
+                    value = address,
+                    onValueChange = {},
+                    modifier = Modifier.fillMaxWidth(),
+                    label = { Text("Address") },
+                    enabled = false,
+                    textStyle = MaterialTheme.typography.bodySmall.copy(fontFamily = FontFamily.Monospace),
+                )
+                Spacer(Modifier.height(8.dp))
+                OutlinedTextField(
+                    value = notes,
+                    onValueChange = { notes = it },
+                    modifier = Modifier.fillMaxWidth(),
+                    label = { Text("Notes (optional)") },
+                    minLines = 2,
+                    maxLines = 4,
+                )
+            }
+        },
+        confirmButton = {
+            Button(
+                onClick = { onSave(name.trim(), notes.trim().ifEmpty { null }) },
+                enabled = name.isNotBlank(),
+            ) { Text("Save") }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) { Text("Not now") }
+        },
+    )
+}

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/send/SendScreen.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/send/SendScreen.kt
@@ -220,6 +220,15 @@ fun SendScreen(
         )
     }
 
+    // #197: prompt to save a brand-new recipient after broadcast.
+    uiState.saveContactPromptAddress?.let { addr ->
+        SaveContactDialog(
+            address = addr,
+            onSave = { name, notes -> viewModel.saveContactPromptSubmit(name, notes) },
+            onDismiss = { viewModel.saveContactPromptDismissed() },
+        )
+    }
+
     SendScreenUI(
         onNavigateBack = onNavigateBack,
         uiState = uiState,

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/send/SendViewModel.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/send/SendViewModel.kt
@@ -61,6 +61,14 @@ data class SendUiState(
     val recipientSuggestions: List<ContactEntity> = emptyList(),
     /** Contact whose address exactly matches the typed recipient. */
     val matchedContact: ContactEntity? = null,
+    /**
+     * Non-null when broadcast succeeded for an address that is NOT in
+     * the user's address book. UI shows a SaveContactDialog with this
+     * address prefilled; user can save or dismiss. Dismiss tracking is
+     * per-address (see [dismissedSavePrompts]) so the dialog never
+     * re-appears for the same recipient. (#197)
+     */
+    val saveContactPromptAddress: String? = null,
 )
 
 @HiltViewModel
@@ -81,6 +89,52 @@ class SendViewModel @Inject constructor(
 
     private var pollingJob: Job? = null
     private var sendJob: Job? = null
+
+    /**
+     * Addresses the user has explicitly dismissed the "Save to contacts?"
+     * prompt for. Lives in the ViewModel (not in UI state) because it's
+     * an interaction history, not a render input. Cleared on process
+     * death, which is acceptable — the user can always re-trigger by
+     * sending again. (#197)
+     */
+    private val dismissedSavePrompts: MutableSet<String> = mutableSetOf()
+
+    /**
+     * Called from broadcast-success paths with the recipient address.
+     * Either bumps the contact's usage counter (if saved) or queues
+     * the save-prompt dialog (if new and not previously dismissed).
+     */
+    private suspend fun afterSendBookkeeping(recipient: String) {
+        val existing = contactRepository.getByAddress(recipient)
+        if (existing != null) {
+            contactRepository.markUsed(recipient)
+            return
+        }
+        if (recipient in dismissedSavePrompts) return
+        _uiState.update { it.copy(saveContactPromptAddress = recipient) }
+    }
+
+    fun saveContactPromptDismissed() {
+        val addr = _uiState.value.saveContactPromptAddress ?: return
+        dismissedSavePrompts.add(addr)
+        _uiState.update { it.copy(saveContactPromptAddress = null) }
+    }
+
+    fun saveContactPromptSubmit(name: String, notes: String?) {
+        val addr = _uiState.value.saveContactPromptAddress ?: return
+        viewModelScope.launch {
+            contactRepository.add(
+                name = name,
+                address = addr,
+                notes = notes?.ifBlank { null },
+                tags = null,
+                activeNetwork = repository.currentNetwork,
+            ).onSuccess {
+                contactRepository.markUsed(addr)
+            }
+            _uiState.update { it.copy(saveContactPromptAddress = null) }
+        }
+    }
 
     companion object {
         private const val TAG = "SendViewModel"
@@ -381,9 +435,10 @@ class SendViewModel @Inject constructor(
         }
         try {
             _uiState.update { it.copy(statusMessage = "Broadcasting transaction...") }
+            val recipient = state.recipientAddress
             val txHash = repository.prepareAndSend(
                 fromAddress = capturedAddress,
-                toAddress = state.recipientAddress,
+                toAddress = recipient,
                 amountShannons = amountShannons,
                 privateKey = privateKey,
             ).getOrThrow()
@@ -397,6 +452,8 @@ class SendViewModel @Inject constructor(
                     statusMessage = "Transaction submitted. Waiting for confirmation..."
                 )
             }
+            // #197: bump useCount for saved contacts, queue save-prompt for new addresses.
+            afterSendBookkeeping(recipient)
             startPollingTransactionStatus(txHash, capturedAddress)
         } catch (e: Exception) {
             Log.e(TAG, "V2 send failed", e)
@@ -454,9 +511,10 @@ class SendViewModel @Inject constructor(
                 _uiState.update { it.copy(statusMessage = "Broadcasting transaction...") }
                 Log.d(TAG, "📡 prepareAndSend: fetching cells, filtering reserved, building, broadcasting...")
 
+                val recipient = state.recipientAddress
                 val txHash = repository.prepareAndSend(
                     fromAddress = capturedAddress,
-                    toAddress = state.recipientAddress,
+                    toAddress = recipient,
                     amountShannons = amountShannons,
                     privateKey = capturedKey
                 ).getOrThrow()
@@ -472,6 +530,9 @@ class SendViewModel @Inject constructor(
                         statusMessage = "Transaction submitted. Waiting for confirmation..."
                     )
                 }
+
+                // #197: usage bump for saved contacts, save-prompt for new ones.
+                afterSendBookkeeping(recipient)
 
                 // Start polling for transaction status using the captured address
                 startPollingTransactionStatus(txHash, capturedAddress)


### PR DESCRIPTION
Closes M4 Phase 2.

- Saved address: silent `markUsed` after broadcast (bumps `useCount`/`lastUsedAt` for the autocomplete sort)
- New address: `SaveContactDialog` (name + read-only address + optional notes). Save persists via `ContactRepository.add` then `markUsed`
- Per-process dismissal so rapid repeats don't re-prompt

Closes #197