### PR TITLE
feat(i18n): extract Contacts + Send-integration strings (#209 part A)

### DIFF
--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/contacts/AddContactScreen.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/contacts/AddContactScreen.kt
@@ -28,8 +28,10 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalClipboardManager
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
+import com.rjnr.pocketnode.R
 import com.composables.icons.lucide.ArrowLeft
 import com.composables.icons.lucide.Clipboard
 import com.composables.icons.lucide.Lucide
@@ -65,10 +67,10 @@ fun AddContactScreen(
     Scaffold(
         topBar = {
             TopAppBar(
-                title = { Text("Add contact") },
+                title = { Text(stringResource(R.string.add_contact_title)) },
                 navigationIcon = {
                     IconButton(onClick = onNavigateBack) {
-                        Icon(Lucide.ArrowLeft, contentDescription = "Back")
+                        Icon(Lucide.ArrowLeft, contentDescription = stringResource(R.string.common_back_cd))
                     }
                 },
                 colors = TopAppBarDefaults.topAppBarColors(
@@ -94,7 +96,7 @@ fun AddContactScreen(
                 addressTrailingIcon = {
                     Box {
                         IconButton(onClick = onNavigateToScanner) {
-                            Icon(Lucide.ScanLine, contentDescription = "Scan QR")
+                            Icon(Lucide.ScanLine, contentDescription = stringResource(R.string.add_contact_scan_cd))
                         }
                     }
                 },
@@ -117,7 +119,7 @@ fun AddContactScreen(
                     modifier = Modifier.size(16.dp),
                 )
                 Spacer(Modifier.size(8.dp))
-                Text("Paste address from clipboard")
+                Text(stringResource(R.string.add_contact_paste))
             }
 
             Spacer(Modifier.height(24.dp))
@@ -134,7 +136,7 @@ fun AddContactScreen(
                         color = MaterialTheme.colorScheme.onPrimary,
                     )
                 } else {
-                    Text("Save contact")
+                    Text(stringResource(R.string.add_contact_save))
                 }
             }
         }

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/contacts/ContactDetailScreen.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/contacts/ContactDetailScreen.kt
@@ -40,11 +40,13 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.platform.LocalClipboardManager
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
+import com.rjnr.pocketnode.R
 import com.composables.icons.lucide.ArrowLeft
 import com.composables.icons.lucide.Copy
 import com.composables.icons.lucide.Lucide
@@ -80,18 +82,20 @@ fun ContactDetailScreen(
     if (uiState.showDeleteConfirm) {
         AlertDialog(
             onDismissRequest = { viewModel.cancelDelete() },
-            title = { Text("Delete contact?") },
-            text = { Text("This removes the address book entry. Your sent transactions are unaffected.") },
+            title = { Text(stringResource(R.string.contact_delete_title)) },
+            text = { Text(stringResource(R.string.contact_delete_body)) },
             confirmButton = {
                 Button(
                     onClick = { viewModel.confirmDelete() },
                     colors = ButtonDefaults.buttonColors(
                         containerColor = MaterialTheme.colorScheme.error,
                     ),
-                ) { Text("Delete") }
+                ) { Text(stringResource(R.string.contact_delete_confirm)) }
             },
             dismissButton = {
-                TextButton(onClick = { viewModel.cancelDelete() }) { Text("Cancel") }
+                TextButton(onClick = { viewModel.cancelDelete() }) {
+                    Text(stringResource(R.string.contact_delete_cancel))
+                }
             },
         )
     }
@@ -99,22 +103,22 @@ fun ContactDetailScreen(
     Scaffold(
         topBar = {
             TopAppBar(
-                title = { Text("Contact") },
+                title = { Text(stringResource(R.string.contact_detail_title)) },
                 navigationIcon = {
                     IconButton(onClick = onNavigateBack) {
-                        Icon(Lucide.ArrowLeft, contentDescription = "Back")
+                        Icon(Lucide.ArrowLeft, contentDescription = stringResource(R.string.common_back_cd))
                     }
                 },
                 actions = {
                     val id = uiState.contact?.id
                     if (id != null) {
                         IconButton(onClick = { onEdit(id) }) {
-                            Icon(Lucide.Pencil, contentDescription = "Edit")
+                            Icon(Lucide.Pencil, contentDescription = stringResource(R.string.contact_detail_edit_cd))
                         }
                         IconButton(onClick = { viewModel.requestDelete() }) {
                             Icon(
                                 imageVector = Lucide.Trash2,
-                                contentDescription = "Delete",
+                                contentDescription = stringResource(R.string.contact_detail_delete_cd),
                                 tint = MaterialTheme.colorScheme.error,
                             )
                         }
@@ -136,7 +140,10 @@ fun ContactDetailScreen(
                 contentAlignment = Alignment.Center,
             ) {
                 Text(
-                    text = if (uiState.isLoading) "Loading…" else "Contact not found",
+                    text = stringResource(
+                        if (uiState.isLoading) R.string.contact_detail_loading
+                        else R.string.contact_detail_not_found
+                    ),
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
             }
@@ -156,7 +163,10 @@ fun ContactDetailScreen(
             )
             Spacer(Modifier.height(4.dp))
             Text(
-                text = "${contact.network.replaceFirstChar { it.uppercase() }} network",
+                text = stringResource(
+                    R.string.contact_detail_network,
+                    contact.network.replaceFirstChar { it.uppercase() },
+                ),
                 style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
             )
@@ -182,11 +192,12 @@ fun ContactDetailScreen(
                         style = MaterialTheme.typography.bodySmall,
                         fontFamily = FontFamily.Monospace,
                     )
+                    val copiedMessage = stringResource(R.string.contact_detail_copied)
                     IconButton(onClick = {
                         clipboard.setText(AnnotatedString(contact.address))
-                        scope.launch { snackbarHostState.showSnackbar("Address copied") }
+                        scope.launch { snackbarHostState.showSnackbar(copiedMessage) }
                     }) {
-                        Icon(Lucide.Copy, contentDescription = "Copy address")
+                        Icon(Lucide.Copy, contentDescription = stringResource(R.string.contact_detail_copy_cd))
                     }
                 }
             }
@@ -194,7 +205,7 @@ fun ContactDetailScreen(
             if (!contact.notes.isNullOrBlank()) {
                 Spacer(Modifier.height(16.dp))
                 Text(
-                    text = "Notes",
+                    text = stringResource(R.string.contact_detail_notes_label),
                     style = MaterialTheme.typography.labelMedium,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
@@ -205,7 +216,10 @@ fun ContactDetailScreen(
             if (contact.useCount > 0) {
                 Spacer(Modifier.height(16.dp))
                 Text(
-                    text = "Sent to ${contact.useCount} time${if (contact.useCount == 1) "" else "s"}",
+                    text = if (contact.useCount == 1)
+                        stringResource(R.string.contact_detail_use_count_one)
+                    else
+                        stringResource(R.string.contact_detail_use_count_other, contact.useCount),
                     style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
@@ -219,7 +233,7 @@ fun ContactDetailScreen(
             ) {
                 Icon(Lucide.Send, contentDescription = null)
                 Spacer(Modifier.size(8.dp))
-                Text("Send to ${contact.name}")
+                Text(stringResource(R.string.contact_detail_send_to, contact.name))
             }
         }
     }

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/contacts/ContactFormFields.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/contacts/ContactFormFields.kt
@@ -8,7 +8,9 @@ import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
+import com.rjnr.pocketnode.R
 
 /**
  * Shared form fields used by both [AddContactScreen] and
@@ -33,7 +35,7 @@ fun ContactFormFields(
             value = name,
             onValueChange = onNameChange,
             modifier = Modifier.fillMaxWidth(),
-            label = { Text("Name") },
+            label = { Text(stringResource(R.string.add_contact_field_name)) },
             singleLine = true,
         )
         Spacer(Modifier.height(12.dp))
@@ -41,8 +43,8 @@ fun ContactFormFields(
             value = address,
             onValueChange = onAddressChange,
             modifier = Modifier.fillMaxWidth(),
-            label = { Text("CKB address") },
-            placeholder = { Text("ckb1… or ckt1…") },
+            label = { Text(stringResource(R.string.add_contact_field_address)) },
+            placeholder = { Text(stringResource(R.string.add_contact_field_address_placeholder)) },
             singleLine = true,
             enabled = addressEditable,
             trailingIcon = addressTrailingIcon,
@@ -52,7 +54,7 @@ fun ContactFormFields(
             value = notes,
             onValueChange = onNotesChange,
             modifier = Modifier.fillMaxWidth(),
-            label = { Text("Notes (optional)") },
+            label = { Text(stringResource(R.string.add_contact_field_notes)) },
             minLines = 2,
             maxLines = 4,
         )

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/contacts/ContactsScreen.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/contacts/ContactsScreen.kt
@@ -31,10 +31,12 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
+import com.rjnr.pocketnode.R
 import com.composables.icons.lucide.ArrowLeft
 import com.composables.icons.lucide.Lucide
 import com.composables.icons.lucide.Plus
@@ -57,10 +59,10 @@ fun ContactsScreen(
     Scaffold(
         topBar = {
             TopAppBar(
-                title = { Text("Address Book") },
+                title = { Text(stringResource(R.string.contacts_title)) },
                 navigationIcon = {
                     IconButton(onClick = onNavigateBack) {
-                        Icon(Lucide.ArrowLeft, contentDescription = "Back")
+                        Icon(Lucide.ArrowLeft, contentDescription = stringResource(R.string.common_back_cd))
                     }
                 },
                 colors = TopAppBarDefaults.topAppBarColors(
@@ -70,7 +72,7 @@ fun ContactsScreen(
         },
         floatingActionButton = {
             FloatingActionButton(onClick = onNavigateToAdd) {
-                Icon(Lucide.Plus, contentDescription = "Add contact")
+                Icon(Lucide.Plus, contentDescription = stringResource(R.string.contacts_add_cd))
             }
         },
     ) { padding ->
@@ -85,7 +87,7 @@ fun ContactsScreen(
                 modifier = Modifier
                     .fillMaxWidth()
                     .padding(horizontal = 16.dp, vertical = 8.dp),
-                placeholder = { Text("Search name or address") },
+                placeholder = { Text(stringResource(R.string.contacts_search_placeholder)) },
                 leadingIcon = { Icon(Lucide.Search, contentDescription = null) },
                 singleLine = true,
             )
@@ -152,7 +154,7 @@ private fun ContactRow(
         IconButton(onClick = onSend) {
             Icon(
                 imageVector = Lucide.Send,
-                contentDescription = "Send to ${contact.name}",
+                contentDescription = stringResource(R.string.contacts_send_cd, contact.name),
                 tint = MaterialTheme.colorScheme.primary,
             )
         }
@@ -194,12 +196,12 @@ private fun EmptyContacts(onAdd: () -> Unit) {
         )
         Spacer(Modifier.height(16.dp))
         Text(
-            text = "No contacts yet",
+            text = stringResource(R.string.contacts_empty_title),
             style = MaterialTheme.typography.titleMedium,
         )
         Spacer(Modifier.height(8.dp))
         Text(
-            text = "Save addresses you send to often. Tap the + button to add your first contact.",
+            text = stringResource(R.string.contacts_empty_body),
             style = MaterialTheme.typography.bodyMedium,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
         )
@@ -216,7 +218,7 @@ private fun NoSearchMatches(query: String) {
         verticalArrangement = Arrangement.Center,
     ) {
         Text(
-            text = "No contacts match \"$query\"",
+            text = stringResource(R.string.contacts_no_match, query),
             style = MaterialTheme.typography.bodyMedium,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
         )

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/contacts/EditContactScreen.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/contacts/EditContactScreen.kt
@@ -25,8 +25,10 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
+import com.rjnr.pocketnode.R
 import com.composables.icons.lucide.ArrowLeft
 import com.composables.icons.lucide.Lucide
 
@@ -53,10 +55,10 @@ fun EditContactScreen(
     Scaffold(
         topBar = {
             TopAppBar(
-                title = { Text("Edit contact") },
+                title = { Text(stringResource(R.string.edit_contact_title)) },
                 navigationIcon = {
                     IconButton(onClick = onNavigateBack) {
-                        Icon(Lucide.ArrowLeft, contentDescription = "Back")
+                        Icon(Lucide.ArrowLeft, contentDescription = stringResource(R.string.common_back_cd))
                     }
                 },
                 colors = TopAppBarDefaults.topAppBarColors(
@@ -96,7 +98,7 @@ fun EditContactScreen(
                         color = MaterialTheme.colorScheme.onPrimary,
                     )
                 } else {
-                    Text("Save changes")
+                    Text(stringResource(R.string.edit_contact_save))
                 }
             }
         }

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/send/ContactPickerSheet.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/send/ContactPickerSheet.kt
@@ -30,11 +30,13 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import com.composables.icons.lucide.Lucide
 import com.composables.icons.lucide.Search
+import com.rjnr.pocketnode.R
 import com.rjnr.pocketnode.data.database.entity.ContactEntity
 
 /**
@@ -73,7 +75,7 @@ fun ContactPickerSheet(
                 .padding(horizontal = 16.dp, vertical = 8.dp),
         ) {
             Text(
-                text = "Send to contact",
+                text = stringResource(R.string.send_contact_picker_title),
                 style = MaterialTheme.typography.titleMedium,
                 fontWeight = FontWeight.SemiBold,
             )
@@ -83,7 +85,7 @@ fun ContactPickerSheet(
                 value = query,
                 onValueChange = { query = it },
                 modifier = Modifier.fillMaxWidth(),
-                placeholder = { Text("Search name or address") },
+                placeholder = { Text(stringResource(R.string.contacts_search_placeholder)) },
                 leadingIcon = { Icon(Lucide.Search, contentDescription = null) },
                 singleLine = true,
             )
@@ -100,9 +102,9 @@ fun ContactPickerSheet(
                 ) {
                     Text(
                         text = if (query.isBlank())
-                            "No saved contacts yet. Add one from Settings → Address Book."
+                            stringResource(R.string.send_contact_picker_empty_no_contacts)
                         else
-                            "No matches for \"$query\"",
+                            stringResource(R.string.send_contact_picker_empty_no_match, query),
                         style = MaterialTheme.typography.bodyMedium,
                         color = MaterialTheme.colorScheme.onSurfaceVariant,
                     )

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/send/SaveContactDialog.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/send/SaveContactDialog.kt
@@ -16,8 +16,10 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.unit.dp
+import com.rjnr.pocketnode.R
 
 /**
  * Dialog shown after a successful send to a previously-unsaved address
@@ -44,11 +46,11 @@ fun SaveContactDialog(
 
     AlertDialog(
         onDismissRequest = onDismiss,
-        title = { Text("Save to contacts?") },
+        title = { Text(stringResource(R.string.save_contact_dialog_title)) },
         text = {
             Column {
                 Text(
-                    text = "Add this recipient to your address book to send to them faster next time.",
+                    text = stringResource(R.string.save_contact_dialog_body),
                     style = MaterialTheme.typography.bodyMedium,
                 )
                 Spacer(Modifier.height(12.dp))
@@ -56,8 +58,8 @@ fun SaveContactDialog(
                     value = name,
                     onValueChange = { name = it },
                     modifier = Modifier.fillMaxWidth(),
-                    label = { Text("Name") },
-                    placeholder = { Text("e.g. Alice") },
+                    label = { Text(stringResource(R.string.add_contact_field_name)) },
+                    placeholder = { Text(stringResource(R.string.save_contact_dialog_name_placeholder)) },
                     singleLine = true,
                 )
                 Spacer(Modifier.height(8.dp))
@@ -65,7 +67,7 @@ fun SaveContactDialog(
                     value = address,
                     onValueChange = {},
                     modifier = Modifier.fillMaxWidth(),
-                    label = { Text("Address") },
+                    label = { Text(stringResource(R.string.add_contact_field_address)) },
                     enabled = false,
                     textStyle = MaterialTheme.typography.bodySmall.copy(fontFamily = FontFamily.Monospace),
                 )
@@ -74,7 +76,7 @@ fun SaveContactDialog(
                     value = notes,
                     onValueChange = { notes = it },
                     modifier = Modifier.fillMaxWidth(),
-                    label = { Text("Notes (optional)") },
+                    label = { Text(stringResource(R.string.add_contact_field_notes)) },
                     minLines = 2,
                     maxLines = 4,
                 )
@@ -84,10 +86,10 @@ fun SaveContactDialog(
             Button(
                 onClick = { onSave(name.trim(), notes.trim().ifEmpty { null }) },
                 enabled = name.isNotBlank(),
-            ) { Text("Save") }
+            ) { Text(stringResource(R.string.save_contact_dialog_save)) }
         },
         dismissButton = {
-            TextButton(onClick = onDismiss) { Text("Not now") }
+            TextButton(onClick = onDismiss) { Text(stringResource(R.string.save_contact_dialog_dismiss)) }
         },
     )
 }

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/send/SendScreen.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/send/SendScreen.kt
@@ -78,6 +78,8 @@ import com.composables.icons.lucide.Lucide
 import com.composables.icons.lucide.ScanLine
 import com.composables.icons.lucide.TriangleAlert
 import com.composables.icons.lucide.Users
+import androidx.compose.ui.res.stringResource
+import com.rjnr.pocketnode.R
 import com.composables.icons.lucide.X
 import com.rjnr.pocketnode.data.database.entity.WalletEntity
 import com.rjnr.pocketnode.data.gateway.models.NetworkType
@@ -368,7 +370,7 @@ private fun SendScreenUI(
                 )
                 Icon(
                     imageVector = Lucide.Users,
-                    contentDescription = "Pick from contacts",
+                    contentDescription = stringResource(R.string.send_contact_picker_cd),
                     modifier = Modifier.clickable { onOpenContactPicker() }
                 )
                 Icon(
@@ -421,7 +423,7 @@ private fun SendScreenUI(
             uiState.matchedContact?.let { contact ->
                 Spacer(modifier = Modifier.height(4.dp))
                 Text(
-                    text = "Saved as ${contact.name}",
+                    text = stringResource(R.string.send_saved_as, contact.name),
                     style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.primary,
                 )

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/settings/SettingsScreen.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/settings/SettingsScreen.kt
@@ -429,7 +429,7 @@ private fun SettingsScreenUI(
             item {
                 SettingsLinkRow(
                     icon = Lucide.Users,
-                    title = "Address Book",
+                    title = stringResource(R.string.settings_address_book),
                     onClick = onNavigateToContacts,
                 )
             }

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -136,6 +136,69 @@
 
     <!-- region: Settings -->
     <string name="settings_help_faq">Help &amp; FAQ</string>
+    <string name="settings_address_book">Address Book</string>
+    <!-- endregion -->
+
+    <!-- region: Contacts (M4 Phase 2) -->
+    <string name="contacts_title">Address Book</string>
+    <string name="contacts_search_placeholder">Search name or address</string>
+    <string name="contacts_add_cd">Add contact</string>
+    <string name="contacts_empty_title">No contacts yet</string>
+    <string name="contacts_empty_body">Save addresses you send to often. Tap the + button to add your first contact.</string>
+    <string name="contacts_no_match">No contacts match \"%1$s\"</string>
+    <string name="contacts_send_cd">Send to %1$s</string>
+
+    <string name="add_contact_title">Add contact</string>
+    <string name="add_contact_save">Save contact</string>
+    <string name="add_contact_paste">Paste address from clipboard</string>
+    <string name="add_contact_field_name">Name</string>
+    <string name="add_contact_field_address">CKB address</string>
+    <string name="add_contact_field_address_placeholder">ckb1… or ckt1…</string>
+    <string name="add_contact_field_notes">Notes (optional)</string>
+    <string name="add_contact_scan_cd">Scan QR</string>
+    <string name="add_contact_required_error">Name and address are required</string>
+
+    <string name="edit_contact_title">Edit contact</string>
+    <string name="edit_contact_save">Save changes</string>
+
+    <string name="contact_detail_title">Contact</string>
+    <string name="contact_detail_network">%1$s network</string>
+    <string name="contact_detail_notes_label">Notes</string>
+    <string name="contact_detail_send_to">Send to %1$s</string>
+    <string name="contact_detail_copy_cd">Copy address</string>
+    <string name="contact_detail_edit_cd">Edit</string>
+    <string name="contact_detail_delete_cd">Delete</string>
+    <string name="contact_detail_copied">Address copied</string>
+    <string name="contact_detail_loading">Loading…</string>
+    <string name="contact_detail_not_found">Contact not found</string>
+    <string name="contact_detail_use_count_one">Sent to 1 time</string>
+    <string name="contact_detail_use_count_other">Sent to %1$d times</string>
+
+    <string name="contact_delete_title">Delete contact?</string>
+    <string name="contact_delete_body">This removes the address book entry. Your sent transactions are unaffected.</string>
+    <string name="contact_delete_confirm">Delete</string>
+    <string name="contact_delete_cancel">Cancel</string>
+
+    <string name="contact_error_invalid_address">Address could not be decoded — check the format</string>
+    <string name="contact_error_wrong_network">This address is for %1$s; switch networks or pick a different address</string>
+    <string name="contact_error_duplicate">An existing contact already uses this address</string>
+    <string name="contact_error_invalid_name">Name must be 1-64 characters</string>
+    <string name="contact_error_notes_too_long">Notes must be 256 characters or fewer</string>
+    <string name="contact_error_no_active_wallet">No active wallet to scope this contact to</string>
+    <string name="contact_error_generic_save">Could not save contact</string>
+    <string name="contact_error_auth_cancelled">Authentication cancelled</string>
+
+    <string name="send_contact_picker_title">Send to contact</string>
+    <string name="send_contact_picker_empty_no_contacts">No saved contacts yet. Add one from Settings → Address Book.</string>
+    <string name="send_contact_picker_empty_no_match">No matches for \"%1$s\"</string>
+    <string name="send_saved_as">Saved as %1$s</string>
+    <string name="send_contact_picker_cd">Pick from contacts</string>
+
+    <string name="save_contact_dialog_title">Save to contacts?</string>
+    <string name="save_contact_dialog_body">Add this recipient to your address book to send to them faster next time.</string>
+    <string name="save_contact_dialog_name_placeholder">e.g. Alice</string>
+    <string name="save_contact_dialog_save">Save</string>
+    <string name="save_contact_dialog_dismiss">Not now</string>
     <!-- endregion -->
 
 </resources>


### PR DESCRIPTION
First slice of #209. Pulls every hardcoded UI string in the M4 Phase 2 address book + Send-integration code into `res/values/strings.xml`.

Pure refactor — no behavior change, every `Text`/`contentDescription` maps 1:1 to a `stringResource`. Compose previews still render.

Excluded from this PR:
- Error messages from `ContactRepository` / ViewModels still use English literals (cross-layer, no Context). Typed-error → UI mapping belongs in #133.
- Log statements (developer-facing) per #209 spec.

Other screens (Home, Onboarding, Wallet, NodeStatus, etc.) follow in subsequent PRs.

Refs #209

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Converted hardcoded strings to localized string resources across all Address Book feature screens, including contacts list, add/edit contact, contact details, and send interface.

* **Chores**
  * Added 50+ new string resource entries for comprehensive support of Address Book UI text, labels, messages, and error states.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/RaheemJnr/pocket-node/pull/240?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->