### PR TITLE
feat(i18n): SecuritySettings + Settings VM errors (#133 phase 2)

### DIFF
--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/settings/SecuritySettingsScreen.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/settings/SecuritySettingsScreen.kt
@@ -41,6 +41,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.rjnr.pocketnode.R
+import com.rjnr.pocketnode.ui.util.resolveString
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -60,9 +61,10 @@ fun SecuritySettingsScreen(
         optimisticBiometric = null
     }
 
+    val context = androidx.compose.ui.platform.LocalContext.current
     LaunchedEffect(uiState.error) {
-        uiState.error?.let {
-            snackbarHostState.showSnackbar(it)
+        uiState.error?.let { msg ->
+            snackbarHostState.showSnackbar(msg.resolveString(context))
             viewModel.clearError()
         }
     }

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/settings/SecuritySettingsViewModel.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/settings/SecuritySettingsViewModel.kt
@@ -3,12 +3,14 @@ package com.rjnr.pocketnode.ui.screens.settings
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.rjnr.pocketnode.R
 import com.rjnr.pocketnode.data.auth.AuthManager
 import com.rjnr.pocketnode.data.auth.PinManager
 import com.rjnr.pocketnode.data.database.dao.WalletDao
 import com.rjnr.pocketnode.data.wallet.KeyBackupManager
 import com.rjnr.pocketnode.data.wallet.KeyManager
 import com.rjnr.pocketnode.data.wallet.KeyMaterial
+import com.rjnr.pocketnode.ui.util.UiMessage
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -30,7 +32,7 @@ data class SecuritySettingsUiState(
     val canRemovePin: Boolean = false,
     val biometricStatusText: String = "",
     val isAuthBeforeSendEnabled: Boolean = false,
-    val error: String? = null,
+    val error: UiMessage? = null,
     /**
      * Non-null when the user is being asked to confirm that adding or
      * removing a biometric enrollment will invalidate their V2 wallet
@@ -115,7 +117,7 @@ class SecuritySettingsViewModel @Inject constructor(
 
     fun toggleAuthBeforeSend(enabled: Boolean) {
         if (enabled && !pinManager.hasPin()) {
-            _uiState.update { it.copy(error = "Set a PIN first to enable send authentication") }
+            _uiState.update { it.copy(error = UiMessage.Resource(R.string.vm_error_set_pin_first_send)) }
             return
         }
         authManager.setAuthBeforeSendEnabled(enabled)
@@ -124,7 +126,7 @@ class SecuritySettingsViewModel @Inject constructor(
 
     private fun toggleBiometric(enabled: Boolean) {
         if (enabled && !pinManager.hasPin()) {
-            _uiState.update { it.copy(error = "Set a PIN first to enable biometric unlock") }
+            _uiState.update { it.copy(error = UiMessage.Resource(R.string.vm_error_set_pin_first_biometric)) }
             return
         }
         // The V2 Keystore key is configured with
@@ -166,13 +168,13 @@ class SecuritySettingsViewModel @Inject constructor(
         viewModelScope.launch {
             if (walletDao.count() > 0) {
                 _uiState.update {
-                    it.copy(error = "PIN is required while you have a wallet. Delete all wallets first to remove the PIN.")
+                    it.copy(error = UiMessage.Resource(R.string.vm_error_pin_required_remove_wallets))
                 }
                 return@launch
             }
             if (keyBackupManager.hasAnyBackups()) {
                 _uiState.update {
-                    it.copy(error = "Cannot remove PIN while encrypted wallet backups exist. Back up your recovery phrase first, then you can remove the PIN.")
+                    it.copy(error = UiMessage.Resource(R.string.vm_error_pin_required_backups))
                 }
                 return@launch
             }

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/settings/SettingsScreen.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/settings/SettingsScreen.kt
@@ -79,6 +79,7 @@ import com.rjnr.pocketnode.data.gateway.models.NetworkType
 import com.rjnr.pocketnode.data.gateway.models.SyncMode
 import com.rjnr.pocketnode.data.gateway.models.displayName
 import com.rjnr.pocketnode.R
+import com.rjnr.pocketnode.ui.util.resolveString
 import com.rjnr.pocketnode.ui.components.SyncOptionsSheet
 import com.rjnr.pocketnode.data.wallet.SyncStrategy
 import com.rjnr.pocketnode.data.wallet.ThemeMode
@@ -327,8 +328,8 @@ fun SettingsScreen(
     }
 
     LaunchedEffect(uiState.error) {
-        uiState.error?.let { error ->
-            snackbarHostState.showSnackbar(error)
+        uiState.error?.let { msg ->
+            snackbarHostState.showSnackbar(msg.resolveString(context))
             viewModel.clearError()
         }
     }

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/settings/SettingsViewModel.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/settings/SettingsViewModel.kt
@@ -43,7 +43,7 @@ class SettingsViewModel @Inject constructor(
         // Active wallet address — used by SyncOptionsDialog's "look up on explorer"
         // helper for the CUSTOM mode (#85). Null until the wallet is initialized.
         val address: String? = null,
-        val error: String? = null
+        val error: com.rjnr.pocketnode.ui.util.UiMessage? = null,
     )
 
     private val _uiState = MutableStateFlow(UiState())
@@ -144,7 +144,15 @@ class SettingsViewModel @Inject constructor(
         viewModelScope.launch {
             repository.resyncAccount(mode, customBlockHeight)
                 .onFailure { e ->
-                    _uiState.update { it.copy(syncMode = previousMode, error = "Sync mode change failed: ${e.message}") }
+                    _uiState.update {
+                        it.copy(
+                            syncMode = previousMode,
+                            error = com.rjnr.pocketnode.ui.util.UiMessage.Resource(
+                                com.rjnr.pocketnode.R.string.vm_error_sync_mode_change_failed,
+                                listOf(e.message ?: ""),
+                            ),
+                        )
+                    }
                 }
         }
     }
@@ -166,7 +174,14 @@ class SettingsViewModel @Inject constructor(
         viewModelScope.launch {
             repository.switchNetwork(target)
                 .onFailure { e ->
-                    _uiState.update { it.copy(error = "Network switch failed: ${e.message}") }
+                    _uiState.update {
+                        it.copy(
+                            error = com.rjnr.pocketnode.ui.util.UiMessage.Resource(
+                                com.rjnr.pocketnode.R.string.vm_error_network_switch_failed,
+                                listOf(e.message ?: ""),
+                            ),
+                        )
+                    }
                 }
         }
     }

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -233,6 +233,15 @@
     <string name="home_copy_cd">Copy</string>
     <!-- endregion -->
 
+    <!-- region: VM errors (#133) -->
+    <string name="vm_error_set_pin_first_send">Set a PIN first to enable send authentication</string>
+    <string name="vm_error_set_pin_first_biometric">Set a PIN first to enable biometric unlock</string>
+    <string name="vm_error_pin_required_remove_wallets">PIN is required while you have a wallet. Delete all wallets first to remove the PIN.</string>
+    <string name="vm_error_pin_required_backups">Cannot remove PIN while encrypted wallet backups exist. Back up your recovery phrase first, then you can remove the PIN.</string>
+    <string name="vm_error_sync_mode_change_failed">Sync mode change failed: %1$s</string>
+    <string name="vm_error_network_switch_failed">Network switch failed: %1$s</string>
+    <!-- endregion -->
+
     <!-- region: SecuritySettings -->
     <string name="security_settings_title">Security Settings</string>
     <string name="security_settings_continue">Continue</string>


### PR DESCRIPTION
Second phase of #133 — migrates SecuritySettingsViewModel (4 errors) + SettingsViewModel (2 errors) to UiMessage. Refs #133.