### PR TITLE
fix(ci): tighten release-signing gate to exact APK/AAB tasks

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -119,13 +119,25 @@ android {
     }
 
     gradle.taskGraph.whenReady {
-        val needsReleaseSigning = allTasks.any { task ->
-            task.name.contains("Release") && (
-                task.name.startsWith("assemble") ||
-                    task.name.startsWith("bundle") ||
-                    task.name.startsWith("package")
-                )
-        }
+        // Identify tasks that actually produce a signed release artifact.
+        // AGP synthesizes a lot of release-named tasks under plain
+        // `./gradlew test` and `./gradlew compileDebug*` invocations
+        // (`packageReleaseResources`, `bundleReleaseClassesToCompileJar`,
+        // `assembleReleaseUnitTest`, etc.). Those tasks stage resources
+        // or classes and never touch the signing config, but broad
+        // name-match heuristics caught them and tripped this gate on
+        // every PR CI run that didn't carry the release-signing secrets.
+        // Enumerate the exact APK / AAB-producing task names instead so
+        // the gate fires only when a real release artifact would be
+        // signed and shipped.
+        val signingTaskNames = setOf(
+            "assembleRelease",
+            "bundleRelease",
+            "packageRelease",
+            "packageReleaseBundle",
+            "packageReleaseUniversalApk",
+        )
+        val needsReleaseSigning = allTasks.any { task -> task.name in signingTaskNames }
         if (needsReleaseSigning) {
             val missingVars = listOf("KEYSTORE_PATH", "KEYSTORE_PASSWORD", "KEY_ALIAS", "KEY_PASSWORD")
                 .filter { System.getenv(it) == null }


### PR DESCRIPTION
## Summary

The fail-closed gate added in #178/#212 used name-pattern matching (`contains(\"Release\") && startsWith(\"package\"|\"assemble\"|\"bundle\")`) which was too broad. AGP synthesizes many release-named intermediate tasks under plain `./gradlew test` and IDE syncs (`packageReleaseResources`, `bundleReleaseClassesToCompileJar`, `assembleReleaseUnitTest`, etc). None touch the signing config, but the pattern caught them and tripped the gate on every PR CI run without the release-signing secrets.

PRs #258, #259, #262, #260 were all hitting this and getting bypassed via `--admin` merge or were blocked outright.

Switch to an explicit allow-list of the five task names that actually produce a signed APK or AAB:

- `assembleRelease`
- `bundleRelease`
- `packageRelease`
- `packageReleaseBundle`
- `packageReleaseUniversalApk`

## Test plan

- [x] `./gradlew test -x cargoBuild --dry-run` succeeds without KEYSTORE_* env vars (matches CI's PR build path)
- [x] `./gradlew assembleRelease -x cargoBuild --dry-run` still fails closed with the same error message as before
- [ ] CI green on this PR

Refs #178, #212