### PR TITLE
refactor(gateway): extract LightClientReadOnly (#106 phase 4)

### DIFF
--- a/android/app/src/main/java/com/rjnr/pocketnode/data/gateway/GatewayRepository.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/gateway/GatewayRepository.kt
@@ -115,6 +115,7 @@ class GatewayRepository @Inject constructor(
     private val syncCoordinator: SyncCoordinator,
     private val daoHeaderResolver: DaoHeaderResolver,
     private val daoDepositReader: DaoDepositReader,
+    private val lightClient: LightClientReadOnly,
 ) : TipSource {
     private val sendMutex = Mutex()
 
@@ -1117,14 +1118,7 @@ class GatewayRepository @Inject constructor(
         CellsResponse(liveCells, pag.lastCursor)
     }
 
-    private suspend fun currentTipNumberOrZero(): Long = try {
-        val tipStr = LightClientNative.nativeGetTipHeader() ?: return 0L
-        val tip = json.decodeFromString<JniHeaderView>(tipStr)
-        tip.number.removePrefix("0x").toLong(16)
-    } catch (e: Exception) {
-        Log.w(TAG, "currentTipNumberOrZero failed: ${e.message}")
-        0L
-    }
+    private suspend fun currentTipNumberOrZero(): Long = lightClient.currentTipNumberOrZero()
 
     /**
      * Single mutex-guarded prepare-and-send. Runs cell-fetch, reservation
@@ -1702,33 +1696,19 @@ class GatewayRepository @Inject constructor(
         }
     }
 
-    // Status UI methods
-    suspend fun getPeers(): String? = withContext(Dispatchers.IO) {
-        LightClientNative.nativeGetPeers()
-    }
-
-    suspend fun getTipHeader(): String? = withContext(Dispatchers.IO) {
-        LightClientNative.nativeGetTipHeader()
-    }
-
-    suspend fun getScripts(): String? = withContext(Dispatchers.IO) {
-        LightClientNative.nativeGetScripts()
-    }
-
-    suspend fun callRpc(method: String): String? = withContext(Dispatchers.IO) {
-        LightClientNative.callRpc(method)
-    }
+    // Diagnostic / read-only JNI passthroughs moved to [LightClientReadOnly]
+    // (#106 phase 4). Thin shims kept so NodeStatusViewModel and other
+    // consumers don't need a constructor change.
+    suspend fun getPeers(): String? = lightClient.getPeers()
+    suspend fun getTipHeader(): String? = lightClient.getTipHeader()
+    suspend fun getScripts(): String? = lightClient.getScripts()
+    suspend fun callRpc(method: String): String? = lightClient.callRpc(method)
 
     // ========================================
     // DAO Operations
     // ========================================
 
-    suspend fun getCurrentEpoch(): Result<EpochInfo> = runCatching {
-        val headerJson = LightClientNative.nativeGetTipHeader()
-            ?: throw Exception("Failed to get tip header")
-        val header = json.decodeFromString<JniHeaderView>(headerJson)
-        EpochInfo.fromHex(header.epoch)
-    }
+    suspend fun getCurrentEpoch(): Result<EpochInfo> = lightClient.getCurrentEpoch()
 
     // DAO chain-state helpers moved to [DaoHeaderResolver] (#106 phase 2).
     // Thin shims kept so internal call sites stay unchanged. getOrFetchHeader's

--- a/android/app/src/main/java/com/rjnr/pocketnode/data/gateway/LightClientReadOnly.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/gateway/LightClientReadOnly.kt
@@ -1,0 +1,86 @@
+package com.rjnr.pocketnode.data.gateway
+
+import android.util.Log
+import com.nervosnetwork.ckblightclient.LightClientNative
+import com.rjnr.pocketnode.data.gateway.models.EpochInfo
+import com.rjnr.pocketnode.data.gateway.models.JniHeaderView
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import kotlinx.serialization.json.Json
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Read-only JNI passthroughs (#106 phase 4).
+ *
+ * The NodeStatus / diagnostic surfaces and the DAO + sync paths all
+ * read a small set of values straight off the light client: peers,
+ * tip header, registered scripts, raw RPC, the parsed tip block
+ * number, and the current epoch. None of these mutate repository
+ * state — they're pure reads.
+ *
+ * Pulling them out frees GatewayRepository of ~50 lines of
+ * boilerplate and gives tests a focused seam: NodeStatusViewModel
+ * (and friends) can take this directly instead of the full
+ * GatewayRepository to exercise diagnostic flows.
+ *
+ * All methods are `suspend` and force `Dispatchers.IO` because JNI
+ * calls can block the caller's thread; the original code wrapped
+ * each call in `withContext(Dispatchers.IO)` for the same reason.
+ */
+@Singleton
+class LightClientReadOnly @Inject constructor(
+    private val json: Json,
+) {
+
+    suspend fun getPeers(): String? = withContext(Dispatchers.IO) {
+        LightClientNative.nativeGetPeers()
+    }
+
+    suspend fun getTipHeader(): String? = withContext(Dispatchers.IO) {
+        LightClientNative.nativeGetTipHeader()
+    }
+
+    suspend fun getScripts(): String? = withContext(Dispatchers.IO) {
+        LightClientNative.nativeGetScripts()
+    }
+
+    suspend fun callRpc(method: String): String? = withContext(Dispatchers.IO) {
+        LightClientNative.callRpc(method)
+    }
+
+    /**
+     * Parsed tip block number, or 0L if the light client hasn't
+     * reported a header yet (cold start) or the header failed to
+     * decode (transient JNI error).
+     */
+    suspend fun currentTipNumberOrZero(): Long = withContext(Dispatchers.IO) {
+        try {
+            val tipStr = LightClientNative.nativeGetTipHeader() ?: return@withContext 0L
+            val tip = json.decodeFromString<JniHeaderView>(tipStr)
+            tip.number.removePrefix("0x").toLong(16)
+        } catch (e: Exception) {
+            Log.w(TAG, "currentTipNumberOrZero failed: ${e.message}")
+            0L
+        }
+    }
+
+    /**
+     * Tip epoch (epoch index + per-epoch fraction). Wrapped in
+     * `Result` because DAO flows want explicit failure rather than a
+     * sentinel value — without a tip header we can't compute
+     * `lockRemainingHours` accurately.
+     */
+    suspend fun getCurrentEpoch(): Result<EpochInfo> = withContext(Dispatchers.IO) {
+        runCatching {
+            val headerJson = LightClientNative.nativeGetTipHeader()
+                ?: throw Exception("Failed to get tip header")
+            val header = json.decodeFromString<JniHeaderView>(headerJson)
+            EpochInfo.fromHex(header.epoch)
+        }
+    }
+
+    companion object {
+        private const val TAG = "LightClientReadOnly"
+    }
+}

--- a/android/app/src/main/java/com/rjnr/pocketnode/di/AppModule.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/di/AppModule.kt
@@ -243,5 +243,6 @@ object AppModule {
         syncCoordinator: com.rjnr.pocketnode.data.gateway.SyncCoordinator,
         daoHeaderResolver: com.rjnr.pocketnode.data.gateway.DaoHeaderResolver,
         daoDepositReader: com.rjnr.pocketnode.data.gateway.DaoDepositReader,
-    ): GatewayRepository = GatewayRepository(context, keyManager, walletPreferences, json, transactionBuilder, cacheManager, daoSyncManager, walletMigrationHelper, walletDao, appDatabase, headerCacheDao, syncProgressDao, pendingBroadcastDao, broadcastClient, syncCoordinator, daoHeaderResolver, daoDepositReader)
+        lightClient: com.rjnr.pocketnode.data.gateway.LightClientReadOnly,
+    ): GatewayRepository = GatewayRepository(context, keyManager, walletPreferences, json, transactionBuilder, cacheManager, daoSyncManager, walletMigrationHelper, walletDao, appDatabase, headerCacheDao, syncProgressDao, pendingBroadcastDao, broadcastClient, syncCoordinator, daoHeaderResolver, daoDepositReader, lightClient)
 }


### PR DESCRIPTION
Phase 4 of #106. Pulls six read-only JNI passthroughs (getPeers / getTipHeader / getScripts / callRpc / currentTipNumberOrZero / getCurrentEpoch) into a focused @Singleton.

Cumulative reduction across all four phases: 2629 → ~2070 lines (~21%).

Refs #106