### PR TITLE
feat(i18n): UiMessage infrastructure + Contacts VM error i18n (#133 phase 1)

### DIFF
--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/contacts/AddContactScreen.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/contacts/AddContactScreen.kt
@@ -28,10 +28,12 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalClipboardManager
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.rjnr.pocketnode.R
+import com.rjnr.pocketnode.ui.util.resolveString
 import com.composables.icons.lucide.ArrowLeft
 import com.composables.icons.lucide.Clipboard
 import com.composables.icons.lucide.Lucide
@@ -48,6 +50,7 @@ fun AddContactScreen(
     val uiState by viewModel.uiState.collectAsState()
     val snackbarHostState = remember { SnackbarHostState() }
     val clipboard = LocalClipboardManager.current
+    val context = LocalContext.current
 
     LaunchedEffect(scannedAddress) {
         scannedAddress?.takeIf { it.isNotBlank() }?.let { viewModel.onAddressChange(it) }
@@ -58,8 +61,8 @@ fun AddContactScreen(
     }
 
     LaunchedEffect(uiState.error) {
-        uiState.error?.let {
-            snackbarHostState.showSnackbar(it)
+        uiState.error?.let { msg ->
+            snackbarHostState.showSnackbar(msg.resolveString(context))
             viewModel.clearError()
         }
     }

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/contacts/AddContactViewModel.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/contacts/AddContactViewModel.kt
@@ -2,8 +2,10 @@ package com.rjnr.pocketnode.ui.screens.contacts
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.rjnr.pocketnode.R
 import com.rjnr.pocketnode.data.contacts.ContactRepository
 import com.rjnr.pocketnode.data.gateway.GatewayRepository
+import com.rjnr.pocketnode.ui.util.UiMessage
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -24,7 +26,7 @@ class AddContactViewModel @Inject constructor(
         val notes: String = "",
         val isSaving: Boolean = false,
         val saved: Boolean = false,
-        val error: String? = null,
+        val error: UiMessage? = null,
     )
 
     private val _uiState = MutableStateFlow(UiState())
@@ -38,7 +40,7 @@ class AddContactViewModel @Inject constructor(
     fun save() {
         val state = _uiState.value
         if (state.name.isBlank() || state.address.isBlank()) {
-            _uiState.update { it.copy(error = "Name and address are required") }
+            _uiState.update { it.copy(error = UiMessage.Resource(R.string.add_contact_required_error)) }
             return
         }
         _uiState.update { it.copy(isSaving = true, error = null) }
@@ -53,19 +55,25 @@ class AddContactViewModel @Inject constructor(
             result
                 .onSuccess { _uiState.update { it.copy(isSaving = false, saved = true) } }
                 .onFailure { e ->
-                    _uiState.update { it.copy(isSaving = false, error = formatError(e)) }
+                    _uiState.update { it.copy(isSaving = false, error = errorMessage(e)) }
                 }
         }
     }
 
-    private fun formatError(e: Throwable): String = when (e) {
-        is ContactRepository.ContactError.InvalidAddress -> "Address could not be decoded — check the format"
+    private fun errorMessage(e: Throwable): UiMessage = when (e) {
+        is ContactRepository.ContactError.InvalidAddress ->
+            UiMessage.Resource(R.string.contact_error_invalid_address)
         is ContactRepository.ContactError.WrongNetwork ->
-            "This address is for ${e.actual.name.lowercase()}; switch networks or pick a different address"
-        is ContactRepository.ContactError.DuplicateAddress -> "An existing contact already uses this address"
-        is ContactRepository.ContactError.InvalidName -> "Name must be 1-64 characters"
-        is ContactRepository.ContactError.NotesTooLong -> "Notes must be 256 characters or fewer"
-        is ContactRepository.ContactError.NoActiveWallet -> "No active wallet to scope this contact to"
-        else -> e.message ?: "Could not save contact"
+            UiMessage.Resource(R.string.contact_error_wrong_network, listOf(e.actual.name.lowercase()))
+        is ContactRepository.ContactError.DuplicateAddress ->
+            UiMessage.Resource(R.string.contact_error_duplicate)
+        is ContactRepository.ContactError.InvalidName ->
+            UiMessage.Resource(R.string.contact_error_invalid_name)
+        is ContactRepository.ContactError.NotesTooLong ->
+            UiMessage.Resource(R.string.contact_error_notes_too_long)
+        is ContactRepository.ContactError.NoActiveWallet ->
+            UiMessage.Resource(R.string.contact_error_no_active_wallet)
+        else -> e.message?.let { UiMessage.Raw(it) }
+            ?: UiMessage.Resource(R.string.contact_error_generic_save)
     }
 }

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/contacts/ContactDetailScreen.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/contacts/ContactDetailScreen.kt
@@ -47,6 +47,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.rjnr.pocketnode.R
+import com.rjnr.pocketnode.ui.util.resolveString
 import com.composables.icons.lucide.ArrowLeft
 import com.composables.icons.lucide.Copy
 import com.composables.icons.lucide.Lucide
@@ -66,6 +67,7 @@ fun ContactDetailScreen(
     val uiState by viewModel.uiState.collectAsState()
     val snackbarHostState = remember { SnackbarHostState() }
     val clipboard = LocalClipboardManager.current
+    val context = androidx.compose.ui.platform.LocalContext.current
     val scope = rememberCoroutineScopeForSnack()
 
     LaunchedEffect(uiState.deleted) {
@@ -73,8 +75,8 @@ fun ContactDetailScreen(
     }
 
     LaunchedEffect(uiState.error) {
-        uiState.error?.let {
-            snackbarHostState.showSnackbar(it)
+        uiState.error?.let { msg ->
+            snackbarHostState.showSnackbar(msg.resolveString(context))
             viewModel.clearError()
         }
     }

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/contacts/ContactDetailViewModel.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/contacts/ContactDetailViewModel.kt
@@ -3,8 +3,10 @@ package com.rjnr.pocketnode.ui.screens.contacts
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.rjnr.pocketnode.R
 import com.rjnr.pocketnode.data.contacts.ContactRepository
 import com.rjnr.pocketnode.data.database.entity.ContactEntity
+import com.rjnr.pocketnode.ui.util.UiMessage
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -27,7 +29,7 @@ class ContactDetailViewModel @Inject constructor(
         val isLoading: Boolean = true,
         val showDeleteConfirm: Boolean = false,
         val deleted: Boolean = false,
-        val error: String? = null,
+        val error: UiMessage? = null,
     )
 
     private val _uiState = MutableStateFlow(UiState())
@@ -51,7 +53,11 @@ class ContactDetailViewModel @Inject constructor(
                 .onSuccess { _uiState.update { it.copy(showDeleteConfirm = false, deleted = true) } }
                 .onFailure { e ->
                     _uiState.update {
-                        it.copy(showDeleteConfirm = false, error = e.message ?: "Could not delete")
+                        it.copy(
+                            showDeleteConfirm = false,
+                            error = e.message?.let(UiMessage::Raw)
+                                ?: UiMessage.Resource(R.string.contact_error_generic_save),
+                        )
                     }
                 }
         }

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/contacts/EditContactScreen.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/contacts/EditContactScreen.kt
@@ -25,10 +25,12 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.rjnr.pocketnode.R
+import com.rjnr.pocketnode.ui.util.resolveString
 import com.composables.icons.lucide.ArrowLeft
 import com.composables.icons.lucide.Lucide
 
@@ -40,14 +42,15 @@ fun EditContactScreen(
 ) {
     val uiState by viewModel.uiState.collectAsState()
     val snackbarHostState = remember { SnackbarHostState() }
+    val context = LocalContext.current
 
     LaunchedEffect(uiState.saved) {
         if (uiState.saved) onNavigateBack()
     }
 
     LaunchedEffect(uiState.error) {
-        uiState.error?.let {
-            snackbarHostState.showSnackbar(it)
+        uiState.error?.let { msg ->
+            snackbarHostState.showSnackbar(msg.resolveString(context))
             viewModel.clearError()
         }
     }

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/contacts/EditContactViewModel.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/contacts/EditContactViewModel.kt
@@ -3,7 +3,9 @@ package com.rjnr.pocketnode.ui.screens.contacts
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.rjnr.pocketnode.R
 import com.rjnr.pocketnode.data.contacts.ContactRepository
+import com.rjnr.pocketnode.ui.util.UiMessage
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -28,7 +30,7 @@ class EditContactViewModel @Inject constructor(
         val isLoading: Boolean = true,
         val isSaving: Boolean = false,
         val saved: Boolean = false,
-        val error: String? = null,
+        val error: UiMessage? = null,
     )
 
     private val _uiState = MutableStateFlow(UiState())
@@ -38,7 +40,12 @@ class EditContactViewModel @Inject constructor(
         viewModelScope.launch {
             val contact = contactRepository.get(contactId)
             if (contact == null) {
-                _uiState.update { it.copy(isLoading = false, error = "Contact not found") }
+                _uiState.update {
+                    it.copy(
+                        isLoading = false,
+                        error = UiMessage.Resource(R.string.contact_detail_not_found),
+                    )
+                }
                 return@launch
             }
             _uiState.update {
@@ -69,7 +76,11 @@ class EditContactViewModel @Inject constructor(
                 .onSuccess { _uiState.update { it.copy(isSaving = false, saved = true) } }
                 .onFailure { e ->
                     _uiState.update {
-                        it.copy(isSaving = false, error = e.message ?: "Could not save")
+                        it.copy(
+                            isSaving = false,
+                            error = e.message?.let(UiMessage::Raw)
+                                ?: UiMessage.Resource(R.string.contact_error_generic_save),
+                        )
                     }
                 }
         }

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/util/UiMessage.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/util/UiMessage.kt
@@ -1,0 +1,55 @@
+package com.rjnr.pocketnode.ui.util
+
+import androidx.annotation.StringRes
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.res.stringResource
+
+/**
+ * Localizable user-facing message that ViewModels emit without holding
+ * a `Context`. Composables resolve via [resolve] (or the suspending
+ * `.resolveString(context)`).
+ *
+ * Two variants:
+ *
+ *  - [Resource] — `@StringRes` ID with optional positional format args.
+ *    Use for every translatable string the VM produces.
+ *  - [Raw] — verbatim text that escapes localization (chain error
+ *    passthrough, transaction hashes shown inline, etc.). Use only
+ *    when the source is genuinely untranslatable.
+ *
+ * Why a sealed type rather than `@StringRes Int`: most error paths
+ * include dynamic content ("Network switch failed: ${e.message}"),
+ * which can't be a pure resource ID. Carrying the args alongside the
+ * ID keeps the VM stringResource-free and i18n-friendly while still
+ * supporting format placeholders.
+ *
+ * Established by #133 to unblock the translation work in #132.
+ */
+sealed class UiMessage {
+    data class Resource(
+        @StringRes val id: Int,
+        val args: List<Any> = emptyList(),
+    ) : UiMessage()
+
+    /** Verbatim, non-localizable text. Avoid for new code unless the source is untranslatable. */
+    data class Raw(val text: String) : UiMessage()
+}
+
+@Composable
+fun UiMessage.resolve(): String = when (this) {
+    is UiMessage.Resource -> stringResource(id, *args.toTypedArray())
+    is UiMessage.Raw -> text
+}
+
+/**
+ * Non-@Composable resolver. Used by snackbar `showSnackbar` callbacks
+ * and other coroutine-context resolvers that can't call `stringResource`.
+ *
+ * Callers obtain the [android.content.Context] from `LocalContext.current`
+ * at the @Composable layer and pass it in. Never call from a ViewModel.
+ */
+fun UiMessage.resolveString(context: android.content.Context): String = when (this) {
+    is UiMessage.Resource ->
+        if (args.isEmpty()) context.getString(id) else context.getString(id, *args.toTypedArray())
+    is UiMessage.Raw -> text
+}


### PR DESCRIPTION
First slice of #133. ViewModels can't hold a Context, so hardcoded error strings have been blocking #132 translations. This PR introduces the [UiMessage](android/app/src/main/java/com/rjnr/pocketnode/ui/util/UiMessage.kt) sealed type and migrates the contact module as the proof of concept.

`UiMessage.Resource(@StringRes id, args)` for translatable strings, `UiMessage.Raw(text)` for verbatim passthrough (chain errors, tx hashes inline). Composables resolve via `stringResource` extension at the UI boundary; ViewModels never see Context.

Subsequent phases migrate SecuritySettings + Settings, then Auth + Recovery + Activity, then Home + Wallet, then Send + DAO.

Refs #133, blocks #132