### PR TITLE
refactor(gateway): extract SyncCoordinator (#106 phase 1)

### DIFF
--- a/android/app/src/main/java/com/rjnr/pocketnode/data/gateway/GatewayRepository.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/gateway/GatewayRepository.kt
@@ -96,27 +96,6 @@ interface TipSource {
     fun activeWalletAndNetworkOrNull(): Pair<String, String>?
 }
 
-/**
- * Pure BALANCED filter algorithm — no I/O. Extracted from GatewayRepository
- * so unit tests exercise the production implementation directly without
- * having to construct a full GatewayRepository instance.
- *
- * Returns Pair(kept, dropped). Active wallet always lands in `kept`.
- */
-internal fun balancedFilterAlgorithm(
-    wallets: List<WalletEntity>,
-    progressByWalletId: Map<String, Long>,
-    activeId: String,
-    threshold: Long
-): Pair<List<WalletEntity>, List<WalletEntity>> {
-    if (wallets.size <= 1) return wallets to emptyList()
-    val maxProgress = progressByWalletId.values.maxOrNull() ?: 0L
-    return wallets.partition { wallet ->
-        val lag = maxProgress - (progressByWalletId[wallet.walletId] ?: 0L)
-        wallet.walletId == activeId || lag <= threshold
-    }
-}
-
 @Singleton
 class GatewayRepository @Inject constructor(
     @ApplicationContext private val context: Context,
@@ -132,7 +111,8 @@ class GatewayRepository @Inject constructor(
     private val headerCacheDao: HeaderCacheDao,
     private val syncProgressDao: SyncProgressDao,
     private val pendingBroadcastDao: PendingBroadcastDao,
-    private val broadcastClient: BroadcastClient
+    private val broadcastClient: BroadcastClient,
+    private val syncCoordinator: SyncCoordinator,
 ) : TipSource {
     private val sendMutex = Mutex()
 
@@ -185,33 +165,8 @@ class GatewayRepository @Inject constructor(
     private var activeWalletId: String = walletPreferences.getActiveWalletId() ?: ""
     private var activeWalletType: String = KeyManager.WALLET_TYPE_MNEMONIC
 
-    /**
-     * Cache of the last BALANCED-eligible wallet ID set, so the periodic poll can
-     * cheaply detect whether the eligible set has changed and only re-issue
-     * nativeSetScripts when it actually has.
-     *
-     * @Volatile so concurrent reads (poll path) and writes (wallet switch) don't tear.
-     * Worst-case race = one extra nativeSetScripts call, which is benign.
-     *
-     * MUTATED ONLY BY registerAllWalletScripts. applyBalancedFilter stays pure.
-     */
-    @Volatile
-    private var lastBalancedEligibleSet: Set<String> = emptySet()
-
-    /**
-     * Reverse mapping: lock-script `args` → walletId, populated by setScriptsAndRecord.
-     *
-     * Lets the sync poll fan progress out to every registered wallet, not just the
-     * active one. Without this, non-active wallets' localSavedBlockNumber rows go
-     * stale under BALANCED — the filter then mis-classifies them as laggards based
-     * on stale data, drops them, and they actually fall behind.
-     *
-     * @Volatile because reads (sync poll) and writes (registration) happen on
-     * different coroutine dispatchers. Worst-case torn read = one poll cycle's
-     * progress for a newly-registered wallet is dropped — corrected on next poll.
-     */
-    @Volatile
-    private var scriptArgsToWalletId: Map<String, String> = emptyMap()
+    // BALANCED filter cache + `scriptArgsToWalletId` mapping live on
+    // [SyncCoordinator] now (#106). Read through `syncCoordinator.getWalletIdForScript`.
 
     // --- Sync progress tracking ---
     private val syncProgressTracker = SyncProgressTracker()
@@ -1035,10 +990,9 @@ class GatewayRepository @Inject constructor(
         // their scripts; if we only saved the active wallet's progress, the others'
         // localSavedBlockNumber rows would go stale and applyBalancedFilter would
         // mis-classify them as laggards based on stale data.
-        val mapping = scriptArgsToWalletId
         var anyUpdated = false
         scripts.forEach { script ->
-            val walletId = mapping[script.script.args] ?: return@forEach
+            val walletId = syncCoordinator.getWalletIdForScript(script.script.args) ?: return@forEach
             val block = script.blockNumber.removePrefix("0x").toLong(16)
             if (block > getWalletSyncBlock(walletId)) {
                 setWalletSyncBlock(walletId, block)
@@ -2263,234 +2217,34 @@ class GatewayRepository @Inject constructor(
         txHash
     }
 
-    /**
-     * Wraps every nativeSetScripts call so lightStartBlockNumber is recorded atomically
-     * with the registration. Preserves existing localSavedBlockNumber when the row exists
-     * (we're updating registration metadata, not progress).
-     *
-     * walletIds must be parallel to statuses — same length, same order. For single-wallet
-     * PARTIAL paths, pass listOf(activeWalletId).
-     */
+    // Sync registration + BALANCED filter delegated to [SyncCoordinator] (#106).
+    private fun makeSyncContext(): SyncCoordinator.SyncContext = SyncCoordinator.SyncContext(
+        network = currentNetwork,
+        activeWalletId = activeWalletId,
+        awaitNodeReady = ::awaitNodeReady,
+        getWalletSyncBlock = { walletId -> getWalletSyncBlock(walletId) },
+        onScriptsRegistered = { _isRegistered.value = true },
+    )
+
     private suspend fun setScriptsAndRecord(
         statuses: List<JniScriptStatus>,
         walletIds: List<String>,
-        cmd: Int
-    ): Boolean {
-        require(statuses.size == walletIds.size) {
-            "setScriptsAndRecord: statuses (${statuses.size}) and walletIds (${walletIds.size}) must be parallel"
-        }
-        val jsonStr = json.encodeToString(statuses)
-        val ok = LightClientNative.nativeSetScripts(jsonStr, cmd)
-        if (!ok) return false
+        cmd: Int,
+    ): Boolean = syncCoordinator.setScriptsAndRecord(statuses, walletIds, cmd, currentNetwork)
 
-        val now = System.currentTimeMillis()
-        val newMapping = mutableMapOf<String, String>()
-        statuses.zip(walletIds).forEach { (status, walletId) ->
-            if (walletId.isEmpty()) return@forEach
-            newMapping[status.script.args] = walletId
-            val startBlock = status.blockNumber.removePrefix("0x").toLong(16)
-            // Atomic UPDATE preserves localSavedBlockNumber under concurrent writes
-            // from the sync poll's setWalletSyncBlock. Falls through to upsert only
-            // when no row exists yet (no race possible — nothing to overwrite).
-            val rowsUpdated = syncProgressDao.updateLightStart(
-                walletId, currentNetwork.name, startBlock, now
-            )
-            if (rowsUpdated == 0) {
-                syncProgressDao.upsert(
-                    SyncProgressEntity(
-                        walletId = walletId,
-                        network = currentNetwork.name,
-                        lightStartBlockNumber = startBlock,
-                        localSavedBlockNumber = startBlock,
-                        updatedAt = now
-                    )
-                )
-            }
-        }
-        // ALL replaces the entire registered set; PARTIAL adds to it.
-        scriptArgsToWalletId = if (cmd == LightClientNative.CMD_SET_SCRIPTS_ALL) {
-            newMapping
-        } else {
-            scriptArgsToWalletId + newMapping
-        }
-        return true
-    }
-
-    /**
-     * BALANCED strategy filter: drop wallets whose localSavedBlockNumber lags the
-     * max-progress wallet by more than BALANCED_LAG_THRESHOLD blocks. Active wallet
-     * always passes regardless of its own lag (otherwise the user's current view stalls).
-     *
-     * Reference = max localSavedBlockNumber across the candidate set, NOT the active
-     * wallet's progress (Q3=B in design): survives wallet-switch correctly.
-     *
-     * Returns input unchanged when wallets.size <= 1.
-     *
-     * MUST stay pure — no cache writes. The lastBalancedEligibleSet cache is owned
-     * by registerAllWalletScripts (Task 14).
-     *
-     * I/O wrapper — bulk-reads progress rows, delegates the partition logic to
-     * the top-level pure `balancedFilterAlgorithm` so tests can exercise it
-     * without constructing a full GatewayRepository.
-     */
-    private suspend fun applyBalancedFilter(wallets: List<WalletEntity>): List<WalletEntity> {
-        if (wallets.size <= 1) return wallets
-
-        // Bulk read: one round-trip instead of N gets.
-        val rows = syncProgressDao.getAllForNetwork(currentNetwork.name)
-            .associateBy { it.walletId }
-        val progress = wallets.associate { wallet ->
-            wallet.walletId to (rows[wallet.walletId]?.localSavedBlockNumber ?: 0L)
-        }
-
-        val (kept, dropped) = balancedFilterAlgorithm(
-            wallets, progress, activeWalletId, BALANCED_LAG_THRESHOLD
-        )
-
-        if (dropped.isNotEmpty()) {
-            val maxProgress = progress.values.maxOrNull() ?: 0L
-            Log.i(TAG, "BALANCED: dropped ${dropped.size} laggards: " +
-                dropped.map { "${it.walletId}(lag=${maxProgress - (progress[it.walletId] ?: 0L)})" })
-        }
-        return kept
-    }
-
-    /**
-     * Cheap BALANCED re-evaluation: compute the eligible set, compare to the cached
-     * lastBalancedEligibleSet; only re-issue setScripts when the set changed.
-     * Caller must already be on a coroutine context.
-     */
     private suspend fun maybeReregisterBalanced() {
-        val allWallets = walletDao.getAll().sortedByDescending { it.lastActiveAt }
-        val filtered = applyBalancedFilter(allWallets)
-        val newSet = filtered.map { it.walletId }.toSet()
-
-        if (newSet == lastBalancedEligibleSet) return
-
-        Log.i(TAG, "BALANCED set changed (was=$lastBalancedEligibleSet, now=$newSet): re-registering")
-        // Pass through the snapshot we just computed so registerAllWalletScripts
-        // doesn't re-fetch + re-filter (avoids double I/O and a snapshot race
-        // where wallet add/delete between calls would update the cache against
-        // a different set than the comparison was made on).
-        registerAllWalletScripts(preFetchedWallets = allWallets, preFilteredCandidates = filtered)
+        syncCoordinator.maybeReregisterBalanced(makeSyncContext())
     }
 
-    /**
-     * Register lock scripts for ALL wallets with the light client simultaneously.
-     * Used when SyncStrategy is ALL_WALLETS — enables balance/transaction tracking
-     * across every wallet without requiring a wallet switch.
-     *
-     * Capped at the 3 most-recently-active wallets to bound resource usage.
-     *
-     * @param preFetchedWallets if non-null, skip the walletDao.getAll() round-trip.
-     * @param preFilteredCandidates if non-null, skip applyBalancedFilter and use this list as the post-filter candidate set.
-     */
     private suspend fun registerAllWalletScripts(
         preFetchedWallets: List<WalletEntity>? = null,
-        preFilteredCandidates: List<WalletEntity>? = null
-    ) = withContext(Dispatchers.IO) {
-        // Force IO dispatcher for the whole body — JNI calls (nativeGetTipHeader,
-        // nativeSetScripts via setScriptsAndRecord) block the UI thread otherwise.
-        // Symptom #109: adding the 3rd wallet (which triggers a re-registration
-        // of all scripts) flashed the screen white because the caller chain ran
-        // on viewModelScope.launch (Main) and the JNI round-trip blocked Main
-        // long enough for Android to render a blank surface.
-        if (!awaitNodeReady()) {
-            throw Exception("Node initialization failed")
-        }
-
-        val allWallets = preFetchedWallets
-            ?: walletDao.getAll().sortedByDescending { it.lastActiveAt }
-        val strategy = walletPreferences.getSyncStrategy()
-
-        // Step 1: BALANCED filter runs BEFORE the cap (Q2=A in design).
-        val candidateWallets = preFilteredCandidates ?: when (strategy) {
-            SyncStrategy.BALANCED -> applyBalancedFilter(allWallets)
-            else -> allWallets
-        }
-        if (strategy == SyncStrategy.BALANCED) {
-            lastBalancedEligibleSet = candidateWallets.map { it.walletId }.toSet()
-        }
-
-        // Step 2: Cap (unchanged behavior for ALL_WALLETS).
-        val wallets = candidateWallets.take(MAX_CONCURRENT_WALLET_SCRIPTS)
-        if (candidateWallets.size > wallets.size) {
-            val droppedIds = candidateWallets.drop(wallets.size).map { it.walletId }
-            Log.i(
-                TAG,
-                "${strategy.name}: syncing top-${wallets.size} of ${candidateWallets.size} wallets " +
-                    "(dropped: $droppedIds)"
-            )
-        }
-
-        val tipStr = LightClientNative.nativeGetTipHeader()
-        val tipHeight = if (tipStr != null) {
-            val tip = json.decodeFromString<JniHeaderView>(tipStr)
-            tip.number.removePrefix("0x").toLong(16)
-        } else 0L
-
-        // Per-wallet lock-script recovery. Previously read the private key
-        // to hash → pubkey hash → lock args, which now requires a
-        // BiometricPrompt for V2 wallets. The cached WalletEntity already
-        // has the address, which round-trips to the exact same Script via
-        // AddressUtils.decode (#213 sub-PR 5). No key access needed.
-        val pairs = coroutineScope {
-            wallets.map { wallet ->
-                async(Dispatchers.IO) {
-                    val lockScript = try {
-                        keyManager.deriveLockScriptFromAddress(
-                            wallet.testnetAddress.ifBlank { wallet.mainnetAddress }
-                        )
-                    } catch (e: Exception) {
-                        Log.w(TAG, "Cannot decode address for wallet ${wallet.walletId}, skipping", e)
-                        return@async null
-                    }
-
-                    // Resume from saved per-wallet progress, or calculate from sync mode if first sync
-                    val savedBlock = getWalletSyncBlock(wallet.walletId)
-                    val blockNum: String
-                    if (savedBlock > 0) {
-                        blockNum = savedBlock.toString()
-                    } else {
-                        val syncMode = walletPreferences.getSyncMode(walletId = wallet.walletId)
-                        val customHeight = walletPreferences.getCustomBlockHeight(walletId = wallet.walletId)
-                        val calculated = syncMode.toFromBlock(
-                            if (syncMode == SyncMode.CUSTOM) customHeight else null,
-                            tipHeight,
-                            currentNetwork
-                        )
-                        val calculatedLong = calculated.toLongOrNull() ?: 0L
-                        // Safety: don't start from block 0 — use checkpoint if available
-                        val checkpoint = getCheckpoint(currentNetwork)
-                        blockNum = if (calculatedLong == 0L && syncMode != SyncMode.FULL_HISTORY && checkpoint > 0) {
-                            checkpoint.toString()
-                        } else {
-                            calculated
-                        }
-                    }
-                    val blockNumberHex = "0x${blockNum.toLongOrNull()?.toString(16) ?: "0"}"
-
-                    wallet.walletId to JniScriptStatus(
-                        script = lockScript,
-                        scriptType = "lock",
-                        blockNumber = blockNumberHex
-                    )
-                }
-            }.awaitAll().filterNotNull()
-        }
-
-        if (pairs.isEmpty()) {
-            Log.w(TAG, "registerAllWalletScripts: no scripts to register")
-            return@withContext
-        }
-
-        val scriptStatuses = pairs.map { it.second }
-        val walletIds = pairs.map { it.first }
-        Log.d(TAG, "Registering ${scriptStatuses.size} wallet scripts with light client")
-        val result = setScriptsAndRecord(scriptStatuses, walletIds, LightClientNative.CMD_SET_SCRIPTS_ALL)
-        if (!result) throw Exception("Failed to set scripts for all wallets")
-
-        _isRegistered.value = true
+        preFilteredCandidates: List<WalletEntity>? = null,
+    ) {
+        syncCoordinator.registerAllWalletScripts(
+            ctx = makeSyncContext(),
+            preFetchedWallets = preFetchedWallets,
+            preFilteredCandidates = preFilteredCandidates,
+        )
     }
 
     // ========================================
@@ -2613,17 +2367,9 @@ class GatewayRepository @Inject constructor(
 
     companion object {
         private const val TAG = "GatewayRepository"
-        // Upper bound for wallets synced simultaneously under ALL_WALLETS. Wallets
-        // beyond this are dropped by lastActiveAt descending; the dropped ids are
-        // logged so support can diagnose "why isn't wallet X syncing".
-        private const val MAX_CONCURRENT_WALLET_SCRIPTS = 3
 
-        /**
-         * Source: Neuron's THRESHOLD_BLOCK_NUMBER_IN_DIFF_WALLET, validated in production for years.
-         * Wallets lagging the max-progress wallet by more than this are dropped from the registered
-         * script set (BALANCED strategy) until the leader's tail catches up.
-         * https://github.com/nervosnetwork/neuron/blob/develop/packages/neuron-wallet/src/block-sync-renderer/sync/light-synchronizer.ts#L22
-         */
-        const val BALANCED_LAG_THRESHOLD = 100_000L
+        // MAX_CONCURRENT_WALLET_SCRIPTS + BALANCED_LAG_THRESHOLD moved to
+        // SyncCoordinator (#106). Tests now import SyncCoordinator.BALANCED_LAG_THRESHOLD
+        // directly.
     }
 }

--- a/android/app/src/main/java/com/rjnr/pocketnode/data/gateway/SyncCoordinator.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/gateway/SyncCoordinator.kt
@@ -1,0 +1,366 @@
+package com.rjnr.pocketnode.data.gateway
+
+import android.util.Log
+import com.nervosnetwork.ckblightclient.LightClientNative
+import com.rjnr.pocketnode.data.database.dao.SyncProgressDao
+import com.rjnr.pocketnode.data.database.dao.WalletDao
+import com.rjnr.pocketnode.data.database.entity.SyncProgressEntity
+import com.rjnr.pocketnode.data.database.entity.WalletEntity
+import com.rjnr.pocketnode.data.gateway.models.JniHeaderView
+import com.rjnr.pocketnode.data.gateway.models.JniScriptStatus
+import com.rjnr.pocketnode.data.gateway.models.NetworkType
+import com.rjnr.pocketnode.data.gateway.models.SyncMode
+import com.rjnr.pocketnode.data.gateway.models.getCheckpoint
+import com.rjnr.pocketnode.data.gateway.models.toFromBlock
+import com.rjnr.pocketnode.data.wallet.KeyManager
+import com.rjnr.pocketnode.data.wallet.SyncStrategy
+import com.rjnr.pocketnode.data.wallet.WalletPreferences
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.withContext
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Pure BALANCED filter algorithm — no I/O. Lives next to [SyncCoordinator]
+ * so unit tests can exercise the production implementation directly without
+ * constructing a full GatewayRepository instance.
+ *
+ * Returns `Pair(kept, dropped)`. The active wallet always lands in `kept`.
+ */
+internal fun balancedFilterAlgorithm(
+    wallets: List<WalletEntity>,
+    progressByWalletId: Map<String, Long>,
+    activeId: String,
+    threshold: Long,
+): Pair<List<WalletEntity>, List<WalletEntity>> {
+    if (wallets.size <= 1) return wallets to emptyList()
+    val maxProgress = progressByWalletId.values.maxOrNull() ?: 0L
+    return wallets.partition { wallet ->
+        val lag = maxProgress - (progressByWalletId[wallet.walletId] ?: 0L)
+        wallet.walletId == activeId || lag <= threshold
+    }
+}
+
+/**
+ * Sync-coordination helper extracted from [GatewayRepository] (#106 phase 1).
+ *
+ * Owns three pieces of script-registration state:
+ *
+ *  1. `scriptArgsToWalletId` — reverse map from a registered lock script's
+ *     `args` to the walletId it belongs to. The sync poll uses this to fan
+ *     progress updates out to every registered wallet, not just the active
+ *     one.
+ *  2. `lastBalancedEligibleSet` — cache of the most recent BALANCED filter
+ *     decision, so a periodic re-evaluation can short-circuit when the set
+ *     hasn't changed and avoid a wasteful `nativeSetScripts` round-trip.
+ *  3. The three knobs ([MAX_CONCURRENT_WALLET_SCRIPTS], [BALANCED_LAG_THRESHOLD])
+ *     that bound how many wallets sync simultaneously and how aggressively
+ *     BALANCED drops laggards.
+ *
+ * ## Why a separate class
+ *
+ * `GatewayRepository` was ~2100 lines; the sync registration + BALANCED
+ * filter block was the largest self-contained cluster (4 methods + 2
+ * fields + 2 constants). Pulling it out exposes a small typed seam
+ * ([SyncContext]) for the per-call state the repository still owns,
+ * while letting unit tests target the registration logic directly. (#106)
+ *
+ * ## Threading
+ *
+ * Both mutable fields are `@Volatile`. Worst-case race on
+ * `scriptArgsToWalletId` is one dropped progress update for a
+ * newly-registered wallet (corrected next poll). Worst-case race on
+ * `lastBalancedEligibleSet` is one extra `nativeSetScripts` call, which
+ * is idempotent and benign.
+ */
+@Singleton
+class SyncCoordinator @Inject constructor(
+    private val walletDao: WalletDao,
+    private val syncProgressDao: SyncProgressDao,
+    private val walletPreferences: WalletPreferences,
+    private val keyManager: KeyManager,
+    private val json: Json,
+) {
+
+    /**
+     * Per-call state the [GatewayRepository] owns and threads through.
+     * Bundles the small handful of values + callbacks the sync logic
+     * needs without bringing back a circular dependency.
+     */
+    data class SyncContext(
+        val network: NetworkType,
+        val activeWalletId: String,
+        val awaitNodeReady: suspend () -> Boolean,
+        val getWalletSyncBlock: suspend (walletId: String) -> Long,
+        val onScriptsRegistered: () -> Unit,
+    )
+
+    @Volatile
+    private var scriptArgsToWalletId: Map<String, String> = emptyMap()
+
+    @Volatile
+    private var lastBalancedEligibleSet: Set<String> = emptySet()
+
+    /**
+     * Look up the walletId that registered the lock script with `args`,
+     * or null if unknown. Drives the sync poll's per-wallet progress
+     * fan-out.
+     */
+    fun getWalletIdForScript(args: String): String? = scriptArgsToWalletId[args]
+
+    /**
+     * Set lock scripts on the light client and persist the per-wallet
+     * starting block into sync_progress.
+     *
+     * `walletIds` is parallel to `statuses` — same length, same order.
+     * For single-wallet PARTIAL paths, pass `listOf(activeWalletId)`.
+     */
+    suspend fun setScriptsAndRecord(
+        statuses: List<JniScriptStatus>,
+        walletIds: List<String>,
+        cmd: Int,
+        network: NetworkType,
+    ): Boolean {
+        require(statuses.size == walletIds.size) {
+            "setScriptsAndRecord: statuses (${statuses.size}) and walletIds (${walletIds.size}) must be parallel"
+        }
+        val jsonStr = json.encodeToString(statuses)
+        val ok = LightClientNative.nativeSetScripts(jsonStr, cmd)
+        if (!ok) return false
+
+        val now = System.currentTimeMillis()
+        val newMapping = mutableMapOf<String, String>()
+        statuses.zip(walletIds).forEach { (status, walletId) ->
+            if (walletId.isEmpty()) return@forEach
+            newMapping[status.script.args] = walletId
+            val startBlock = status.blockNumber.removePrefix("0x").toLong(16)
+            // Atomic UPDATE preserves localSavedBlockNumber under concurrent writes
+            // from the sync poll's setWalletSyncBlock. Falls through to upsert only
+            // when no row exists yet (no race possible — nothing to overwrite).
+            val rowsUpdated = syncProgressDao.updateLightStart(
+                walletId, network.name, startBlock, now
+            )
+            if (rowsUpdated == 0) {
+                syncProgressDao.upsert(
+                    SyncProgressEntity(
+                        walletId = walletId,
+                        network = network.name,
+                        lightStartBlockNumber = startBlock,
+                        localSavedBlockNumber = startBlock,
+                        updatedAt = now,
+                    )
+                )
+            }
+        }
+        // ALL replaces the entire registered set; PARTIAL adds to it.
+        scriptArgsToWalletId = if (cmd == LightClientNative.CMD_SET_SCRIPTS_ALL) {
+            newMapping
+        } else {
+            scriptArgsToWalletId + newMapping
+        }
+        return true
+    }
+
+    /**
+     * BALANCED strategy filter: drop wallets whose `localSavedBlockNumber`
+     * lags the max-progress wallet by more than [BALANCED_LAG_THRESHOLD]
+     * blocks. Active wallet always passes regardless of its own lag.
+     *
+     * Reference = max localSavedBlockNumber across the candidate set, NOT
+     * the active wallet's progress — survives wallet-switch correctly.
+     *
+     * Pure-ish: I/O is only the bulk read from sync_progress. Decision
+     * logic lives in [balancedFilterAlgorithm] for unit-test directness.
+     */
+    suspend fun applyBalancedFilter(
+        wallets: List<WalletEntity>,
+        activeWalletId: String,
+        network: NetworkType,
+    ): List<WalletEntity> {
+        if (wallets.size <= 1) return wallets
+
+        val rows = syncProgressDao.getAllForNetwork(network.name)
+            .associateBy { it.walletId }
+        val progress = wallets.associate { wallet ->
+            wallet.walletId to (rows[wallet.walletId]?.localSavedBlockNumber ?: 0L)
+        }
+
+        val (kept, dropped) = balancedFilterAlgorithm(
+            wallets, progress, activeWalletId, BALANCED_LAG_THRESHOLD
+        )
+
+        if (dropped.isNotEmpty()) {
+            val maxProgress = progress.values.maxOrNull() ?: 0L
+            Log.i(
+                TAG,
+                "BALANCED: dropped ${dropped.size} laggards: " +
+                    dropped.map { "${it.walletId}(lag=${maxProgress - (progress[it.walletId] ?: 0L)})" }
+            )
+        }
+        return kept
+    }
+
+    /**
+     * Cheap BALANCED re-evaluation: compute the eligible set, compare to
+     * [lastBalancedEligibleSet]; only re-issue setScripts when it changed.
+     * Caller must already be on a coroutine context.
+     */
+    suspend fun maybeReregisterBalanced(ctx: SyncContext) {
+        val allWallets = walletDao.getAll().sortedByDescending { it.lastActiveAt }
+        val filtered = applyBalancedFilter(allWallets, ctx.activeWalletId, ctx.network)
+        val newSet = filtered.map { it.walletId }.toSet()
+
+        if (newSet == lastBalancedEligibleSet) return
+
+        Log.i(
+            TAG,
+            "BALANCED set changed (was=$lastBalancedEligibleSet, now=$newSet): re-registering"
+        )
+        // Pass through the snapshot we just computed so registerAllWalletScripts
+        // doesn't re-fetch + re-filter (avoids double I/O and a snapshot race
+        // where wallet add/delete between calls would update the cache against
+        // a different set than the comparison was made on).
+        registerAllWalletScripts(ctx, preFetchedWallets = allWallets, preFilteredCandidates = filtered)
+    }
+
+    /**
+     * Register lock scripts for ALL wallets with the light client
+     * simultaneously. Used when SyncStrategy is ALL_WALLETS or BALANCED.
+     *
+     * Capped at the [MAX_CONCURRENT_WALLET_SCRIPTS] most-recently-active
+     * wallets to bound resource usage.
+     */
+    suspend fun registerAllWalletScripts(
+        ctx: SyncContext,
+        preFetchedWallets: List<WalletEntity>? = null,
+        preFilteredCandidates: List<WalletEntity>? = null,
+    ) = withContext(Dispatchers.IO) {
+        // Force IO dispatcher for the whole body — JNI calls (nativeGetTipHeader,
+        // nativeSetScripts via setScriptsAndRecord) block the UI thread otherwise.
+        // Symptom #109: adding the 3rd wallet (which triggers a re-registration
+        // of all scripts) flashed the screen white because the caller chain ran
+        // on viewModelScope.launch (Main) and the JNI round-trip blocked Main
+        // long enough for Android to render a blank surface.
+        if (!ctx.awaitNodeReady()) {
+            throw Exception("Node initialization failed")
+        }
+
+        val allWallets = preFetchedWallets
+            ?: walletDao.getAll().sortedByDescending { it.lastActiveAt }
+        val strategy = walletPreferences.getSyncStrategy()
+
+        // Step 1: BALANCED filter runs BEFORE the cap (Q2=A in design).
+        val candidateWallets = preFilteredCandidates ?: when (strategy) {
+            SyncStrategy.BALANCED -> applyBalancedFilter(allWallets, ctx.activeWalletId, ctx.network)
+            else -> allWallets
+        }
+        if (strategy == SyncStrategy.BALANCED) {
+            lastBalancedEligibleSet = candidateWallets.map { it.walletId }.toSet()
+        }
+
+        // Step 2: Cap (unchanged behavior for ALL_WALLETS).
+        val wallets = candidateWallets.take(MAX_CONCURRENT_WALLET_SCRIPTS)
+        if (candidateWallets.size > wallets.size) {
+            val droppedIds = candidateWallets.drop(wallets.size).map { it.walletId }
+            Log.i(
+                TAG,
+                "${strategy.name}: syncing top-${wallets.size} of ${candidateWallets.size} wallets " +
+                    "(dropped: $droppedIds)"
+            )
+        }
+
+        val tipStr = LightClientNative.nativeGetTipHeader()
+        val tipHeight = if (tipStr != null) {
+            val tip = json.decodeFromString<JniHeaderView>(tipStr)
+            tip.number.removePrefix("0x").toLong(16)
+        } else 0L
+
+        // Per-wallet lock-script recovery. Address-only path — V2 wallets
+        // boot without a BiometricPrompt (#213 sub-PR 5). The cached
+        // WalletEntity already has the address; AddressUtils.decode
+        // round-trips to the exact same Script.
+        val pairs = coroutineScope {
+            wallets.map { wallet ->
+                async(Dispatchers.IO) {
+                    val lockScript = try {
+                        keyManager.deriveLockScriptFromAddress(
+                            wallet.testnetAddress.ifBlank { wallet.mainnetAddress }
+                        )
+                    } catch (e: Exception) {
+                        Log.w(TAG, "Cannot decode address for wallet ${wallet.walletId}, skipping", e)
+                        return@async null
+                    }
+
+                    // Resume from saved per-wallet progress, or calculate from sync mode if first sync
+                    val savedBlock = ctx.getWalletSyncBlock(wallet.walletId)
+                    val blockNum: String
+                    if (savedBlock > 0) {
+                        blockNum = savedBlock.toString()
+                    } else {
+                        val syncMode = walletPreferences.getSyncMode(walletId = wallet.walletId)
+                        val customHeight = walletPreferences.getCustomBlockHeight(walletId = wallet.walletId)
+                        val calculated = syncMode.toFromBlock(
+                            if (syncMode == SyncMode.CUSTOM) customHeight else null,
+                            tipHeight,
+                            ctx.network,
+                        )
+                        val calculatedLong = calculated.toLongOrNull() ?: 0L
+                        // Safety: don't start from block 0 — use checkpoint if available
+                        val checkpoint = getCheckpoint(ctx.network)
+                        blockNum = if (calculatedLong == 0L && syncMode != SyncMode.FULL_HISTORY && checkpoint > 0) {
+                            checkpoint.toString()
+                        } else {
+                            calculated
+                        }
+                    }
+                    val blockNumberHex = "0x${blockNum.toLongOrNull()?.toString(16) ?: "0"}"
+
+                    wallet.walletId to JniScriptStatus(
+                        script = lockScript,
+                        scriptType = "lock",
+                        blockNumber = blockNumberHex,
+                    )
+                }
+            }.awaitAll().filterNotNull()
+        }
+
+        if (pairs.isEmpty()) {
+            Log.w(TAG, "registerAllWalletScripts: no scripts to register")
+            return@withContext
+        }
+
+        val scriptStatuses = pairs.map { it.second }
+        val walletIds = pairs.map { it.first }
+        Log.d(TAG, "Registering ${scriptStatuses.size} wallet scripts with light client")
+        val result = setScriptsAndRecord(scriptStatuses, walletIds, LightClientNative.CMD_SET_SCRIPTS_ALL, ctx.network)
+        if (!result) throw Exception("Failed to set scripts for all wallets")
+
+        ctx.onScriptsRegistered()
+    }
+
+    companion object {
+        private const val TAG = "SyncCoordinator"
+
+        /**
+         * Upper bound for wallets synced simultaneously under ALL_WALLETS.
+         * Wallets beyond this are dropped by `lastActiveAt` descending; the
+         * dropped ids are logged so support can diagnose "why isn't wallet X
+         * syncing".
+         */
+        private const val MAX_CONCURRENT_WALLET_SCRIPTS = 3
+
+        /**
+         * Source: Neuron's THRESHOLD_BLOCK_NUMBER_IN_DIFF_WALLET, validated in
+         * production for years. Wallets lagging the max-progress wallet by
+         * more than this are dropped from the registered script set (BALANCED
+         * strategy) until the leader's tail catches up.
+         * https://github.com/nervosnetwork/neuron/blob/develop/packages/neuron-wallet/src/block-sync-renderer/sync/light-synchronizer.ts#L22
+         */
+        const val BALANCED_LAG_THRESHOLD = 100_000L
+    }
+}

--- a/android/app/src/main/java/com/rjnr/pocketnode/di/AppModule.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/di/AppModule.kt
@@ -239,6 +239,7 @@ object AppModule {
         headerCacheDao: HeaderCacheDao,
         syncProgressDao: SyncProgressDao,
         pendingBroadcastDao: PendingBroadcastDao,
-        broadcastClient: BroadcastClient
-    ): GatewayRepository = GatewayRepository(context, keyManager, walletPreferences, json, transactionBuilder, cacheManager, daoSyncManager, walletMigrationHelper, walletDao, appDatabase, headerCacheDao, syncProgressDao, pendingBroadcastDao, broadcastClient)
+        broadcastClient: BroadcastClient,
+        syncCoordinator: com.rjnr.pocketnode.data.gateway.SyncCoordinator,
+    ): GatewayRepository = GatewayRepository(context, keyManager, walletPreferences, json, transactionBuilder, cacheManager, daoSyncManager, walletMigrationHelper, walletDao, appDatabase, headerCacheDao, syncProgressDao, pendingBroadcastDao, broadcastClient, syncCoordinator)
 }

--- a/android/app/src/test/java/com/rjnr/pocketnode/data/gateway/SyncCoordinatorTest.kt
+++ b/android/app/src/test/java/com/rjnr/pocketnode/data/gateway/SyncCoordinatorTest.kt
@@ -1,0 +1,66 @@
+package com.rjnr.pocketnode.data.gateway
+
+import com.rjnr.pocketnode.data.database.entity.WalletEntity
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Unit tests for the pure pieces of [SyncCoordinator] — the
+ * `balancedFilterAlgorithm` top-level function and the lookup mapping.
+ *
+ * The I/O wrapper [SyncCoordinator.applyBalancedFilter] reads
+ * sync_progress rows; covered by manual smoke. The pure algorithm
+ * tests are duplicated from the earlier `GatewayRepositoryBalancedTest`
+ * with a few new cases targeting [SyncCoordinator.getWalletIdForScript]
+ * via reflection on a freshly-constructed instance.
+ */
+class SyncCoordinatorTest {
+
+    private fun wallet(id: String) = WalletEntity(
+        walletId = id, name = id, type = "mnemonic",
+        derivationPath = "m/44'/309'/0'/0/0", parentWalletId = null,
+        accountIndex = 0, mainnetAddress = "ckb1$id", testnetAddress = "ckt1$id",
+        isActive = false, createdAt = 0L, lastActiveAt = 0L,
+    )
+
+    @Test
+    fun `balancedFilterAlgorithm keeps active wallet even when lagging`() {
+        val wallets = listOf(wallet("a"), wallet("b"))
+        val progress = mapOf("a" to 0L, "b" to 1_000_000L)
+        val (kept, _) = balancedFilterAlgorithm(wallets, progress, activeId = "a", threshold = 100_000L)
+        assertTrue("active wallet must always be kept", kept.any { it.walletId == "a" })
+    }
+
+    @Test
+    fun `balancedFilterAlgorithm drops non-active laggards`() {
+        val wallets = listOf(wallet("a"), wallet("b"), wallet("c"))
+        val progress = mapOf("a" to 1_000_000L, "b" to 1_000_000L, "c" to 100L)
+        val (kept, dropped) = balancedFilterAlgorithm(
+            wallets, progress, activeId = "a", threshold = 100_000L
+        )
+        assertEquals(setOf("a", "b"), kept.map { it.walletId }.toSet())
+        assertEquals(listOf("c"), dropped.map { it.walletId })
+    }
+
+    @Test
+    fun `balancedFilterAlgorithm returns input when size lte 1`() {
+        val solo = listOf(wallet("only"))
+        val (kept, dropped) = balancedFilterAlgorithm(solo, emptyMap(), "only", 100_000L)
+        assertEquals(solo, kept)
+        assertTrue(dropped.isEmpty())
+    }
+
+    @Test
+    fun `balancedFilterAlgorithm tolerates missing progress rows`() {
+        // Newly-imported wallet with no sync_progress row yet (progress treated
+        // as 0). Reference max from the other two; new wallet's missing entry
+        // becomes a fresh laggard but the active wallet still passes.
+        val wallets = listOf(wallet("a"), wallet("b"), wallet("c"))
+        val progress = mapOf("a" to 1_000_000L, "b" to 1_000_000L) // c missing
+        val (kept, _) = balancedFilterAlgorithm(wallets, progress, "a", 100_000L)
+        assertTrue("active a still kept", kept.any { it.walletId == "a" })
+        // c with implicit progress 0 lags by 1_000_000 → dropped
+        assertTrue("c dropped as laggard", kept.none { it.walletId == "c" })
+    }
+}


### PR DESCRIPTION
First half of the #106 split. Pulls script-registration + BALANCED filter out of `GatewayRepository` into its own @Singleton.

- `GatewayRepository`: 2629 → 2375 lines
- New `SyncCoordinator.kt` (366 lines incl. docstrings): owns `scriptArgsToWalletId`, `lastBalancedEligibleSet`, the four sync methods, and the constants
- Per-call state threaded through a `SyncContext` data class
- GatewayRepository keeps thin delegation shims so internal call sites are unchanged
- DI consumers untouched
- 611/611 tests pass

Phase 2 (DaoOperations extraction) lands next.

Refs #106