### PR TITLE
feat(i18n): extract auth-flow strings (#209 part B)

### DIFF
--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/auth/AuthScreen.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/auth/AuthScreen.kt
@@ -27,8 +27,10 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import com.rjnr.pocketnode.R
 import androidx.core.content.ContextCompat
 import androidx.fragment.app.FragmentActivity
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -42,6 +44,12 @@ fun AuthScreen(
     val uiState by viewModel.uiState.collectAsState()
     val snackbarHostState = remember { SnackbarHostState() }
     val context = LocalContext.current
+
+    // Capture localized strings now — the prompt builder runs from a
+    // non-@Composable callback site, which can't call stringResource().
+    val biometricTitle = stringResource(R.string.auth_biometric_title)
+    val biometricSubtitle = stringResource(R.string.auth_biometric_subtitle)
+    val biometricNegative = stringResource(R.string.auth_biometric_negative)
 
     fun launchBiometric() {
         val activity = context as? FragmentActivity ?: return
@@ -63,9 +71,9 @@ fun AuthScreen(
             }
         )
         val promptInfo = BiometricPrompt.PromptInfo.Builder()
-            .setTitle("Unlock Pocket Node")
-            .setSubtitle("Authenticate to access your wallet")
-            .setNegativeButtonText("Use PIN")
+            .setTitle(biometricTitle)
+            .setSubtitle(biometricSubtitle)
+            .setNegativeButtonText(biometricNegative)
             .build()
         prompt.authenticate(promptInfo)
     }
@@ -112,7 +120,7 @@ fun AuthScreen(
         ) {
             Icon(
                 imageVector = Lucide.Lock,
-                contentDescription = "Locked",
+                contentDescription = stringResource(R.string.auth_locked_cd),
                 modifier = Modifier.size(80.dp),
                 tint = MaterialTheme.colorScheme.primary
             )
@@ -138,7 +146,7 @@ fun AuthScreen(
                     onClick = { launchBiometric() },
                     modifier = Modifier.fillMaxWidth()
                 ) {
-                    Text("Unlock with Fingerprint")
+                    Text(stringResource(R.string.auth_unlock_fingerprint))
                 }
 
                 Spacer(modifier = Modifier.height(12.dp))
@@ -149,7 +157,7 @@ fun AuthScreen(
                     onClick = onNavigateToPinVerify,
                     modifier = Modifier.fillMaxWidth().uaTestTag("auth-use-pin")
                 ) {
-                    Text("Use PIN")
+                    Text(stringResource(R.string.auth_use_pin))
                 }
             }
         }

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/recovery/RecoveryScreen.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/recovery/RecoveryScreen.kt
@@ -28,10 +28,12 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
+import com.rjnr.pocketnode.R
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -45,7 +47,7 @@ fun RecoveryScreen(
 
     Scaffold(
         topBar = {
-            TopAppBar(title = { Text("Wallet Recovery") })
+            TopAppBar(title = { Text(stringResource(R.string.recovery_title)) })
         }
     ) { padding ->
         Column(
@@ -81,7 +83,7 @@ fun RecoveryScreen(
                     OutlinedTextField(
                         value = pinInput,
                         onValueChange = { if (it.length <= 6 && it.all { c -> c.isDigit() }) pinInput = it },
-                        label = { Text("PIN") },
+                        label = { Text(stringResource(R.string.recovery_pin_label)) },
                         keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.NumberPassword),
                         visualTransformation = PasswordVisualTransformation(),
                         singleLine = true,
@@ -104,11 +106,11 @@ fun RecoveryScreen(
                         enabled = pinInput.length == 6,
                         modifier = Modifier.fillMaxWidth()
                     ) {
-                        Text("Recover with PIN")
+                        Text(stringResource(R.string.recovery_with_pin))
                     }
 
                     TextButton(onClick = onMnemonicRestore) {
-                        Text("Use recovery phrase instead")
+                        Text(stringResource(R.string.recovery_use_phrase_instead))
                     }
                 }
 
@@ -122,7 +124,7 @@ fun RecoveryScreen(
                         onClick = onMnemonicRestore,
                         modifier = Modifier.fillMaxWidth()
                     ) {
-                        Text("Enter recovery phrase")
+                        Text(stringResource(R.string.recovery_enter_phrase))
                     }
                 }
 
@@ -154,7 +156,7 @@ fun RecoveryScreen(
                     )
 
                     Button(onClick = onMnemonicRestore, modifier = Modifier.fillMaxWidth()) {
-                        Text("Restore with recovery phrase")
+                        Text(stringResource(R.string.recovery_restore_with_phrase))
                     }
                 }
             }

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/security/MnemonicVerifyScreen.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/security/MnemonicVerifyScreen.kt
@@ -8,8 +8,10 @@ import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.unit.dp
+import com.rjnr.pocketnode.R
 
 data class QuizQuestion(val wordIndex: Int, val correctWord: String)
 
@@ -35,10 +37,13 @@ fun MnemonicVerifyScreen(
     Scaffold(
         topBar = {
             TopAppBar(
-                title = { Text("Verify Recovery Phrase") },
+                title = { Text(stringResource(R.string.mnemonic_verify_title)) },
                 navigationIcon = {
                     IconButton(onClick = onBack) {
-                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                        Icon(
+                            Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = stringResource(R.string.common_back_cd),
+                        )
                     }
                 }
             )
@@ -61,15 +66,23 @@ fun MnemonicVerifyScreen(
             )
 
             Text(
-                text = "Question ${currentQuestionIndex + 1} of 3",
+                text = stringResource(
+                    R.string.mnemonic_verify_question_progress,
+                    currentQuestionIndex + 1,
+                ),
                 style = MaterialTheme.typography.titleMedium
             )
 
             if (currentQuestion != null) {
                 Text(
-                    text = "What is word #${currentQuestion.wordIndex + 1}?",
+                    text = stringResource(
+                        R.string.mnemonic_verify_prompt,
+                        currentQuestion.wordIndex + 1,
+                    ),
                     style = MaterialTheme.typography.headlineSmall
                 )
+
+                val incorrectMsg = stringResource(R.string.mnemonic_verify_incorrect)
 
                 OutlinedTextField(
                     value = answer,
@@ -77,7 +90,7 @@ fun MnemonicVerifyScreen(
                         answer = it.lowercase().trim()
                         error = null
                     },
-                    label = { Text("Enter word") },
+                    label = { Text(stringResource(R.string.mnemonic_verify_enter_word)) },
                     singleLine = true,
                     keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
                     isError = error != null,
@@ -96,13 +109,18 @@ fun MnemonicVerifyScreen(
                                 onVerified()
                             }
                         } else {
-                            error = "Incorrect. Try again."
+                            error = incorrectMsg
                         }
                     },
                     enabled = answer.isNotBlank(),
                     modifier = Modifier.fillMaxWidth()
                 ) {
-                    Text(if (currentQuestionIndex < 2) "Next" else "Verify")
+                    Text(
+                        stringResource(
+                            if (currentQuestionIndex < 2) R.string.mnemonic_verify_next
+                            else R.string.mnemonic_verify_verify
+                        )
+                    )
                 }
             }
         }

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/security/SecurityChecklistScreen.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/security/SecurityChecklistScreen.kt
@@ -9,7 +9,9 @@ import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
+import com.rjnr.pocketnode.R
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -32,10 +34,13 @@ fun SecurityChecklistScreen(
     Scaffold(
         topBar = {
             TopAppBar(
-                title = { Text("Security Setup") },
+                title = { Text(stringResource(R.string.security_checklist_title)) },
                 navigationIcon = {
                     IconButton(onClick = onBack) {
-                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                        Icon(
+                            Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = stringResource(R.string.common_back_cd),
+                        )
                     }
                 }
             )

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -139,6 +139,38 @@
     <string name="settings_address_book">Address Book</string>
     <!-- endregion -->
 
+    <!-- region: Auth -->
+    <string name="auth_biometric_title">Unlock Pocket Node</string>
+    <string name="auth_biometric_subtitle">Authenticate to access your wallet</string>
+    <string name="auth_biometric_negative">Use PIN</string>
+    <string name="auth_locked_cd">Locked</string>
+    <string name="auth_unlock_fingerprint">Unlock with Fingerprint</string>
+    <string name="auth_use_pin">Use PIN</string>
+    <!-- endregion -->
+
+    <!-- region: Recovery -->
+    <string name="recovery_title">Wallet Recovery</string>
+    <string name="recovery_pin_label">PIN</string>
+    <string name="recovery_with_pin">Recover with PIN</string>
+    <string name="recovery_use_phrase_instead">Use recovery phrase instead</string>
+    <string name="recovery_enter_phrase">Enter recovery phrase</string>
+    <string name="recovery_restore_with_phrase">Restore with recovery phrase</string>
+    <!-- endregion -->
+
+    <!-- region: MnemonicVerify -->
+    <string name="mnemonic_verify_title">Verify Recovery Phrase</string>
+    <string name="mnemonic_verify_enter_word">Enter word</string>
+    <string name="mnemonic_verify_question_progress">Question %1$d of 3</string>
+    <string name="mnemonic_verify_prompt">What is word #%1$d?</string>
+    <string name="mnemonic_verify_incorrect">Incorrect. Try again.</string>
+    <string name="mnemonic_verify_next">Next</string>
+    <string name="mnemonic_verify_verify">Verify</string>
+    <!-- endregion -->
+
+    <!-- region: SecurityChecklist -->
+    <string name="security_checklist_title">Security Setup</string>
+    <!-- endregion -->
+
     <!-- region: Contacts (M4 Phase 2) -->
     <string name="contacts_title">Address Book</string>
     <string name="contacts_search_placeholder">Search name or address</string>


### PR DESCRIPTION
Auth + Recovery + MnemonicVerify + SecurityChecklist strings extracted to strings.xml.

Pattern note for the BiometricPrompt builder in AuthScreen: stringResource() can only be called inside @Composable. The prompt is built inside a regular local function, so I captured the three strings into vals at the @Composable scope and reference those. This is the canonical fix for non-Composable callbacks that need localized strings.

Refs #209