### PR TITLE
feat(website): restore Learn CKB link from the legacy site

### DIFF
--- a/website/components/Footer.tsx
+++ b/website/components/Footer.tsx
@@ -72,6 +72,9 @@ export function Footer() {
             <FooterLink href="https://nervos.org" external>
               Nervos Network
             </FooterLink>
+            <FooterLink href="https://pocket-node-learn-ckb.vercel.app/" external>
+              Learn CKB
+            </FooterLink>
           </FooterColumn>
         </div>
 

--- a/website/components/Navbar.tsx
+++ b/website/components/Navbar.tsx
@@ -60,6 +60,9 @@ export function Navbar() {
             <NavLink href="/#features">Features</NavLink>
             <NavLink href="/#security">Security</NavLink>
             <NavLink href="/guide">Guide</NavLink>
+            <NavLink href="https://pocket-node-learn-ckb.vercel.app/" external>
+              Learn CKB
+            </NavLink>
             <Link
               href="https://github.com/RaheemJnr/pocket-node/releases/latest"
               target="_blank"
@@ -121,6 +124,13 @@ export function Navbar() {
             <DrawerLink href="/guide" onClick={() => setOpen(false)}>
               User Guide
             </DrawerLink>
+            <DrawerLink
+              href="https://pocket-node-learn-ckb.vercel.app/"
+              onClick={() => setOpen(false)}
+              external
+            >
+              Learn CKB
+            </DrawerLink>
             <DrawerLink href="/privacy" onClick={() => setOpen(false)}>
               Privacy
             </DrawerLink>
@@ -151,10 +161,19 @@ export function Navbar() {
   )
 }
 
-function NavLink({ href, children }: { href: string; children: React.ReactNode }) {
+function NavLink({
+  href,
+  external,
+  children,
+}: {
+  href: string
+  external?: boolean
+  children: React.ReactNode
+}) {
   return (
     <Link
       href={href}
+      {...(external ? { target: '_blank', rel: 'noopener noreferrer' } : {})}
       className="flex h-20 items-center px-5 font-doto text-sm font-black uppercase leading-none tracking-wide text-green/80 transition-colors hover:text-green-glow"
     >
       {children}


### PR DESCRIPTION
Adds the Learn CKB link back in three places to match the legacy website's navigation:

- Desktop navbar (between Guide and Download APK)
- Mobile drawer (between User Guide and Privacy)
- Footer Project column (below Nervos Network)

Target URL unchanged from legacy: https://pocket-node-learn-ckb.vercel.app/

Build verified locally; all 6 routes prerender static.