### PR TITLE
feat(sync): stall detector + one-tap RECENT switch (#150 Step 2)

### DIFF
--- a/android/app/src/main/java/com/rjnr/pocketnode/data/sync/SyncStallDetector.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/sync/SyncStallDetector.kt
@@ -1,0 +1,71 @@
+package com.rjnr.pocketnode.data.sync
+
+/**
+ * Pure-logic detector for sync-stall: catches the production pathology where
+ * `syncedToBlock` stops advancing for many minutes while the user sees 0%
+ * (reported via Telegram for a 2021-era wallet, #150).
+ *
+ * Contract:
+ *  - First [evaluate] call captures the baseline; never reports stalled.
+ *  - Every advance (syncedBlock > lastObservedBlock) refreshes the baseline.
+ *  - When syncedBlock has not advanced for >= [stallThresholdMs] AND we are
+ *    not within [SYNC_TOLERANCE] of tip, [StallInfo.isStalled] is true.
+ *  - When within tolerance of tip, baseline resets and stall flag clears.
+ *
+ * Thread-safety: NOT thread-safe. Called from a single sync-poll observer.
+ */
+class SyncStallDetector(
+    private val stallThresholdMs: Long = DEFAULT_STALL_THRESHOLD_MS,
+) {
+
+    data class StallInfo(
+        val isStalled: Boolean,
+        val stalledForMs: Long,
+        val syncedBlock: Long,
+        val tipBlock: Long,
+    ) {
+        val stalledForMinutes: Long get() = stalledForMs / 60_000L
+    }
+
+    private var lastObservedBlock: Long = -1L
+    private var lastAdvanceAtMs: Long = 0L
+
+    fun evaluate(syncedBlock: Long, tipBlock: Long, nowMs: Long): StallInfo {
+        val isSynced = tipBlock > 0 && syncedBlock >= tipBlock - SYNC_TOLERANCE
+        if (isSynced) {
+            lastObservedBlock = syncedBlock
+            lastAdvanceAtMs = nowMs
+            return StallInfo(false, 0L, syncedBlock, tipBlock)
+        }
+
+        if (lastObservedBlock < 0) {
+            lastObservedBlock = syncedBlock
+            lastAdvanceAtMs = nowMs
+            return StallInfo(false, 0L, syncedBlock, tipBlock)
+        }
+
+        if (syncedBlock > lastObservedBlock) {
+            lastObservedBlock = syncedBlock
+            lastAdvanceAtMs = nowMs
+            return StallInfo(false, 0L, syncedBlock, tipBlock)
+        }
+
+        val stalledForMs = (nowMs - lastAdvanceAtMs).coerceAtLeast(0L)
+        return StallInfo(
+            isStalled = stalledForMs >= stallThresholdMs,
+            stalledForMs = stalledForMs,
+            syncedBlock = syncedBlock,
+            tipBlock = tipBlock,
+        )
+    }
+
+    fun reset() {
+        lastObservedBlock = -1L
+        lastAdvanceAtMs = 0L
+    }
+
+    companion object {
+        const val DEFAULT_STALL_THRESHOLD_MS: Long = 5L * 60L * 1000L
+        private const val SYNC_TOLERANCE: Long = 10L
+    }
+}

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/components/SyncStallBanner.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/components/SyncStallBanner.kt
@@ -1,0 +1,83 @@
+package com.rjnr.pocketnode.ui.components
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Warning
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.FilledTonalButton
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import com.rjnr.pocketnode.R
+
+/**
+ * Surfaces a stall warning when `syncedToBlock` has not advanced for several
+ * minutes (#150). Two CTAs:
+ *  - "Use Recent" — switch sync mode to RECENT (fastest recovery for the
+ *    2021-era-wallet pathology reported on Telegram).
+ *  - "Dismiss" — hide for the current sync session.
+ */
+@Composable
+fun SyncStallBanner(
+    minutesStalled: Long,
+    onSwitchToRecent: () -> Unit,
+    onDismiss: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Card(
+        modifier = modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.errorContainer,
+        ),
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(12.dp),
+            ) {
+                Icon(
+                    imageVector = Icons.Default.Warning,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.error,
+                )
+                Text(
+                    text = stringResource(R.string.sync_stall_banner_title, minutesStalled),
+                    style = MaterialTheme.typography.titleSmall,
+                    color = MaterialTheme.colorScheme.onErrorContainer,
+                )
+            }
+            Text(
+                text = stringResource(R.string.sync_stall_banner_body),
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onErrorContainer,
+            )
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.End,
+            ) {
+                TextButton(onClick = onDismiss) {
+                    Text(stringResource(R.string.sync_stall_banner_action_dismiss))
+                }
+                FilledTonalButton(onClick = onSwitchToRecent) {
+                    Text(stringResource(R.string.sync_stall_banner_action_switch_recent))
+                }
+            }
+        }
+    }
+}

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/home/HomeScreen.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/home/HomeScreen.kt
@@ -92,6 +92,7 @@ import com.composables.icons.lucide.ChevronDown
 import androidx.compose.ui.res.stringResource
 import com.rjnr.pocketnode.ui.components.SecurityBanner
 import com.rjnr.pocketnode.ui.components.SecurityBannerState
+import com.rjnr.pocketnode.ui.components.SyncStallBanner
 import com.rjnr.pocketnode.ui.components.SyncOptionsSheet
 import com.rjnr.pocketnode.ui.components.UpdateDialog
 import com.rjnr.pocketnode.ui.components.AccountSelectorSheet
@@ -480,6 +481,8 @@ fun HomeScreen(
                     selectedTransaction = { selectedTransaction = it },
                     onRetryFailed = { retryDialogTx = it },
                     onTopicHelp = { topic -> educationTopic = topic },
+                    onSyncStallSwitchToRecent = { viewModel.switchToRecentSyncFromStall() },
+                    onSyncStallDismiss = { viewModel.dismissSyncStallBanner() },
                 )
                 if (uiState.isSwitchingWallet) {
                     LinearProgressIndicator(
@@ -547,6 +550,8 @@ fun HomeScreenUI(
     selectedTransaction: (tx: TransactionRecord) -> Unit,
     onRetryFailed: (tx: TransactionRecord) -> Unit = {},
     onTopicHelp: (EducationTopic) -> Unit = {},
+    onSyncStallSwitchToRecent: () -> Unit = {},
+    onSyncStallDismiss: () -> Unit = {},
 ) {
     PullToRefreshBox(
         isRefreshing = uiState.isRefreshing,
@@ -607,6 +612,18 @@ fun HomeScreenUI(
                         }
                     }
                 )
+            }
+
+            // Sync-stall warning banner (#150): syncedToBlock has not advanced
+            // for >= 5 min. Offers one-tap switch to RECENT or dismiss.
+            if (uiState.showSyncStallBanner) {
+                item {
+                    SyncStallBanner(
+                        minutesStalled = uiState.syncStallMinutes,
+                        onSwitchToRecent = onSyncStallSwitchToRecent,
+                        onDismiss = onSyncStallDismiss,
+                    )
+                }
             }
 
             // Sync warning banner

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/home/HomeViewModel.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/home/HomeViewModel.kt
@@ -7,6 +7,7 @@ import com.rjnr.pocketnode.data.database.entity.WalletEntity
 import com.rjnr.pocketnode.data.gateway.CacheManager
 import com.rjnr.pocketnode.data.gateway.GatewayRepository
 import com.rjnr.pocketnode.data.gateway.SyncProgress
+import com.rjnr.pocketnode.data.sync.SyncStallDetector
 import com.rjnr.pocketnode.data.gateway.models.NetworkType
 import com.rjnr.pocketnode.data.gateway.models.SyncMode
 import com.rjnr.pocketnode.data.gateway.models.TransactionRecord
@@ -93,6 +94,12 @@ class HomeViewModel @Inject constructor(
     // load these can fire within milliseconds. tryLock means we never queue a
     // duplicate JNI/Room round-trip — the second caller bails immediately.
     private val txRefreshMutex = Mutex()
+
+    // Tracks whether the user has dismissed the stall banner this session.
+    // Reset on sync mode change, wallet switch, network switch (each clears
+    // the detector and re-opens the banner if the new sync also stalls).
+    private var stallBannerDismissed: Boolean = false
+    private val syncStallDetector = SyncStallDetector()
 
     private val _uiState = MutableStateFlow(
         // Restore the sync-options dialog visibility across process death so
@@ -358,12 +365,22 @@ class HomeViewModel @Inject constructor(
     private fun observeSyncProgress() {
         viewModelScope.launch {
             repository.syncProgress.collect { progress ->
+                val stallInfo = syncStallDetector.evaluate(
+                    syncedBlock = progress.syncedToBlock,
+                    tipBlock = progress.tipBlockNumber,
+                    nowMs = System.currentTimeMillis(),
+                )
+                val showStallBanner = stallInfo.isStalled
+                    && progress.isSyncing
+                    && !stallBannerDismissed
                 _uiState.update {
                     it.copy(
                         syncProgress = progress.percentage / 100.0,
                         isSyncing = progress.isSyncing,
                         syncedToBlock = progress.syncedToBlock.toString(),
-                        tipBlockNumber = progress.tipBlockNumber.toString()
+                        tipBlockNumber = progress.tipBlockNumber.toString(),
+                        showSyncStallBanner = showStallBanner,
+                        syncStallMinutes = stallInfo.stalledForMinutes,
                     )
                 }
 
@@ -512,6 +529,8 @@ class HomeViewModel @Inject constructor(
             Log.d(TAG, "Changing sync mode to: $syncMode, customBlock: $customBlockHeight")
 
             repository.stopSyncPolling()
+            syncStallDetector.reset()
+            stallBannerDismissed = false
 
             _uiState.update {
                 it.copy(
@@ -520,7 +539,9 @@ class HomeViewModel @Inject constructor(
                     syncProgress = 0.0,
                     transactions = emptyList(),
                     currentSyncMode = syncMode,
-                    savedCustomBlockHeight = customBlockHeight
+                    savedCustomBlockHeight = customBlockHeight,
+                    showSyncStallBanner = false,
+                    syncStallMinutes = 0L,
                 )
             }
 
@@ -662,7 +683,9 @@ class HomeViewModel @Inject constructor(
     fun switchWallet(walletId: String) {
         viewModelScope.launch {
             try {
-                _uiState.update { it.copy(isSwitchingWallet = true) }
+                syncStallDetector.reset()
+                stallBannerDismissed = false
+                _uiState.update { it.copy(isSwitchingWallet = true, showSyncStallBanner = false, syncStallMinutes = 0L) }
                 walletRepository.switchActiveWallet(walletId)
                 val wallet = walletRepository.getById(walletId) ?: return@launch
                 repository.onActiveWalletChanged(wallet)
@@ -702,6 +725,8 @@ class HomeViewModel @Inject constructor(
         viewModelScope.launch {
             // Cancel active polling before switching
             repository.stopSyncPolling()
+            syncStallDetector.reset()
+            stallBannerDismissed = false
 
             // Clear UI state for fresh network
             _uiState.update {
@@ -715,7 +740,9 @@ class HomeViewModel @Inject constructor(
                     tipBlockNumber = "",
                     peerCount = 0,
                     isSyncing = true,
-                    error = null
+                    error = null,
+                    showSyncStallBanner = false,
+                    syncStallMinutes = 0L,
                 )
             }
 
@@ -846,6 +873,25 @@ class HomeViewModel @Inject constructor(
         walletPreferences.markSyncCoachmarkSeen()
     }
 
+    /**
+     * Hide the sync-stall banner without changing sync mode. Stays hidden
+     * until the user changes sync mode / wallet / network. The detector
+     * itself keeps running and would re-flag if the next reset matches.
+     */
+    fun dismissSyncStallBanner() {
+        stallBannerDismissed = true
+        _uiState.update { it.copy(showSyncStallBanner = false) }
+    }
+
+    /**
+     * One-tap recovery from a stall on a 2021-era wallet (#150): switch to
+     * RECENT sync mode. Delegates to [changeSyncMode] so the polling teardown,
+     * detector reset, and resync run via the existing path.
+     */
+    fun switchToRecentSyncFromStall() {
+        changeSyncMode(SyncMode.RECENT, customBlockHeight = null)
+    }
+
     override fun onCleared() {
         super.onCleared()
         // Do NOT call updateDownloader.cleanup() here. The downloader is a
@@ -921,5 +967,7 @@ data class HomeUiState(
     val isSwitchingWallet: Boolean = false,
     val savedCustomBlockHeight: Long? = null,
     val walletBalances: Map<String, String> = emptyMap(),
-    val showSyncCoachmark: Boolean = false
+    val showSyncCoachmark: Boolean = false,
+    val showSyncStallBanner: Boolean = false,
+    val syncStallMinutes: Long = 0L,
 )

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -468,4 +468,11 @@
     <string name="save_contact_dialog_dismiss">Not now</string>
     <!-- endregion -->
 
+    <!-- region: sync stall banner (#150) -->
+    <string name="sync_stall_banner_title">Sync hasn\'t progressed in %1$d min</string>
+    <string name="sync_stall_banner_body">If this wallet has years of history, scanning from that far back is slow. Switch to Recent activity to catch up faster.</string>
+    <string name="sync_stall_banner_action_switch_recent">Use Recent</string>
+    <string name="sync_stall_banner_action_dismiss">Dismiss</string>
+    <!-- endregion -->
+
 </resources>

--- a/android/app/src/test/java/com/rjnr/pocketnode/data/sync/SyncStallDetectorTest.kt
+++ b/android/app/src/test/java/com/rjnr/pocketnode/data/sync/SyncStallDetectorTest.kt
@@ -1,0 +1,97 @@
+package com.rjnr.pocketnode.data.sync
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+class SyncStallDetectorTest {
+
+    private lateinit var detector: SyncStallDetector
+
+    @Before
+    fun setUp() {
+        // 5 min threshold matches production default
+        detector = SyncStallDetector(stallThresholdMs = 5L * 60L * 1000L)
+    }
+
+    @Test
+    fun `first call never reports stalled`() {
+        val info = detector.evaluate(syncedBlock = 5_000_000, tipBlock = 10_000_000, nowMs = 0L)
+        assertFalse(info.isStalled)
+        assertEquals(0L, info.stalledForMs)
+    }
+
+    @Test
+    fun `not stalled while advancing`() {
+        detector.evaluate(5_000_000, 10_000_000, 0L)
+        detector.evaluate(5_100_000, 10_000_000, 60_000L)
+        val info = detector.evaluate(5_200_000, 10_000_000, 120_000L)
+        assertFalse(info.isStalled)
+    }
+
+    @Test
+    fun `stalled after threshold with no advance`() {
+        detector.evaluate(5_000_000, 10_000_000, 0L)
+        // Same block 6 minutes later
+        val info = detector.evaluate(5_000_000, 10_000_000, 6L * 60L * 1000L)
+        assertTrue(info.isStalled)
+        assertEquals(6L, info.stalledForMinutes)
+    }
+
+    @Test
+    fun `not stalled below threshold`() {
+        detector.evaluate(5_000_000, 10_000_000, 0L)
+        // Same block 4 minutes later — under 5 min threshold
+        val info = detector.evaluate(5_000_000, 10_000_000, 4L * 60L * 1000L)
+        assertFalse(info.isStalled)
+        assertEquals(4L, info.stalledForMinutes)
+    }
+
+    @Test
+    fun `advance after long stall clears the flag`() {
+        detector.evaluate(5_000_000, 10_000_000, 0L)
+        val stalled = detector.evaluate(5_000_000, 10_000_000, 6L * 60L * 1000L)
+        assertTrue(stalled.isStalled)
+
+        val recovered = detector.evaluate(5_100_000, 10_000_000, 7L * 60L * 1000L)
+        assertFalse(recovered.isStalled)
+        assertEquals(0L, recovered.stalledForMs)
+    }
+
+    @Test
+    fun `synced within tolerance never stalls`() {
+        // syncedBlock within SYNC_TOLERANCE (10) of tip — treat as synced
+        detector.evaluate(9_999_995, 10_000_000, 0L)
+        val info = detector.evaluate(9_999_995, 10_000_000, 10L * 60L * 1000L)
+        assertFalse(info.isStalled)
+    }
+
+    @Test
+    fun `tipBlock zero treated as not-synced still stalls`() {
+        // tip=0 is a transient state during peer warm-up; don't suppress stall detection
+        detector.evaluate(0L, 0L, 0L)
+        val info = detector.evaluate(0L, 0L, 10L * 60L * 1000L)
+        assertTrue(info.isStalled)
+    }
+
+    @Test
+    fun `reset clears all state`() {
+        detector.evaluate(5_000_000, 10_000_000, 0L)
+        detector.evaluate(5_000_000, 10_000_000, 6L * 60L * 1000L)
+        detector.reset()
+
+        val info = detector.evaluate(5_000_000, 10_000_000, 10L * 60L * 1000L)
+        assertFalse(info.isStalled)
+        assertEquals(0L, info.stalledForMs)
+    }
+
+    @Test
+    fun `negative time delta coerced to zero`() {
+        detector.evaluate(5_000_000, 10_000_000, 1000L)
+        val info = detector.evaluate(5_000_000, 10_000_000, 500L)
+        assertEquals(0L, info.stalledForMs)
+        assertFalse(info.isStalled)
+    }
+}


### PR DESCRIPTION
## Summary

Closes the diagnostic loop for the production sync-stall reports (V.bit's 2021-era wallet "stayed at 0 for 30 minutes" via Telegram, #150).

`SyncStallDetector` (pure logic, fully tested) tracks `syncedToBlock` across poll cycles. When the value has not advanced for >= 5 minutes AND we are still away from tip, `HomeViewModel` raises `showSyncStallBanner`.

`SyncStallBanner` surfaces above the existing sync warning with two CTAs:
- **Use Recent** — calls `changeSyncMode(RECENT)`. Fastest recovery for the 2021-wallet pathology (usable in ~2 min instead of unknown wait against full history).
- **Dismiss** — hides for the session; detector keeps watching but banner stays suppressed until sync mode / wallet / network changes.

Detector + dismissal flag reset on `changeSyncMode`, `switchWallet`, `confirmNetworkSwitch`.

## Test plan

- [x] `./gradlew testDebugUnitTest` — 628/628 pass (9 new in `SyncStallDetectorTest`)
- [ ] Manual: start sync on a 2021-era wallet; wait 5 min; banner appears with elapsed-minutes count
- [ ] Manual: tap "Use Recent"; banner clears, sync mode switches, polling resumes from checkpoint
- [ ] Manual: tap "Dismiss"; banner clears, does NOT re-appear in same sync session
- [ ] Manual: dismiss banner; then change sync mode; banner re-eligible if new sync stalls

Refs #150