### PR TITLE
diag(sync): registration logging + truthful percentage baseline (#150 Steps 1+3)

### DIFF
--- a/android/app/src/main/java/com/rjnr/pocketnode/data/gateway/GatewayRepository.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/gateway/GatewayRepository.kt
@@ -280,6 +280,14 @@ class GatewayRepository @Inject constructor(
         // starts from its own baseline. Otherwise ACTIVE_ONLY switches can spuriously
         // report progress / ETA / justReachedTip from the old wallet's syncing window.
         syncProgressTracker.reset()
+        // Seed the percentage baseline with the registered light-client start
+        // block so the first sample doesn't anchor the math to a transient
+        // syncedToBlock=0 reading during peer warm-up (#150).
+        val lightStart = syncProgressDao.get(wallet.walletId, currentNetwork.name)
+            ?.lightStartBlockNumber ?: 0L
+        if (lightStart > 0) {
+            syncProgressTracker.seedStartHeight(lightStart)
+        }
         wasSyncing = false
         firstCatchingUpAtMs = null
         _syncProgress.value = SyncProgress()
@@ -1976,6 +1984,16 @@ class GatewayRepository @Inject constructor(
 
                         val syncedBlock = status.syncedToBlock.toLongOrNull() ?: 0L
                         val tipBlock = status.tipNumber.toLongOrNull() ?: 0L
+
+                        // Diagnostic for the production sync-stall reports (#150).
+                        // Logged once every poll cycle so support can see the
+                        // delta between syncedBlock and tipBlock in logcat
+                        // without enabling verbose JNI logging.
+                        Log.i(
+                            TAG,
+                            "syncPoll synced=$syncedBlock tip=$tipBlock " +
+                                "delta=${tipBlock - syncedBlock} progress=${status.syncProgress}"
+                        )
 
                         syncProgressTracker.recordSample(syncedBlock, System.currentTimeMillis())
                         val info = syncProgressTracker.calculate(tipBlock)

--- a/android/app/src/main/java/com/rjnr/pocketnode/data/gateway/SyncCoordinator.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/gateway/SyncCoordinator.kt
@@ -151,8 +151,24 @@ class SyncCoordinator @Inject constructor(
             "setScriptsAndRecord: statuses (${statuses.size}) and walletIds (${walletIds.size}) must be parallel"
         }
         val jsonStr = json.encodeToString(statuses)
+        // Diagnostic for the production sync-stall reports (#150). Logs every
+        // (walletId, startBlock) pair just before the JNI handoff. If a user
+        // reports "stayed at 0", this line tells us deterministically what
+        // block they were actually scanning from. Logged at INFO so it
+        // survives release builds' default log level.
+        statuses.zip(walletIds).forEach { (status, walletId) ->
+            val startBlock = status.blockNumber.removePrefix("0x").toLongOrNull(16) ?: -1L
+            Log.i(
+                TAG,
+                "setScripts cmd=$cmd walletId=$walletId network=${network.name} " +
+                    "startBlock=$startBlock (hex=${status.blockNumber})"
+            )
+        }
         val ok = lightClient.setScripts(jsonStr, cmd)
-        if (!ok) return false
+        if (!ok) {
+            Log.w(TAG, "setScripts cmd=$cmd returned false — light client refused registration")
+            return false
+        }
 
         val now = System.currentTimeMillis()
         val newMapping = mutableMapOf<String, String>()

--- a/android/app/src/main/java/com/rjnr/pocketnode/data/sync/SyncProgressTracker.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/sync/SyncProgressTracker.kt
@@ -24,7 +24,30 @@ class SyncProgressTracker {
     private val samples = mutableListOf<Sample>()
     private var startHeight: Long? = null
 
-    /** Record a new block height observation. First call captures startHeight. */
+    /**
+     * Seed the percentage baseline with the wallet's registered light-client
+     * start block (from `sync_progress.lightStartBlockNumber`). Called once
+     * per wallet activation, before the polling loop starts feeding samples.
+     *
+     * Previously the first sample's blockHeight was used as the baseline. On
+     * a 2021 wallet that path silently anchors to whatever the light client
+     * reports first — often 0 during peer warm-up — which makes
+     * `percentage = (current - 0) / (tip - 0)` lie about real progress for
+     * the first poll cycle. Seeding with the registered start block fixes
+     * the math from sample #1.
+     *
+     * Safe to call multiple times; later calls overwrite the baseline only
+     * when the new value is non-zero. This handles the wallet-switch case
+     * where the persisted lightStartBlock may temporarily be unknown.
+     */
+    fun seedStartHeight(startBlock: Long) {
+        if (startBlock > 0) {
+            startHeight = startBlock
+        }
+    }
+
+    /** Record a new block height observation. First call captures startHeight
+     *  iff [seedStartHeight] wasn't called first. */
     fun recordSample(blockHeight: Long, timestampMs: Long) {
         if (startHeight == null) {
             startHeight = blockHeight

--- a/android/app/src/test/java/com/rjnr/pocketnode/data/sync/SyncProgressTrackerTest.kt
+++ b/android/app/src/test/java/com/rjnr/pocketnode/data/sync/SyncProgressTrackerTest.kt
@@ -122,4 +122,42 @@ class SyncProgressTrackerTest {
 
         assertTrue(info.isSynced)
     }
+
+    @Test
+    fun `seedStartHeight anchors percentage to registered start block (#150)`() {
+        // Pre-#150 the first sample's blockHeight became the baseline.
+        // For a 2021 wallet whose light client reports syncedToBlock=0
+        // on the first poll cycle, that anchored to 0 and the percentage
+        // was momentarily wrong. Seeding with the registered start block
+        // (5_000_000 here) keeps the math truthful from sample #1.
+        tracker.seedStartHeight(startBlock = 5_000_000L)
+        tracker.recordSample(blockHeight = 5_000_100L, timestampMs = 0L)
+        // Tip = 18M, baseline = 5M, current = 5_000_100. Range = 13M,
+        // progress = 100 blocks → ~0.0008%.
+        val info = tracker.calculate(tipHeight = 18_000_000L)
+        assertTrue("expected positive but tiny progress, got ${info.percentage}", info.percentage > 0.0)
+        assertTrue("expected < 1%, got ${info.percentage}", info.percentage < 1.0)
+    }
+
+    @Test
+    fun `seedStartHeight ignored when called with zero`() {
+        // Defensive: a missing sync_progress row resolves to lightStartBlock=0;
+        // seeding with 0 would re-introduce the pre-#150 bug shape.
+        tracker.seedStartHeight(startBlock = 0L)
+        // No seed applied → first sample provides baseline.
+        tracker.recordSample(blockHeight = 5_000_000L, timestampMs = 0L)
+        tracker.recordSample(blockHeight = 5_000_100L, timestampMs = 1000L)
+        val info = tracker.calculate(tipHeight = 18_000_000L)
+        // Baseline = first sample (5M), range = 13M, progress = 100 → tiny.
+        assertTrue(info.percentage > 0.0 && info.percentage < 1.0)
+    }
+
+    @Test
+    fun `seedStartHeight tolerates no-sample state`() {
+        // Edge case: seed then ask immediately. No crash; percentage clamps
+        // to 0 because currentHeight is 0 < startHeight.
+        tracker.seedStartHeight(startBlock = 5_000_000L)
+        val info = tracker.calculate(tipHeight = 18_000_000L)
+        assertEquals(0.0, info.percentage, 0.01)
+    }
 }


### PR DESCRIPTION
## Summary

Two complementary changes for production sync-stall reports ("stayed at 0 for 30 minutes" on a 2021 wallet, reported via Telegram).

- **Step 1 — registration-path logging**: `SyncCoordinator.setScriptsAndRecord` logs every `(walletId, startBlock)` pair before the JNI `setScripts` call. The polling loop in `GatewayRepository` logs `syncPoll synced=X tip=Y delta=Z progress=P` each cycle. Next "stayed at 0" report, logcat shows deterministically what we registered and whether `syncedToBlock` advances. INFO level so release builds keep it.
- **Step 3 — truthful percentage baseline**: `SyncProgressTracker.recordSample` previously used the FIRST sample's blockHeight as baseline. On a 2021 wallet the first poll often returns `syncedToBlock=0` (peer warm-up), anchoring the math to 0. New `seedStartHeight(registeredStartBlock)` is called by `GatewayRepository.onActiveWalletChanged` with the persisted `lightStartBlockNumber` from `sync_progress`. Percentage is truthful from poll cycle #1.

## Test plan

- [x] `./gradlew testDebugUnitTest` — 619/619 pass (3 new in `SyncProgressTrackerTest`)
- [ ] Manual: trigger active-wallet change with a wallet that has prior `sync_progress.lightStartBlockNumber`; confirm percentage shows >0% on first poll
- [ ] Manual: filter logcat for `SyncCoordinator` and `GatewayRepository`; verify both new lines fire

Refs #150