### PR TITLE
feat(i18n): all remaining VM error i18n — closes #133

### DIFF
--- a/android/app/src/main/java/com/rjnr/pocketnode/data/gateway/models/DaoModels.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/gateway/models/DaoModels.kt
@@ -102,7 +102,7 @@ data class DaoUiState(
     // Pull-to-refresh indicator. Distinct from `isLoading` so the user can
     // refresh without the screen blanking out into a fullscreen spinner.
     val isRefreshing: Boolean = false,
-    val error: String? = null,
+    val error: com.rjnr.pocketnode.ui.util.UiMessage? = null,
     val pendingAction: DaoAction? = null,
     val requiresAuth: Boolean = false,
     val authMethod: AuthMethod? = null

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/dao/DaoScreen.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/dao/DaoScreen.kt
@@ -24,6 +24,7 @@ import com.rjnr.pocketnode.data.gateway.models.DaoAction
 import androidx.compose.ui.res.stringResource
 import com.rjnr.pocketnode.R
 import com.rjnr.pocketnode.data.gateway.models.DaoDeposit
+import com.rjnr.pocketnode.ui.util.resolveString
 import com.rjnr.pocketnode.data.gateway.models.DaoOverview
 import com.rjnr.pocketnode.data.gateway.models.DaoTab
 import com.rjnr.pocketnode.data.gateway.models.NetworkType
@@ -196,7 +197,7 @@ fun DaoScreen(
     // Snackbar for errors
     uiState.error?.let { error ->
         LaunchedEffect(error) {
-            snackbarHostState.showSnackbar(error)
+            snackbarHostState.showSnackbar(error.resolveString(context))
             viewModel.clearError()
         }
     }

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/dao/DaoViewModel.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/dao/DaoViewModel.kt
@@ -102,7 +102,7 @@ class DaoViewModel @Inject constructor(
             }
             .onFailure { e ->
                 _uiState.update {
-                    it.copy(error = e.message, isLoading = false)
+                    it.copy(error = e.message?.let(com.rjnr.pocketnode.ui.util.UiMessage::Raw), isLoading = false)
                 }
             }
     }
@@ -132,7 +132,7 @@ class DaoViewModel @Inject constructor(
         val amount = amountShannons ?: pendingDepositAmount
         pendingDepositAmount = 0L
         if (amount <= 0L) {
-            _uiState.update { it.copy(error = "Invalid deposit amount", requiresAuth = false, authMethod = null) }
+            _uiState.update { it.copy(error = com.rjnr.pocketnode.ui.util.UiMessage.Resource(com.rjnr.pocketnode.R.string.vm_error_invalid_deposit_amount), requiresAuth = false, authMethod = null) }
             return
         }
         _uiState.update {
@@ -142,7 +142,7 @@ class DaoViewModel @Inject constructor(
             repository.depositToDao(amount)
                 .onFailure { e ->
                     _uiState.update {
-                        it.copy(error = e.message, pendingAction = null)
+                        it.copy(error = e.message?.let(com.rjnr.pocketnode.ui.util.UiMessage::Raw), pendingAction = null)
                     }
                 }
         }
@@ -186,7 +186,7 @@ class DaoViewModel @Inject constructor(
             repository.withdrawFromDao(deposit.outPoint)
                 .onFailure { e ->
                     _uiState.update {
-                        it.copy(error = e.message, pendingAction = null)
+                        it.copy(error = e.message?.let(com.rjnr.pocketnode.ui.util.UiMessage::Raw), pendingAction = null)
                     }
                 }
         }
@@ -212,7 +212,7 @@ class DaoViewModel @Inject constructor(
             repository.unlockDao(withdrawingOutPoint = deposit.outPoint)
                 .onFailure { e ->
                     _uiState.update {
-                        it.copy(error = e.message, pendingAction = null)
+                        it.copy(error = e.message?.let(com.rjnr.pocketnode.ui.util.UiMessage::Raw), pendingAction = null)
                     }
                 }
         }
@@ -241,7 +241,7 @@ class DaoViewModel @Inject constructor(
     ) {
         val walletId = walletRepository.activeWalletIdSnapshot()
         if (walletId.isNullOrEmpty()) {
-            _uiState.update { it.copy(error = "No active wallet", pendingAction = null) }
+            _uiState.update { it.copy(error = com.rjnr.pocketnode.ui.util.UiMessage.Resource(com.rjnr.pocketnode.R.string.vm_error_no_active_wallet), pendingAction = null) }
             return
         }
         _uiState.update {
@@ -257,22 +257,22 @@ class DaoViewModel @Inject constructor(
                 _uiState.update { it.copy(pendingAction = null) }
             is WalletKeyReader.Result.AuthError ->
                 _uiState.update {
-                    it.copy(error = "Authentication failed: ${read.message}", pendingAction = null)
+                    it.copy(error = com.rjnr.pocketnode.ui.util.UiMessage.Resource(com.rjnr.pocketnode.R.string.vm_error_auth_failed_with_reason, listOf(read.message.toString())), pendingAction = null)
                 }
             is WalletKeyReader.Result.NotAvailable ->
                 _uiState.update {
-                    it.copy(error = "Cannot read wallet key: ${read.reason}", pendingAction = null)
+                    it.copy(error = com.rjnr.pocketnode.ui.util.UiMessage.Resource(com.rjnr.pocketnode.R.string.vm_error_cannot_read_wallet_key, listOf(read.reason)), pendingAction = null)
                 }
             is WalletKeyReader.Result.KeyInvalidated ->
                 _uiState.update {
                     it.copy(
-                        error = "Biometric enrollment changed — re-import this wallet from its recovery phrase to continue",
+                        error = com.rjnr.pocketnode.ui.util.UiMessage.Resource(com.rjnr.pocketnode.R.string.vm_error_biometric_changed_send),
                         pendingAction = null,
                     )
                 }
             is WalletKeyReader.Result.Success ->
                 operation(read.privateKey).onFailure { e ->
-                    _uiState.update { it.copy(error = e.message, pendingAction = null) }
+                    _uiState.update { it.copy(error = e.message?.let(com.rjnr.pocketnode.ui.util.UiMessage::Raw), pendingAction = null) }
                 }
         }
     }

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/home/HomeScreen.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/home/HomeScreen.kt
@@ -83,6 +83,7 @@ import com.composables.icons.lucide.Lucide
 import com.composables.icons.lucide.TriangleAlert
 import com.composables.icons.lucide.X
 import com.rjnr.pocketnode.R
+import com.rjnr.pocketnode.ui.util.resolveString
 import com.rjnr.pocketnode.data.gateway.models.NetworkType
 import com.rjnr.pocketnode.data.gateway.models.SyncMode
 import com.rjnr.pocketnode.data.gateway.models.TransactionRecord
@@ -302,8 +303,9 @@ fun HomeScreen(
 
     LaunchedEffect(uiState.error) {
         uiState.error?.let { error ->
-            snackbarHostState.showSnackbar(error)
-            Log.e("HomeScreen", "Error: $error")
+            val resolved = error.resolveString(context)
+            snackbarHostState.showSnackbar(resolved)
+            Log.e("HomeScreen", "Error: $resolved")
             viewModel.clearError()
         }
     }

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/home/HomeViewModel.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/home/HomeViewModel.kt
@@ -250,7 +250,7 @@ class HomeViewModel @Inject constructor(
             .onFailure { error ->
                 Log.e(TAG, "Wallet initialization failed", error)
                 _uiState.update {
-                    it.copy(error = error.message, isLoading = false)
+                    it.copy(error = error.message?.let(com.rjnr.pocketnode.ui.util.UiMessage::Raw), isLoading = false)
                 }
             }
     }
@@ -345,7 +345,7 @@ class HomeViewModel @Inject constructor(
             }
             .onFailure { error ->
                 Log.e(TAG, "Registration failed", error)
-                _uiState.update { it.copy(error = "Registration failed: ${error.message}") }
+                _uiState.update { it.copy(error = com.rjnr.pocketnode.ui.util.UiMessage.Resource(com.rjnr.pocketnode.R.string.vm_error_registration_failed, listOf(error.message ?: ""))) }
             }
     }
 
@@ -453,7 +453,7 @@ class HomeViewModel @Inject constructor(
                     Log.e(TAG, "Failed to fetch transactions", error)
                     if (!silent) {
                         _uiState.update {
-                            it.copy(error = "Failed to load transactions: ${error.message}")
+                            it.copy(error = com.rjnr.pocketnode.ui.util.UiMessage.Resource(com.rjnr.pocketnode.R.string.vm_error_load_transactions_failed, listOf(error.message ?: "")))
                         }
                     }
                 }
@@ -490,7 +490,7 @@ class HomeViewModel @Inject constructor(
                 }
                 .onFailure { e ->
                     Log.e(TAG, "retryFailedTransaction failed for $txHash", e)
-                    _uiState.update { it.copy(error = "Couldn't retry: ${e.message}") }
+                    _uiState.update { it.copy(error = com.rjnr.pocketnode.ui.util.UiMessage.Resource(com.rjnr.pocketnode.R.string.vm_error_retry_failed, listOf(e.message ?: ""))) }
                 }
         }
     }
@@ -536,7 +536,7 @@ class HomeViewModel @Inject constructor(
                         it.copy(
                             isLoading = false,
                             isSyncing = false,
-                            error = "Failed to change sync mode: ${error.message}"
+                            error = com.rjnr.pocketnode.ui.util.UiMessage.Resource(com.rjnr.pocketnode.R.string.vm_error_sync_mode_change_failed_home, listOf(error.message ?: ""))
                         )
                     }
                 }
@@ -652,7 +652,7 @@ class HomeViewModel @Inject constructor(
                     _uiState.update { 
                         it.copy(
                             isLoading = false, 
-                            error = "Import failed: ${error.message}"
+                            error = com.rjnr.pocketnode.ui.util.UiMessage.Resource(com.rjnr.pocketnode.R.string.vm_error_import_failed, listOf(error.message ?: ""))
                         ) 
                     }
                 }
@@ -682,7 +682,7 @@ class HomeViewModel @Inject constructor(
                 refresh()
             } catch (e: Exception) {
                 Log.e(TAG, "Failed to switch wallet", e)
-                _uiState.update { it.copy(isSwitchingWallet = false, error = "Failed to switch wallet: ${e.message}") }
+                _uiState.update { it.copy(isSwitchingWallet = false, error = com.rjnr.pocketnode.ui.util.UiMessage.Resource(com.rjnr.pocketnode.R.string.vm_error_switch_wallet_failed, listOf(e.message ?: ""))) }
             }
         }
     }
@@ -733,7 +733,7 @@ class HomeViewModel @Inject constructor(
                     _uiState.update {
                         it.copy(
                             isSyncing = false,
-                            error = "Network switch failed: ${error.message}"
+                            error = com.rjnr.pocketnode.ui.util.UiMessage.Resource(com.rjnr.pocketnode.R.string.vm_error_network_switch_failed, listOf(error.message ?: ""))
                         )
                     }
                 }
@@ -899,7 +899,7 @@ data class HomeUiState(
     val ckbUsdPrice: Double? = null,
     val peerCount: Int = 0,
     val transactions: List<TransactionRecord> = emptyList(),
-    val error: String? = null,
+    val error: com.rjnr.pocketnode.ui.util.UiMessage? = null,
     val currentSyncMode: SyncMode = SyncMode.RECENT,
     val showSyncOptionsDialog: Boolean = false,
     val showImportDialog: Boolean = false,

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/onboarding/OnboardingScreen.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/onboarding/OnboardingScreen.kt
@@ -14,6 +14,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
+import com.rjnr.pocketnode.ui.util.resolveString
 import com.rjnr.pocketnode.ui.util.uaTestTag
 
 @Composable
@@ -33,9 +34,10 @@ fun OnboardingScreen(
         }
     }
 
+    val context = androidx.compose.ui.platform.LocalContext.current
     LaunchedEffect(uiState.error) {
         uiState.error?.let { error ->
-            snackbarHostState.showSnackbar(error)
+            snackbarHostState.showSnackbar(error.resolveString(context))
             viewModel.clearError()
         }
     }

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/onboarding/OnboardingViewModel.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/onboarding/OnboardingViewModel.kt
@@ -18,7 +18,7 @@ private const val TAG = "OnboardingViewModel"
 
 data class OnboardingUiState(
     val isLoading: Boolean = false,
-    val error: String? = null,
+    val error: com.rjnr.pocketnode.ui.util.UiMessage? = null,
     val isWalletCreated: Boolean = false,
     val wasCorrupted: Boolean = false,
     /**
@@ -64,7 +64,9 @@ class OnboardingViewModel @Inject constructor(
         if (!canCreateV2BoundKey()) {
             _uiState.update {
                 it.copy(
-                    error = "Set a screen lock (PIN, pattern, password, or biometric) in Android Settings, then try again. Pocket Node uses your device lock to protect your wallet keys.",
+                    error = com.rjnr.pocketnode.ui.util.UiMessage.Resource(
+                        com.rjnr.pocketnode.R.string.vm_error_no_device_credential,
+                    ),
                     noDeviceCredential = true,
                 )
             }
@@ -79,7 +81,12 @@ class OnboardingViewModel @Inject constructor(
                 _uiState.update { it.copy(isLoading = false, isWalletCreated = true) }
             } catch (e: Exception) {
                 Log.e(TAG, "Wallet creation failed", e)
-                _uiState.update { it.copy(isLoading = false, error = e.message) }
+                _uiState.update {
+                    it.copy(
+                        isLoading = false,
+                        error = e.message?.let(com.rjnr.pocketnode.ui.util.UiMessage::Raw),
+                    )
+                }
             }
         }
     }

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/send/SendScreen.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/send/SendScreen.kt
@@ -81,6 +81,7 @@ import com.composables.icons.lucide.TriangleAlert
 import com.composables.icons.lucide.Users
 import androidx.compose.ui.res.stringResource
 import com.rjnr.pocketnode.R
+import com.rjnr.pocketnode.ui.util.resolveString
 import com.composables.icons.lucide.X
 import com.rjnr.pocketnode.data.database.entity.WalletEntity
 import com.rjnr.pocketnode.data.gateway.models.NetworkType
@@ -205,7 +206,7 @@ fun SendScreen(
     // Show error dialog with better UX
     if (uiState.error != null && uiState.transactionState != TransactionState.SENDING) {
         ErrorDialog(
-            errorMessage = uiState.error ?: "An unknown error occurred",
+            errorMessage = uiState.error?.resolveString(context) ?: "An unknown error occurred",
             onDismiss = { viewModel.clearError() },
             onRetry = if (uiState.transactionState == TransactionState.FAILED) {
                 { viewModel.clearError() }

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/send/SendViewModel.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/send/SendViewModel.kt
@@ -41,7 +41,7 @@ data class SendUiState(
     val recipientAddress: String = "",
     val amountCkb: String = "",
     val isLoading: Boolean = false,
-    val error: String? = null,
+    val error: com.rjnr.pocketnode.ui.util.UiMessage? = null,
     val txHash: String? = null,
     val availableBalance: Long = 0L,
     val estimatedFee: Long = 0L,
@@ -170,7 +170,7 @@ class SendViewModel @Inject constructor(
                         it.copy(
                             networkType = network,
                             isLoading = false,
-                            error = "Network changed. Transaction cancelled.",
+                            error = com.rjnr.pocketnode.ui.util.UiMessage.Resource(com.rjnr.pocketnode.R.string.vm_error_network_changed_tx_cancelled),
                             transactionState = TransactionState.FAILED,
                             statusMessage = "Transaction cancelled due to network switch"
                         )
@@ -298,7 +298,7 @@ class SendViewModel @Inject constructor(
         viewModelScope.launch {
             if (peekActiveKdfVersion() == 2) {
                 _uiState.update {
-                    it.copy(error = "This wallet requires biometric unlock; reopen Send and try again")
+                    it.copy(error = com.rjnr.pocketnode.ui.util.UiMessage.Resource(com.rjnr.pocketnode.R.string.vm_error_send_v2_reopen))
                 }
                 return@launch
             }
@@ -338,27 +338,27 @@ class SendViewModel @Inject constructor(
     private fun validateInputs(): Boolean {
         val state = _uiState.value
         if (state.recipientAddress.isBlank()) {
-            _uiState.update { it.copy(error = "Please enter recipient address") }
+            _uiState.update { it.copy(error = com.rjnr.pocketnode.ui.util.UiMessage.Resource(com.rjnr.pocketnode.R.string.vm_error_enter_recipient)) }
             return false
         }
         if (state.amountCkb.isBlank()) {
-            _uiState.update { it.copy(error = "Please enter amount") }
+            _uiState.update { it.copy(error = com.rjnr.pocketnode.ui.util.UiMessage.Resource(com.rjnr.pocketnode.R.string.vm_error_enter_amount)) }
             return false
         }
         val amountShannons = try {
             BigDecimal(state.amountCkb).setScale(8, RoundingMode.DOWN)
                 .multiply(BigDecimal(100_000_000)).toLong()
         } catch (e: Exception) {
-            _uiState.update { it.copy(error = "Invalid amount") }
+            _uiState.update { it.copy(error = com.rjnr.pocketnode.ui.util.UiMessage.Resource(com.rjnr.pocketnode.R.string.vm_error_invalid_amount)) }
             return false
         }
         val minCapacity = 61_00000000L
         if (amountShannons < minCapacity) {
-            _uiState.update { it.copy(error = "Minimum transfer is 61 CKB") }
+            _uiState.update { it.copy(error = com.rjnr.pocketnode.ui.util.UiMessage.Resource(com.rjnr.pocketnode.R.string.vm_error_min_transfer)) }
             return false
         }
         if (amountShannons > state.availableBalance) {
-            _uiState.update { it.copy(error = "Insufficient balance") }
+            _uiState.update { it.copy(error = com.rjnr.pocketnode.ui.util.UiMessage.Resource(com.rjnr.pocketnode.R.string.vm_error_insufficient_balance)) }
             return false
         }
         return true
@@ -388,12 +388,12 @@ class SendViewModel @Inject constructor(
 
         val capturedAddress = repository.getCurrentAddress()
         if (capturedAddress == null) {
-            _uiState.update { it.copy(error = "Wallet not initialized") }
+            _uiState.update { it.copy(error = com.rjnr.pocketnode.ui.util.UiMessage.Resource(com.rjnr.pocketnode.R.string.vm_error_wallet_not_initialized)) }
             return
         }
 
         val walletId = walletPreferencesActiveId() ?: run {
-            _uiState.update { it.copy(error = "No active wallet") }
+            _uiState.update { it.copy(error = com.rjnr.pocketnode.ui.util.UiMessage.Resource(com.rjnr.pocketnode.R.string.vm_error_no_active_wallet)) }
             return
         }
 
@@ -409,20 +409,20 @@ class SendViewModel @Inject constructor(
             }
             is WalletKeyReader.Result.AuthError -> {
                 _uiState.update {
-                    it.copy(error = "Authentication failed: ${readResult.message}", isLoading = false)
+                    it.copy(error = com.rjnr.pocketnode.ui.util.UiMessage.Resource(com.rjnr.pocketnode.R.string.vm_error_auth_failed_with_reason, listOf(readResult.message.toString())), isLoading = false)
                 }
                 return
             }
             is WalletKeyReader.Result.NotAvailable -> {
                 _uiState.update {
-                    it.copy(error = "Cannot read wallet key: ${readResult.reason}", isLoading = false)
+                    it.copy(error = com.rjnr.pocketnode.ui.util.UiMessage.Resource(com.rjnr.pocketnode.R.string.vm_error_cannot_read_wallet_key, listOf(readResult.reason)), isLoading = false)
                 }
                 return
             }
             is WalletKeyReader.Result.KeyInvalidated -> {
                 _uiState.update {
                     it.copy(
-                        error = "Biometric enrollment changed — re-import this wallet from its recovery phrase to continue",
+                        error = com.rjnr.pocketnode.ui.util.UiMessage.Resource(com.rjnr.pocketnode.R.string.vm_error_biometric_changed_send),
                         isLoading = false,
                     )
                 }
@@ -475,7 +475,7 @@ class SendViewModel @Inject constructor(
             _uiState.update {
                 it.copy(
                     isLoading = false,
-                    error = parseErrorMessage(e),
+                    error = com.rjnr.pocketnode.ui.util.UiMessage.Raw(parseErrorMessage(e)),
                     transactionState = TransactionState.FAILED,
                     statusMessage = "Transaction failed"
                 )
@@ -491,7 +491,7 @@ class SendViewModel @Inject constructor(
             BigDecimal(state.amountCkb).setScale(8, RoundingMode.DOWN)
                 .multiply(BigDecimal(100_000_000)).toLong()
         } catch (e: Exception) {
-            _uiState.update { it.copy(error = "Invalid amount") }
+            _uiState.update { it.copy(error = com.rjnr.pocketnode.ui.util.UiMessage.Resource(com.rjnr.pocketnode.R.string.vm_error_invalid_amount)) }
             return
         }
 
@@ -499,13 +499,13 @@ class SendViewModel @Inject constructor(
         val capturedAddress = repository.getCurrentAddress()
 
         if (capturedAddress == null) {
-            _uiState.update { it.copy(error = "Wallet not initialized") }
+            _uiState.update { it.copy(error = com.rjnr.pocketnode.ui.util.UiMessage.Resource(com.rjnr.pocketnode.R.string.vm_error_wallet_not_initialized)) }
             return
         }
 
         sendJob = viewModelScope.launch {
             val capturedKey = try { repository.getPrivateKey() } catch (e: Exception) {
-                _uiState.update { it.copy(error = "Failed to access wallet keys: ${e.message}") }
+                _uiState.update { it.copy(error = com.rjnr.pocketnode.ui.util.UiMessage.Resource(com.rjnr.pocketnode.R.string.vm_error_access_keys_failed, listOf(e.message ?: ""))) }
                 return@launch
             }
             _uiState.update {
@@ -562,7 +562,7 @@ class SendViewModel @Inject constructor(
                 _uiState.update {
                     it.copy(
                         isLoading = false,
-                        error = userFriendlyError,
+                        error = com.rjnr.pocketnode.ui.util.UiMessage.Raw(userFriendlyError),
                         transactionState = TransactionState.FAILED,
                         statusMessage = "Transaction failed"
                     )

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/wallet/AddWalletScreen.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/wallet/AddWalletScreen.kt
@@ -61,6 +61,7 @@ import com.composables.icons.lucide.Wallet
 import androidx.compose.ui.res.stringResource
 import com.rjnr.pocketnode.R
 import com.rjnr.pocketnode.ui.components.MnemonicWordInput
+import com.rjnr.pocketnode.ui.util.resolveString
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -81,9 +82,10 @@ fun AddWalletScreen(
         }
     }
 
+    val context = androidx.compose.ui.platform.LocalContext.current
     LaunchedEffect(uiState.error) {
-        uiState.error?.let {
-            snackbarHostState.showSnackbar(it)
+        uiState.error?.let { msg ->
+            snackbarHostState.showSnackbar(msg.resolveString(context))
             viewModel.clearError()
         }
     }

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/wallet/AddWalletViewModel.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/wallet/AddWalletViewModel.kt
@@ -5,8 +5,10 @@ import androidx.lifecycle.viewModelScope
 import com.rjnr.pocketnode.data.database.entity.WalletEntity
 import com.rjnr.pocketnode.data.gateway.GatewayRepository
 import com.rjnr.pocketnode.data.wallet.MnemonicManager
+import com.rjnr.pocketnode.R
 import com.rjnr.pocketnode.data.wallet.WalletRepository
 import com.rjnr.pocketnode.ui.util.Bip39WordList
+import com.rjnr.pocketnode.ui.util.UiMessage
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -24,7 +26,7 @@ data class AddWalletUiState(
     val importPrivateKey: String = "",
     val createdWallet: WalletEntity? = null,
     val isNewlyGenerated: Boolean = false,
-    val error: String? = null,
+    val error: UiMessage? = null,
     val parentWallets: List<WalletEntity> = emptyList(),
     val selectedParentId: String? = null
 )
@@ -57,11 +59,11 @@ class AddWalletViewModel @Inject constructor(
         val parentId = _uiState.value.selectedParentId
 
         if (name.isBlank()) {
-            _uiState.update { it.copy(error = "Please enter a wallet name") }
+            _uiState.update { it.copy(error = UiMessage.Resource(R.string.vm_error_enter_wallet_name)) }
             return
         }
         if (parentId == null) {
-            _uiState.update { it.copy(error = "Please select a parent wallet") }
+            _uiState.update { it.copy(error = UiMessage.Resource(R.string.vm_error_select_parent_wallet)) }
             return
         }
 
@@ -73,7 +75,7 @@ class AddWalletViewModel @Inject constructor(
                 gatewayRepository.onActiveWalletChanged(wallet)
                 _uiState.update { it.copy(isLoading = false, createdWallet = wallet) }
             }.onFailure { error ->
-                _uiState.update { it.copy(isLoading = false, error = error.message) }
+                _uiState.update { it.copy(isLoading = false, error = error.message?.let(UiMessage::Raw)) }
             }
         }
     }
@@ -145,7 +147,7 @@ class AddWalletViewModel @Inject constructor(
         if (_uiState.value.isLoading) return // prevent double-tap
         val name = _uiState.value.name.trim()
         if (name.isBlank()) {
-            _uiState.update { it.copy(error = "Please enter a wallet name") }
+            _uiState.update { it.copy(error = UiMessage.Resource(R.string.vm_error_enter_wallet_name)) }
             return
         }
 
@@ -162,7 +164,7 @@ class AddWalletViewModel @Inject constructor(
                 gatewayRepository.onActiveWalletChanged(wallet)
                 _uiState.update { it.copy(isLoading = false, createdWallet = wallet, isNewlyGenerated = true) }
             }.onFailure { error ->
-                _uiState.update { it.copy(isLoading = false, error = error.message) }
+                _uiState.update { it.copy(isLoading = false, error = error.message?.let(UiMessage::Raw)) }
             }
         }
     }
@@ -173,19 +175,19 @@ class AddWalletViewModel @Inject constructor(
         val words = _uiState.value.importWords.map { it.trim().lowercase() }
 
         if (name.isBlank()) {
-            _uiState.update { it.copy(error = "Please enter a wallet name") }
+            _uiState.update { it.copy(error = UiMessage.Resource(R.string.vm_error_enter_wallet_name)) }
             return
         }
         if (words.any { it.isEmpty() }) {
-            _uiState.update { it.copy(error = "Please fill in all 12 words") }
+            _uiState.update { it.copy(error = UiMessage.Resource(R.string.vm_error_fill_all_words)) }
             return
         }
         if (words.any { !Bip39WordList.isValidWord(it) }) {
-            _uiState.update { it.copy(error = "One or more words are not in the BIP39 wordlist") }
+            _uiState.update { it.copy(error = UiMessage.Resource(R.string.vm_error_words_not_bip39)) }
             return
         }
         if (!mnemonicManager.validateMnemonic(words)) {
-            _uiState.update { it.copy(error = "Invalid mnemonic. Please check your words and try again.") }
+            _uiState.update { it.copy(error = UiMessage.Resource(R.string.vm_error_invalid_mnemonic)) }
             return
         }
 
@@ -197,7 +199,7 @@ class AddWalletViewModel @Inject constructor(
                 gatewayRepository.onActiveWalletChanged(wallet)
                 _uiState.update { it.copy(isLoading = false, createdWallet = wallet) }
             }.onFailure { error ->
-                _uiState.update { it.copy(isLoading = false, error = error.message) }
+                _uiState.update { it.copy(isLoading = false, error = error.message?.let(UiMessage::Raw)) }
             }
         }
     }
@@ -208,11 +210,11 @@ class AddWalletViewModel @Inject constructor(
         val key = _uiState.value.importPrivateKey.trim()
 
         if (name.isBlank()) {
-            _uiState.update { it.copy(error = "Please enter a wallet name") }
+            _uiState.update { it.copy(error = UiMessage.Resource(R.string.vm_error_enter_wallet_name)) }
             return
         }
         if (key.removePrefix("0x").length != 64) {
-            _uiState.update { it.copy(error = "Private key must be 32 bytes (64 hex characters)") }
+            _uiState.update { it.copy(error = UiMessage.Resource(R.string.vm_error_invalid_private_key)) }
             return
         }
 
@@ -224,7 +226,7 @@ class AddWalletViewModel @Inject constructor(
                 gatewayRepository.onActiveWalletChanged(wallet)
                 _uiState.update { it.copy(isLoading = false, createdWallet = wallet) }
             }.onFailure { error ->
-                _uiState.update { it.copy(isLoading = false, error = error.message) }
+                _uiState.update { it.copy(isLoading = false, error = error.message?.let(UiMessage::Raw)) }
             }
         }
     }

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/wallet/WalletManagerScreen.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/wallet/WalletManagerScreen.kt
@@ -45,6 +45,7 @@ import com.composables.icons.lucide.Lucide
 import com.composables.icons.lucide.Plus
 import com.rjnr.pocketnode.R
 import com.rjnr.pocketnode.ui.components.WalletAvatar
+import com.rjnr.pocketnode.ui.util.resolveString
 import com.rjnr.pocketnode.ui.components.WalletGroup
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -57,10 +58,11 @@ fun WalletManagerScreen(
 ) {
     val uiState by viewModel.uiState.collectAsState()
     val snackbarHostState = remember { SnackbarHostState() }
+    val context = androidx.compose.ui.platform.LocalContext.current
 
     LaunchedEffect(uiState.error) {
-        uiState.error?.let {
-            snackbarHostState.showSnackbar(it)
+        uiState.error?.let { msg ->
+            snackbarHostState.showSnackbar(msg.resolveString(context))
             viewModel.clearError()
         }
     }

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/wallet/WalletManagerViewModel.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/wallet/WalletManagerViewModel.kt
@@ -48,7 +48,14 @@ class WalletManagerViewModel @Inject constructor(
                 gatewayRepository.onActiveWalletChanged(wallet)
             } catch (e: Exception) {
                 Log.e(TAG, "Failed to switch wallet", e)
-                _uiState.update { it.copy(error = "Failed to switch wallet: ${e.message}") }
+                _uiState.update {
+                    it.copy(
+                        error = com.rjnr.pocketnode.ui.util.UiMessage.Resource(
+                            com.rjnr.pocketnode.R.string.vm_error_switch_wallet_failed,
+                            listOf(e.message ?: ""),
+                        ),
+                    )
+                }
             }
         }
     }
@@ -60,5 +67,5 @@ class WalletManagerViewModel @Inject constructor(
 
 data class WalletManagerUiState(
     val walletGroups: List<WalletGroup> = emptyList(),
-    val error: String? = null
+    val error: com.rjnr.pocketnode.ui.util.UiMessage? = null,
 )

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/wallet/WalletSettingsScreen.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/wallet/WalletSettingsScreen.kt
@@ -55,6 +55,7 @@ import com.composables.icons.lucide.Plus
 import androidx.compose.ui.res.stringResource
 import com.rjnr.pocketnode.R
 import com.rjnr.pocketnode.data.database.entity.WalletEntity
+import com.rjnr.pocketnode.ui.util.resolveString
 import com.rjnr.pocketnode.ui.components.WalletAvatar
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -86,8 +87,8 @@ fun WalletSettingsScreen(
     }
 
     LaunchedEffect(uiState.error) {
-        uiState.error?.let {
-            snackbarHostState.showSnackbar(it)
+        uiState.error?.let { msg ->
+            snackbarHostState.showSnackbar(msg.resolveString(context))
             viewModel.clearError()
         }
     }

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/wallet/WalletSettingsViewModel.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/wallet/WalletSettingsViewModel.kt
@@ -97,7 +97,7 @@ class WalletSettingsViewModel @Inject constructor(
                 loadWallet()
                 _uiState.update { it.copy(isEditing = false) }
             } catch (e: Exception) {
-                _uiState.update { it.copy(error = "Failed to rename: ${e.message}") }
+                _uiState.update { it.copy(error = com.rjnr.pocketnode.ui.util.UiMessage.Resource(com.rjnr.pocketnode.R.string.vm_error_rename_failed, listOf(e.message ?: ""))) }
             }
         }
     }
@@ -107,13 +107,13 @@ class WalletSettingsViewModel @Inject constructor(
     fun requestDelete() {
         val wallet = _uiState.value.wallet ?: return
         if (wallet.isActive) {
-            _uiState.update { it.copy(error = "Cannot delete the active wallet. Switch to another wallet first.") }
+            _uiState.update { it.copy(error = com.rjnr.pocketnode.ui.util.UiMessage.Resource(com.rjnr.pocketnode.R.string.vm_error_cannot_delete_active)) }
             return
         }
         viewModelScope.launch {
             val count = walletRepository.walletCount()
             if (count <= 1) {
-                _uiState.update { it.copy(error = "Cannot delete the last wallet. Create another wallet first.") }
+                _uiState.update { it.copy(error = com.rjnr.pocketnode.ui.util.UiMessage.Resource(com.rjnr.pocketnode.R.string.vm_error_cannot_delete_last)) }
                 return@launch
             }
 
@@ -123,7 +123,15 @@ class WalletSettingsViewModel @Inject constructor(
             val subAccounts = walletDao.getSubAccountsList(walletId)
             if (subAccounts.isNotEmpty()) {
                 _uiState.update {
-                    it.copy(error = "This wallet has ${subAccounts.size} sub-account${if (subAccounts.size > 1) "s" else ""}. Delete them first before removing the parent.")
+                    it.copy(
+                        error = if (subAccounts.size == 1)
+                            com.rjnr.pocketnode.ui.util.UiMessage.Resource(com.rjnr.pocketnode.R.string.vm_error_delete_sub_accounts_first_one)
+                        else
+                            com.rjnr.pocketnode.ui.util.UiMessage.Resource(
+                                com.rjnr.pocketnode.R.string.vm_error_delete_sub_accounts_first_other,
+                                listOf(subAccounts.size),
+                            ),
+                    )
                 }
                 return@launch
             }
@@ -164,7 +172,7 @@ class WalletSettingsViewModel @Inject constructor(
             } catch (e: Exception) {
                 Log.e(TAG, "Failed to delete wallet", e)
                 _uiState.update {
-                    it.copy(showDeleteConfirm = false, error = "Delete failed: ${e.message}")
+                    it.copy(showDeleteConfirm = false, error = com.rjnr.pocketnode.ui.util.UiMessage.Resource(com.rjnr.pocketnode.R.string.vm_error_delete_failed, listOf(e.message ?: "")))
                 }
             }
         }
@@ -213,7 +221,7 @@ class WalletSettingsViewModel @Inject constructor(
         viewModelScope.launch {
             if (keyMaterialDao.getKdfVersion(walletId) == 2) {
                 _uiState.update {
-                    it.copy(error = "Reopen this screen — biometric unlock required for V2 wallets")
+                    it.copy(error = com.rjnr.pocketnode.ui.util.UiMessage.Resource(com.rjnr.pocketnode.R.string.vm_error_reopen_for_biometric))
                 }
                 return@launch
             }
@@ -259,14 +267,14 @@ class WalletSettingsViewModel @Inject constructor(
             )) {
                 is WalletKeyReader.MaterialResult.Cancelled,
                 is WalletKeyReader.MaterialResult.AuthError -> {
-                    _uiState.update { it.copy(error = "Authentication cancelled") }
+                    _uiState.update { it.copy(error = com.rjnr.pocketnode.ui.util.UiMessage.Resource(com.rjnr.pocketnode.R.string.vm_error_auth_cancelled)) }
                 }
                 is WalletKeyReader.MaterialResult.NotAvailable -> {
-                    _uiState.update { it.copy(error = "Cannot read wallet key: ${result.reason}") }
+                    _uiState.update { it.copy(error = com.rjnr.pocketnode.ui.util.UiMessage.Resource(com.rjnr.pocketnode.R.string.vm_error_cannot_read_wallet_key, listOf(result.reason))) }
                 }
                 is WalletKeyReader.MaterialResult.KeyInvalidated -> {
                     _uiState.update {
-                        it.copy(error = "Biometric enrollment changed — re-import this wallet to view its recovery phrase")
+                        it.copy(error = com.rjnr.pocketnode.ui.util.UiMessage.Resource(com.rjnr.pocketnode.R.string.vm_error_biometric_changed_self))
                     }
                 }
                 is WalletKeyReader.MaterialResult.Success -> {
@@ -286,7 +294,7 @@ class WalletSettingsViewModel @Inject constructor(
                 walletRepository.createSubAccount(walletId, name)
             } catch (e: Exception) {
                 Log.e(TAG, "Failed to create sub-account", e)
-                _uiState.update { it.copy(error = "Failed to create account: ${e.message}") }
+                _uiState.update { it.copy(error = com.rjnr.pocketnode.ui.util.UiMessage.Resource(com.rjnr.pocketnode.R.string.vm_error_create_account_failed, listOf(e.message ?: ""))) }
             }
         }
     }
@@ -313,24 +321,24 @@ class WalletSettingsViewModel @Inject constructor(
             )) {
                 is WalletKeyReader.MaterialResult.Cancelled,
                 is WalletKeyReader.MaterialResult.AuthError ->
-                    _uiState.update { it.copy(error = "Authentication cancelled") }
+                    _uiState.update { it.copy(error = com.rjnr.pocketnode.ui.util.UiMessage.Resource(com.rjnr.pocketnode.R.string.vm_error_auth_cancelled)) }
                 is WalletKeyReader.MaterialResult.NotAvailable ->
-                    _uiState.update { it.copy(error = "Cannot read parent wallet: ${result.reason}") }
+                    _uiState.update { it.copy(error = com.rjnr.pocketnode.ui.util.UiMessage.Resource(com.rjnr.pocketnode.R.string.vm_error_cannot_read_parent, listOf(result.reason))) }
                 is WalletKeyReader.MaterialResult.KeyInvalidated ->
                     _uiState.update {
-                        it.copy(error = "Biometric enrollment changed — re-import the parent wallet to create sub-accounts")
+                        it.copy(error = com.rjnr.pocketnode.ui.util.UiMessage.Resource(com.rjnr.pocketnode.R.string.vm_error_biometric_changed_parent))
                     }
                 is WalletKeyReader.MaterialResult.Success -> {
                     val words = result.mnemonic?.split(" ")
                     if (words.isNullOrEmpty()) {
-                        _uiState.update { it.copy(error = "Parent wallet has no mnemonic") }
+                        _uiState.update { it.copy(error = com.rjnr.pocketnode.ui.util.UiMessage.Resource(com.rjnr.pocketnode.R.string.vm_error_parent_no_mnemonic)) }
                         return@launch
                     }
                     try {
                         walletRepository.createSubAccount(walletId, name, parentMnemonicOverride = words)
                     } catch (e: Exception) {
                         Log.e(TAG, "Failed to create V2 sub-account", e)
-                        _uiState.update { it.copy(error = "Failed to create account: ${e.message}") }
+                        _uiState.update { it.copy(error = com.rjnr.pocketnode.ui.util.UiMessage.Resource(com.rjnr.pocketnode.R.string.vm_error_create_account_failed, listOf(e.message ?: ""))) }
                     }
                 }
             }
@@ -353,7 +361,7 @@ data class WalletSettingsUiState(
     val daoDepositAmount: String = "",
     val pendingTxCount: Int = 0,
     val deleted: Boolean = false,
-    val error: String? = null,
+    val error: com.rjnr.pocketnode.ui.util.UiMessage? = null,
     val seedPhraseUnlocked: Boolean = false,
     val privateKeyHex: String? = null,
     val mnemonicWords: List<String>? = null

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -234,6 +234,53 @@
     <!-- endregion -->
 
     <!-- region: VM errors (#133) -->
+    <!-- AddWalletViewModel -->
+    <string name="vm_error_enter_wallet_name">Please enter a wallet name</string>
+    <string name="vm_error_select_parent_wallet">Please select a parent wallet</string>
+    <string name="vm_error_fill_all_words">Please fill in all 12 words</string>
+    <string name="vm_error_words_not_bip39">One or more words are not in the BIP39 wordlist</string>
+    <string name="vm_error_invalid_mnemonic">Invalid mnemonic. Please check your words and try again.</string>
+    <string name="vm_error_invalid_private_key">Private key must be 32 bytes (64 hex characters)</string>
+    <!-- WalletManager / WalletSettings -->
+    <string name="vm_error_switch_wallet_failed">Failed to switch wallet: %1$s</string>
+    <string name="vm_error_rename_failed">Failed to rename: %1$s</string>
+    <string name="vm_error_cannot_delete_active">Cannot delete the active wallet. Switch to another wallet first.</string>
+    <string name="vm_error_cannot_delete_last">Cannot delete the last wallet. Create another wallet first.</string>
+    <string name="vm_error_delete_sub_accounts_first_one">This wallet has 1 sub-account. Delete it first before removing the parent.</string>
+    <string name="vm_error_delete_sub_accounts_first_other">This wallet has %1$d sub-accounts. Delete them first before removing the parent.</string>
+    <string name="vm_error_delete_failed">Delete failed: %1$s</string>
+    <string name="vm_error_reopen_for_biometric">Reopen this screen — biometric unlock required for V2 wallets</string>
+    <string name="vm_error_auth_cancelled">Authentication cancelled</string>
+    <string name="vm_error_cannot_read_wallet_key">Cannot read wallet key: %1$s</string>
+    <string name="vm_error_biometric_changed_self">Biometric enrollment changed — re-import this wallet to view its recovery phrase</string>
+    <string name="vm_error_biometric_changed_parent">Biometric enrollment changed — re-import the parent wallet to create sub-accounts</string>
+    <string name="vm_error_biometric_changed_send">Biometric enrollment changed — re-import this wallet from its recovery phrase to continue</string>
+    <string name="vm_error_create_account_failed">Failed to create account: %1$s</string>
+    <string name="vm_error_parent_no_mnemonic">Parent wallet has no mnemonic</string>
+    <string name="vm_error_cannot_read_parent">Cannot read parent wallet: %1$s</string>
+    <!-- DaoViewModel -->
+    <string name="vm_error_invalid_deposit_amount">Invalid deposit amount</string>
+    <string name="vm_error_no_active_wallet_dao">No active wallet</string>
+    <string name="vm_error_auth_failed_with_reason">Authentication failed: %1$s</string>
+    <!-- HomeViewModel -->
+    <string name="vm_error_registration_failed">Registration failed: %1$s</string>
+    <string name="vm_error_load_transactions_failed">Failed to load transactions: %1$s</string>
+    <string name="vm_error_sync_mode_change_failed_home">Failed to change sync mode: %1$s</string>
+    <string name="vm_error_import_failed">Import failed: %1$s</string>
+    <!-- SendViewModel -->
+    <string name="vm_error_network_changed_tx_cancelled">Network changed. Transaction cancelled.</string>
+    <string name="vm_error_send_v2_reopen">This wallet requires biometric unlock; reopen Send and try again</string>
+    <string name="vm_error_enter_recipient">Please enter recipient address</string>
+    <string name="vm_error_enter_amount">Please enter amount</string>
+    <string name="vm_error_invalid_amount">Invalid amount</string>
+    <string name="vm_error_min_transfer">Minimum transfer is 61 CKB</string>
+    <string name="vm_error_insufficient_balance">Insufficient balance</string>
+    <string name="vm_error_wallet_not_initialized">Wallet not initialized</string>
+    <string name="vm_error_no_active_wallet">No active wallet</string>
+    <string name="vm_error_access_keys_failed">Failed to access wallet keys: %1$s</string>
+    <!-- OnboardingViewModel -->
+    <string name="vm_error_no_device_credential">Set a screen lock (PIN, pattern, password, or biometric) in Android Settings, then try again. Pocket Node uses your device lock to protect your wallet keys.</string>
+
     <string name="vm_error_migration_incomplete">Wallet security upgrade incomplete; you\'ll be prompted again next launch</string>
     <string name="vm_error_migration_failed">Wallet security upgrade failed: %1$s</string>
     <string name="vm_error_retry_failed">Couldn\'t retry: %1$s</string>


### PR DESCRIPTION
Final slice of #133. Migrates Home, Send, DAO, AddWallet, WalletSettings, WalletManager, and Onboarding ViewModels (~47 errors) plus their screens to UiMessage.

After this PR all 65 hardcoded VM error strings emit typed UiMessage. Translation work in #132 is now unblocked.

611/611 tests pass. Closes #133.