### PR TITLE
feat(i18n): settings + send + activity (#209 part F)

### DIFF
--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/activity/ActivityScreen.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/activity/ActivityScreen.kt
@@ -67,6 +67,8 @@ import androidx.paging.compose.collectAsLazyPagingItems
 import com.composables.icons.lucide.*
 import com.rjnr.pocketnode.data.gateway.models.NetworkType
 import com.rjnr.pocketnode.data.gateway.models.TransactionRecord
+import androidx.compose.ui.res.stringResource
+import com.rjnr.pocketnode.R
 import com.rjnr.pocketnode.ui.screens.home.HomeNavEvent
 import com.rjnr.pocketnode.ui.theme.ErrorRed
 import com.rjnr.pocketnode.ui.theme.PendingAmber
@@ -107,16 +109,16 @@ fun ActivityScreen(
     retryDialogTx?.let { tx ->
         AlertDialog(
             onDismissRequest = { retryDialogTx = null },
-            title = { Text("Retry transaction?") },
-            text = { Text("This transaction may not have reached the network. Retry?") },
+            title = { Text(stringResource(R.string.activity_retry_dialog_title)) },
+            text = { Text(stringResource(R.string.activity_retry_dialog_body)) },
             confirmButton = {
                 TextButton(onClick = {
                     retryDialogTx = null
                     viewModel.retryFailedTransaction(tx.txHash)
-                }) { Text("Retry") }
+                }) { Text(stringResource(R.string.activity_retry)) }
             },
             dismissButton = {
-                TextButton(onClick = { retryDialogTx = null }) { Text("Cancel") }
+                TextButton(onClick = { retryDialogTx = null }) { Text(stringResource(R.string.activity_cancel)) }
             }
         )
     }
@@ -151,7 +153,7 @@ fun ActivityScreen(
             TopAppBar(
                 title = {
                     Text(
-                        text = "Activity",
+                        text = stringResource(R.string.activity_title),
                         fontWeight = FontWeight.Bold,
                         fontSize = 20.sp
                     )
@@ -160,7 +162,7 @@ fun ActivityScreen(
                     IconButton(onClick = { viewModel.exportTransactions() }) {
                         Icon(
                             imageVector = Lucide.Download,
-                            contentDescription = "Export CSV"
+                            contentDescription = stringResource(R.string.activity_export_csv_cd)
                         )
                     }
                 },
@@ -550,7 +552,7 @@ private fun ErrorState(message: String?, onRetry: () -> Unit) {
                     contentColor = MaterialTheme.colorScheme.onPrimary
                 )
             ) {
-                Text("Retry", fontWeight = FontWeight.SemiBold)
+                Text(stringResource(R.string.activity_retry), fontWeight = FontWeight.SemiBold)
             }
         }
     }
@@ -671,7 +673,7 @@ private fun TransactionDetailSheet(
                 ) {
                     Icon(
                         imageVector = Lucide.Copy,
-                        contentDescription = "Copy TX hash",
+                        contentDescription = stringResource(R.string.activity_copy_tx_cd),
                         modifier = Modifier.size(18.dp),
                         tint = MaterialTheme.colorScheme.onSurfaceVariant
                     )
@@ -682,7 +684,7 @@ private fun TransactionDetailSheet(
                 ) {
                     Icon(
                         imageVector = Lucide.ExternalLink,
-                        contentDescription = "View on explorer",
+                        contentDescription = stringResource(R.string.activity_explorer_cd),
                         modifier = Modifier.size(18.dp),
                         tint = MaterialTheme.colorScheme.primary
                     )
@@ -737,7 +739,7 @@ private fun TransactionDetailSheet(
                         contentColor = MaterialTheme.colorScheme.onError
                     )
                 ) {
-                    Text("Retry Transaction")
+                    Text(stringResource(R.string.activity_retry_transaction))
                 }
             }
         }

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/send/SendScreen.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/send/SendScreen.kt
@@ -131,6 +131,11 @@ fun SendScreen(
 
     val context = LocalContext.current
 
+    // Captured for the non-@Composable LaunchedEffect callback below.
+    val sendAuthTitle = stringResource(R.string.send_auth_biometric_title)
+    val sendAuthSubtitle = stringResource(R.string.send_auth_biometric_subtitle)
+    val sendAuthNegative = stringResource(R.string.send_auth_biometric_negative)
+
     // Handle PIN auth result
     LaunchedEffect(sendAuthVerified) {
         if (sendAuthVerified) {
@@ -165,9 +170,9 @@ fun SendScreen(
                     }
                 )
                 val promptInfo = BiometricPrompt.PromptInfo.Builder()
-                    .setTitle("Authenticate to Send")
-                    .setSubtitle("Verify your identity to send CKB")
-                    .setNegativeButtonText("Use PIN")
+                    .setTitle(sendAuthTitle)
+                    .setSubtitle(sendAuthSubtitle)
+                    .setNegativeButtonText(sendAuthNegative)
                     .build()
                 prompt.authenticate(promptInfo)
             }
@@ -286,7 +291,7 @@ private fun SendScreenUI(
                     IconButton(onClick = { onNavigateBack() }) {
                         Icon(
                             Lucide.ChevronLeft,
-                            contentDescription = "Back",
+                            contentDescription = stringResource(R.string.common_back_cd),
                             modifier = Modifier.size(28.dp)
                         )
                     }
@@ -375,7 +380,7 @@ private fun SendScreenUI(
                 )
                 Icon(
                     imageVector = Lucide.ScanLine,
-                    contentDescription = "Scan",
+                    contentDescription = stringResource(R.string.send_scan_cd),
                     modifier = Modifier.clickable{onNavigateToScanner()}
                 )
             }
@@ -437,7 +442,7 @@ private fun SendScreenUI(
                         onClick = { showMyWallets = true },
                         enabled = !uiState.isLoading
                     ) {
-                        Text("My Wallets", style = MaterialTheme.typography.labelSmall)
+                        Text(stringResource(R.string.send_my_wallets), style = MaterialTheme.typography.labelSmall)
                     }
                     DropdownMenu(
                         expanded = showMyWallets,
@@ -616,7 +621,7 @@ private fun SendScreenUI(
                     Spacer(modifier = Modifier.width(8.dp))
                     Text(uiState.statusMessage.ifEmpty { "Sending..." })
                 } else {
-                    Text("Send CKB")
+                    Text(stringResource(R.string.send_send_ckb))
                 }
             }
         }
@@ -780,13 +785,13 @@ fun ErrorDialog(
         },
         confirmButton = {
             Button(onClick = onDismiss) {
-                Text("OK")
+                Text(stringResource(R.string.send_ok))
             }
         },
         dismissButton = if (onRetry != null) {
             {
                 OutlinedButton(onClick = onRetry) {
-                    Text("Retry")
+                    Text(stringResource(R.string.send_retry))
                 }
             }
         } else null
@@ -824,7 +829,7 @@ fun TransactionStatusDialog(
                     ) {
                         Icon(
                             imageVector = Lucide.CircleCheck,
-                            contentDescription = "Success",
+                            contentDescription = stringResource(R.string.send_success_cd),
                             modifier = Modifier.size(40.dp),
                             tint = SuccessGreen
                         )
@@ -841,7 +846,7 @@ fun TransactionStatusDialog(
                     ) {
                         Icon(
                             imageVector = Lucide.X,
-                            contentDescription = "Failed",
+                            contentDescription = stringResource(R.string.send_failed_cd),
                             modifier = Modifier.size(40.dp),
                             tint = MaterialTheme.colorScheme.error
                         )
@@ -967,11 +972,11 @@ fun TransactionStatusDialog(
                         containerColor = SuccessGreen
                     )
                 ) {
-                    Text("Done")
+                    Text(stringResource(R.string.send_done))
                 }
             } else if (isFailed) {
                 Button(onClick = onDismiss) {
-                    Text("Close")
+                    Text(stringResource(R.string.send_close))
                 }
             }
         },
@@ -983,7 +988,7 @@ fun TransactionStatusDialog(
                         contentColor = MaterialTheme.colorScheme.outline
                     )
                 ) {
-                    Text("Hide")
+                    Text(stringResource(R.string.send_hide))
                 }
             }
         }

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/settings/SecuritySettingsScreen.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/settings/SecuritySettingsScreen.kt
@@ -37,8 +37,10 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
+import com.rjnr.pocketnode.R
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -83,12 +85,12 @@ fun SecuritySettingsScreen(
             },
             confirmButton = {
                 Button(onClick = { viewModel.confirmBiometricEnrollmentWarning() }) {
-                    Text("Continue")
+                    Text(stringResource(R.string.security_settings_continue))
                 }
             },
             dismissButton = {
                 TextButton(onClick = { viewModel.dismissBiometricEnrollmentWarning() }) {
-                    Text("Cancel")
+                    Text(stringResource(R.string.security_settings_cancel))
                 }
             }
         )
@@ -98,7 +100,7 @@ fun SecuritySettingsScreen(
         if (!uiState.canRemovePin) {
             AlertDialog(
                 onDismissRequest = { showRemoveDialog = false },
-                title = { Text("PIN is required") },
+                title = { Text(stringResource(R.string.security_settings_pin_required_title)) },
                 text = {
                     Text(
                         "A PIN is mandatory while you have a wallet. It protects your PIN-encrypted recovery backup.\n\n" +
@@ -106,15 +108,15 @@ fun SecuritySettingsScreen(
                     )
                 },
                 confirmButton = {
-                    Button(onClick = { showRemoveDialog = false }) { Text("OK") }
+                    Button(onClick = { showRemoveDialog = false }) { Text(stringResource(R.string.security_settings_pin_required_ok)) }
                 }
             )
         } else {
             AlertDialog(
                 onDismissRequest = { showRemoveDialog = false },
-                title = { Text("Remove PIN?") },
+                title = { Text(stringResource(R.string.security_settings_remove_pin_title)) },
                 text = {
-                    Text("Your wallet will no longer be locked on launch. This also disables biometric unlock.")
+                    Text(stringResource(R.string.security_settings_remove_pin_body))
                 },
                 confirmButton = {
                     Button(onClick = {
@@ -122,12 +124,12 @@ fun SecuritySettingsScreen(
                         viewModel.setPendingAction(PendingSecurityAction.REMOVE_PIN)
                         onNavigateToPinVerify()
                     }) {
-                        Text("Remove")
+                        Text(stringResource(R.string.security_settings_remove))
                     }
                 },
                 dismissButton = {
                     TextButton(onClick = { showRemoveDialog = false }) {
-                        Text("Cancel")
+                        Text(stringResource(R.string.security_settings_cancel))
                     }
                 }
             )
@@ -138,7 +140,7 @@ fun SecuritySettingsScreen(
         containerColor = MaterialTheme.colorScheme.surface,
         topBar = {
             TopAppBar(
-                title = { Text("Security Settings") },
+                title = { Text(stringResource(R.string.security_settings_title)) },
                 navigationIcon = {
                     IconButton(onClick = onNavigateBack) {
                         Icon(Lucide.ArrowLeft, "Back")
@@ -181,14 +183,14 @@ fun SecuritySettingsScreen(
                                 tint = MaterialTheme.colorScheme.primary,
                                 modifier = Modifier.padding(end = 8.dp)
                             )
-                            Text("PIN is enabled")
+                            Text(stringResource(R.string.security_settings_pin_enabled))
                         }
 
                         Spacer(modifier = Modifier.height(12.dp))
 
                         Row {
                             OutlinedButton(onClick = onNavigateToPinSetup) {
-                                Text("Change PIN")
+                                Text(stringResource(R.string.security_settings_change_pin))
                             }
                             Spacer(modifier = Modifier.width(8.dp))
                             TextButton(onClick = { showRemoveDialog = true }) {
@@ -208,7 +210,7 @@ fun SecuritySettingsScreen(
                         Spacer(modifier = Modifier.height(12.dp))
 
                         Button(onClick = onNavigateToPinSetup) {
-                            Text("Set PIN")
+                            Text(stringResource(R.string.security_settings_set_pin))
                         }
                     }
                 }

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/settings/SettingsScreen.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/settings/SettingsScreen.kt
@@ -141,7 +141,7 @@ fun SettingsScreen(
     if (showNotificationExplanation) {
         AlertDialog(
             onDismissRequest = { showNotificationExplanation = false },
-            title = { Text("Allow Notifications") },
+            title = { Text(stringResource(R.string.settings_allow_notifications_title)) },
             text = {
                 Text(
                     "Pocket Node needs notification permission to show sync progress " +
@@ -156,7 +156,7 @@ fun SettingsScreen(
                     showNotificationExplanation = false
                     notificationPermissionLauncher.launch(Manifest.permission.POST_NOTIFICATIONS)
                 }) {
-                    Text("Allow")
+                    Text(stringResource(R.string.settings_allow))
                 }
             },
             dismissButton = {
@@ -167,7 +167,7 @@ fun SettingsScreen(
                     // ON while sync was silently dead. (#116)
                     showNotificationExplanation = false
                 }) {
-                    Text("Skip")
+                    Text(stringResource(R.string.settings_skip))
                 }
             }
         )
@@ -210,7 +210,7 @@ fun SettingsScreen(
     if (uiState.showNetworkSwitchDialog && pendingSwitch != null) {
         AlertDialog(
             onDismissRequest = { viewModel.cancelNetworkSwitch() },
-            title = { Text("Switch to CKB ${pendingSwitch.displayName}?") },
+            title = { Text(stringResource(R.string.settings_switch_network_title, pendingSwitch.displayName)) },
             text = {
                 Text(
                     "The app will close and reopen on CKB ${pendingSwitch.displayName}. " +
@@ -220,12 +220,12 @@ fun SettingsScreen(
             },
             confirmButton = {
                 Button(onClick = { viewModel.confirmNetworkSwitch() }) {
-                    Text("Switch & Restart")
+                    Text(stringResource(R.string.settings_switch_restart))
                 }
             },
             dismissButton = {
                 TextButton(onClick = { viewModel.cancelNetworkSwitch() }) {
-                    Text("Cancel")
+                    Text(stringResource(R.string.settings_cancel))
                 }
             }
         )
@@ -235,7 +235,7 @@ fun SettingsScreen(
     if (uiState.showSyncStrategyDialog) {
         AlertDialog(
             onDismissRequest = { viewModel.hideSyncStrategyDialog() },
-            title = { Text("Wallet Sync Strategy") },
+            title = { Text(stringResource(R.string.settings_sync_strategy_title)) },
             text = {
                 androidx.compose.foundation.layout.Column {
                     SyncStrategy.entries.forEach { strategy ->
@@ -274,7 +274,7 @@ fun SettingsScreen(
     if (uiState.showThemeDialog) {
         AlertDialog(
             onDismissRequest = { viewModel.hideThemeDialog() },
-            title = { Text("Theme") },
+            title = { Text(stringResource(R.string.settings_theme_title)) },
             text = {
                 androidx.compose.foundation.layout.Column {
                     ThemeMode.entries.forEach { mode ->
@@ -388,7 +388,7 @@ private fun SettingsScreenUI(
         containerColor = MaterialTheme.colorScheme.surface,
         topBar = {
             TopAppBar(
-                title = { Text("Settings", fontWeight = FontWeight.SemiBold) },
+                title = { Text(stringResource(R.string.settings_title), fontWeight = FontWeight.SemiBold) },
                 colors = TopAppBarDefaults.topAppBarColors(
                     containerColor = MaterialTheme.colorScheme.surface
                 )

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -213,6 +213,60 @@
     <string name="node_status_export_logs">Export Logs</string>
     <!-- endregion -->
 
+    <!-- region: SecuritySettings -->
+    <string name="security_settings_title">Security Settings</string>
+    <string name="security_settings_continue">Continue</string>
+    <string name="security_settings_cancel">Cancel</string>
+    <string name="security_settings_pin_required_title">PIN is required</string>
+    <string name="security_settings_pin_required_ok">OK</string>
+    <string name="security_settings_remove_pin_title">Remove PIN?</string>
+    <string name="security_settings_remove_pin_body">Your wallet will no longer be locked on launch. This also disables biometric unlock.</string>
+    <string name="security_settings_remove">Remove</string>
+    <string name="security_settings_pin_enabled">PIN is enabled</string>
+    <string name="security_settings_change_pin">Change PIN</string>
+    <string name="security_settings_set_pin">Set PIN</string>
+    <!-- endregion -->
+
+    <!-- region: Settings extra -->
+    <string name="settings_allow_notifications_title">Allow Notifications</string>
+    <string name="settings_allow">Allow</string>
+    <string name="settings_skip">Skip</string>
+    <string name="settings_switch_network_title">Switch to CKB %1$s?</string>
+    <string name="settings_switch_restart">Switch &amp; Restart</string>
+    <string name="settings_cancel">Cancel</string>
+    <string name="settings_sync_strategy_title">Wallet Sync Strategy</string>
+    <string name="settings_theme_title">Theme</string>
+    <string name="settings_title">Settings</string>
+    <!-- endregion -->
+
+    <!-- region: Send extra -->
+    <string name="send_auth_biometric_title">Authenticate to Send</string>
+    <string name="send_auth_biometric_subtitle">Verify your identity to send CKB</string>
+    <string name="send_auth_biometric_negative">Use PIN</string>
+    <string name="send_scan_cd">Scan</string>
+    <string name="send_my_wallets">My Wallets</string>
+    <string name="send_send_ckb">Send CKB</string>
+    <string name="send_ok">OK</string>
+    <string name="send_retry">Retry</string>
+    <string name="send_success_cd">Success</string>
+    <string name="send_failed_cd">Failed</string>
+    <string name="send_done">Done</string>
+    <string name="send_close">Close</string>
+    <string name="send_hide">Hide</string>
+    <!-- endregion -->
+
+    <!-- region: Activity -->
+    <string name="activity_title">Activity</string>
+    <string name="activity_retry_dialog_title">Retry transaction?</string>
+    <string name="activity_retry_dialog_body">This transaction may not have reached the network. Retry?</string>
+    <string name="activity_retry">Retry</string>
+    <string name="activity_cancel">Cancel</string>
+    <string name="activity_export_csv_cd">Export CSV</string>
+    <string name="activity_copy_tx_cd">Copy TX hash</string>
+    <string name="activity_explorer_cd">View on explorer</string>
+    <string name="activity_retry_transaction">Retry Transaction</string>
+    <!-- endregion -->
+
     <!-- region: WalletManager -->
     <string name="wallet_manager_title">Wallets</string>
     <string name="wallet_manager_add_cd">Add Wallet</string>


### PR DESCRIPTION
Sixth batch of #209.

- SecuritySettings: PIN-required + Remove-PIN dialogs, title
- Settings: Allow-notifications, network-switch (parameterized network name), Wallet Sync Strategy / Theme dialogs
- Send: BiometricPrompt strings, contentDescriptions, all transaction-status buttons
- Activity: Retry transaction dialog, top bar, action CDs

Refs #209