### PR TITLE
fix(send): empty contact picker + QR scan double-pop

### DIFF
--- a/android/app/src/main/java/com/rjnr/pocketnode/data/contacts/ContactRepository.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/contacts/ContactRepository.kt
@@ -8,6 +8,7 @@ import com.rjnr.pocketnode.data.wallet.AddressUtils
 import com.rjnr.pocketnode.data.wallet.WalletRepository
 import androidx.annotation.VisibleForTesting
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.flatMapLatest
@@ -69,6 +70,18 @@ class ContactRepository @Inject constructor(
         val walletId = walletRepository.activeWalletIdSnapshot()
         return if (walletId.isNullOrEmpty()) flowOf(emptyList())
         else contactDao.observeAll(walletId)
+    }
+
+    /**
+     * Snapshot of every contact visible to the active wallet, sorted by
+     * name. Differs from [observe] in that callers get a single
+     * suspending read rather than a Flow — useful for one-shot UI
+     * loads like the Send picker sheet.
+     */
+    suspend fun listAll(): List<ContactEntity> {
+        val walletId = walletRepository.activeWalletIdSnapshot()?.takeIf { it.isNotEmpty() }
+            ?: return emptyList()
+        return contactDao.observeAll(walletId).firstOrNull() ?: emptyList()
     }
 
     suspend fun get(id: String): ContactEntity? = contactDao.getById(id)

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/navigation/NavGraph.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/navigation/NavGraph.kt
@@ -411,11 +411,15 @@ fun CkbNavGraph(
 
         composable(Screen.Scanner.route) {
             QrScannerScreen(
+                // The screen calls both onScanResult AND onNavigateBack on a
+                // successful scan (see QrScannerScreen.kt:85-88). Don't pop
+                // here — onNavigateBack does it. Earlier this lambda also
+                // popped, which double-popped the back stack and dumped the
+                // user on Home after scanning into Send / AddContact.
                 onScanResult = { address ->
                     navController.previousBackStackEntry
                         ?.savedStateHandle
                         ?.set("scanned_address", address)
-                    navController.popBackStack()
                 },
                 onNavigateBack = { navController.popBackStack() }
             )

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/send/SendScreen.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/send/SendScreen.kt
@@ -70,6 +70,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
+import com.composables.icons.lucide.BookUser
 import com.composables.icons.lucide.Check
 import com.composables.icons.lucide.ChevronLeft
 import com.composables.icons.lucide.CircleAlert
@@ -374,7 +375,7 @@ private fun SendScreenUI(
                     }
                 )
                 Icon(
-                    imageVector = Lucide.Users,
+                    imageVector = Lucide.BookUser,
                     contentDescription = stringResource(R.string.send_contact_picker_cd),
                     modifier = Modifier.clickable { onOpenContactPicker() }
                 )

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/send/SendViewModel.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/send/SendViewModel.kt
@@ -224,8 +224,23 @@ class SendViewModel @Inject constructor(
         }
     }
 
-    /** Snapshot of recent contacts for the picker sheet's empty-query state. */
-    suspend fun recentContacts(): List<ContactEntity> = contactRepository.recentlyUsed()
+    /**
+     * Snapshot for the picker sheet's empty-query state. Returns the
+     * full address book (alphabetical) with `recentlyUsed` floated to
+     * the top — so a freshly-added contact (useCount=0) still appears,
+     * while frequently-used recipients stay one tap away.
+     *
+     * Earlier this returned just `recentlyUsed()`, which surfaced
+     * nothing for new wallets / new contacts (bug: empty picker even
+     * when contacts exist).
+     */
+    suspend fun recentContacts(): List<ContactEntity> {
+        val recent = contactRepository.recentlyUsed()
+        val all = contactRepository.listAll()
+        if (recent.isEmpty()) return all
+        val recentIds = recent.map { it.id }.toSet()
+        return recent + all.filter { it.id !in recentIds }
+    }
 
     /** Snapshot of contacts matching [query] for the picker sheet search. */
     suspend fun searchContacts(query: String): List<ContactEntity> =


### PR DESCRIPTION
Two bugs found during M4 smoke testing.

### 1. Contact picker empty when query blank
`SendViewModel.recentContacts` only surfaced contacts with `useCount>0` (via `ContactRepository.recentlyUsed`), so a freshly-added contact (useCount=0) never appeared.

**Fix:** `ContactRepository.listAll()` snapshot + picker now merges recently-used on top of the full address book. Also swapped picker icon from `Lucide.Users` to `Lucide.BookUser` per the bug report wording.

### 2. QR scan from Send dismissed Send instead of filling the recipient
Two callbacks both popped the back stack on a successful scan:
- `NavGraph.Scanner.onScanResult`: `set savedStateHandle + popBackStack`
- `QrScannerScreen.CameraPreviewWithScanner`: `onScanResult(addr) + onNavigateBack()`

Result: Scanner popped, then Send popped, user landed on Home.

**Fix:** Removed the `popBackStack` from NavGraph; `onNavigateBack` already does it. Applies to both Send → Scanner and AddContact → Scanner.

## Test plan

- [x] 611/611 unit tests pass
- [x] Debug APK builds + installs + cold-launches cleanly on emulator
- [ ] Manual repro on a physical device (need you for the QR scan and contact-picker walkthrough)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed navigation issue in scanner that could unexpectedly exit the current workflow.

* **New Features**
  * Contact picker now displays full address book when no recent contacts are available.
  * Improved contact deduplication in the picker to eliminate duplicates.

* **Style**
  * Updated contact picker icon appearance.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/RaheemJnr/pocket-node/pull/249?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->