### PR TITLE
feat(website): direct APK download via /download route handler

### DIFF
--- a/website/app/download/route.ts
+++ b/website/app/download/route.ts
@@ -1,0 +1,88 @@
+import { NextResponse } from 'next/server'
+
+/**
+ * Direct-download handler for the APK.
+ *
+ * The Pocket Node Play Store listing is in preparation; until it goes
+ * live the only install path is sideloading the latest GitHub Release.
+ * We don't want the Download APK button to dump people on the GitHub
+ * release page (which is noisy and requires them to scroll to find the
+ * .apk asset), so this route resolves the latest release at request
+ * time and 302-redirects to the .apk asset directly.
+ *
+ * Why a Route Handler (and not a static link to a versioned URL):
+ *   - The release artifact name encodes the version (e.g.
+ *     `PocketNode-v1.6.1.apk`), so a static link would go stale on
+ *     every release.
+ *   - GitHub's `/releases/latest/download/<name>` redirect requires
+ *     the asset filename to be stable across releases. Ours isn't.
+ *   - This handler asks the GitHub API for the current latest, picks
+ *     out the .apk asset, and returns its `browser_download_url`.
+ *
+ * Caching:
+ *   The redirect itself is cached at the Vercel edge for 10 minutes
+ *   with stale-while-revalidate of 1 hour, so the GitHub API quota
+ *   (60/hour anonymous) is not a bottleneck even during a launch
+ *   spike. New releases propagate within the cache window.
+ */
+
+const REPO_OWNER = 'RaheemJnr'
+const REPO_NAME = 'pocket-node'
+const RELEASES_API_URL = `https://api.github.com/repos/${REPO_OWNER}/${REPO_NAME}/releases/latest`
+const FALLBACK_URL = `https://github.com/${REPO_OWNER}/${REPO_NAME}/releases/latest`
+
+interface ReleaseAsset {
+  name: string
+  browser_download_url: string
+}
+
+interface LatestRelease {
+  assets?: ReleaseAsset[]
+}
+
+export const dynamic = 'force-dynamic'
+
+export async function GET() {
+  try {
+    const response = await fetch(RELEASES_API_URL, {
+      headers: {
+        Accept: 'application/vnd.github+json',
+        // GitHub asks for a unique User-Agent on API requests so they
+        // can identify high-volume callers. The handler runs server-
+        // side on Vercel, so the user's browser never sees this.
+        'User-Agent': 'pocket-node-website-download-handler',
+      },
+      // Cache the upstream API response too, so this handler doesn't
+      // hammer api.github.com inside a single edge cache window.
+      next: { revalidate: 600 },
+    })
+
+    if (!response.ok) {
+      throw new Error(`GitHub API responded ${response.status}`)
+    }
+
+    const release = (await response.json()) as LatestRelease
+    const apkAsset = release.assets?.find((asset) => asset.name.endsWith('.apk'))
+
+    if (!apkAsset) {
+      throw new Error('Latest release has no .apk asset')
+    }
+
+    return NextResponse.redirect(apkAsset.browser_download_url, {
+      status: 302,
+      headers: {
+        // Vercel edge cache for 10 minutes; can serve stale for an
+        // extra hour while revalidating in the background. This means
+        // new releases propagate inside ~10 minutes worst case, with
+        // no user ever seeing a hard error during the revalidation.
+        'Cache-Control': 'public, s-maxage=600, stale-while-revalidate=3600',
+      },
+    })
+  } catch (error) {
+    // If anything fails (rate limit, network blip, malformed response)
+    // we send the user to the GitHub release page rather than show
+    // them a 500. They can grab the .apk by hand from there.
+    console.error('Failed to resolve latest APK asset:', error)
+    return NextResponse.redirect(FALLBACK_URL, { status: 302 })
+  }
+}

--- a/website/app/page.tsx
+++ b/website/app/page.tsx
@@ -221,9 +221,7 @@ function ClosingCta() {
         </p>
         <div className="flex flex-col items-stretch gap-3 sm:flex-row sm:items-center">
           <Link
-            href="https://github.com/RaheemJnr/pocket-node/releases/latest"
-            target="_blank"
-            rel="noopener noreferrer"
+            href="/download"
             className="group inline-flex items-center justify-center gap-3 rounded-md border border-green bg-green/5 px-8 py-4 font-doto text-sm font-black uppercase leading-none tracking-wider text-green transition-colors hover:bg-green-deep hover:text-green-glow"
           >
             Download for Android

--- a/website/components/Hero.tsx
+++ b/website/components/Hero.tsx
@@ -38,9 +38,11 @@ export function Hero() {
 
         <div className="flex flex-col items-start gap-3 sm:flex-row sm:items-center">
           <Link
-            href="https://github.com/RaheemJnr/pocket-node/releases/latest"
-            target="_blank"
-            rel="noopener noreferrer"
+            href="/download"
+            // The /download route resolves the latest GitHub release's
+            // .apk asset at request time and 302-redirects to it. The
+            // browser kicks off a normal file download without leaving
+            // the site visually.
             className="group inline-flex items-center gap-3 rounded-md border border-green bg-green/5 px-6 py-4 font-doto text-sm font-black uppercase leading-none tracking-wider text-green transition-colors hover:bg-green-deep hover:text-green-glow"
           >
             Download APK

--- a/website/components/Navbar.tsx
+++ b/website/components/Navbar.tsx
@@ -64,9 +64,7 @@ export function Navbar() {
               Learn CKB
             </NavLink>
             <Link
-              href="https://github.com/RaheemJnr/pocket-node/releases/latest"
-              target="_blank"
-              rel="noopener noreferrer"
+              href="/download"
               className="group flex h-20 items-center gap-3 border-l border-green/40 px-8 font-doto text-sm font-black uppercase leading-none tracking-wide text-green transition-colors hover:bg-green/10"
             >
               Download APK
@@ -145,9 +143,7 @@ export function Navbar() {
 
           <div className="mt-auto border-t border-green/40 p-6">
             <Link
-              href="https://github.com/RaheemJnr/pocket-node/releases/latest"
-              target="_blank"
-              rel="noopener noreferrer"
+              href="/download"
               onClick={() => setOpen(false)}
               className="group flex items-center justify-center gap-3 rounded-md border border-green bg-green/5 px-6 py-4 font-doto text-sm font-black uppercase leading-none tracking-wider text-green transition-colors hover:bg-green-deep hover:text-green-glow"
             >


### PR DESCRIPTION
## Summary

Replace the four Download APK buttons (Hero, Closing CTA, desktop navbar, mobile drawer) that navigated to the GitHub releases page with a single Route Handler at `/download` that resolves the latest release's .apk asset at request time and 302-redirects to it.

Click flow: user taps **Download APK** → browser hits `/download` → server-side handler queries the GitHub API → 302 redirect to `https://github.com/.../releases/download/v<X.Y.Z>/PocketNode-v<X.Y.Z>.apk` → browser starts the file download.

## Why not a static link

GitHub's `/releases/latest/download/<filename>` redirect requires the asset name to be stable across releases. Our APKs are named `PocketNode-v<version>.apk`, so a static link would go stale on every release. The handler always points at the current cut.

## Caching

- Vercel edge cache: `Cache-Control: public, s-maxage=600, stale-while-revalidate=3600`
- Upstream `fetch` to api.github.com: `next.revalidate: 600`

GitHub's anonymous API quota is 60 requests/hour. With a 10-minute cache window the website would need 60 distinct edge nodes to hit the limit, which is well above typical traffic.

## Failure mode

If the GitHub API call fails for any reason (rate limit, network blip, malformed response) the handler falls back to redirecting to the GitHub release page. No 500s; users can still grab the APK manually.

## Test plan

- [x] `npm run build` shows `/download` as `ƒ` (dynamic), other 6 routes still static
- [ ] On the Vercel preview, tapping Download APK in the hero, closing CTA, navbar, and mobile drawer all kick off a download of the current `PocketNode-v<latest>.apk`
- [ ] If GitHub is briefly unreachable, the user lands on `releases/latest` instead of an error page

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an internal download route for Android APK files that automatically fetches and redirects to the latest release.

* **Improvements**
  * Updated download buttons across the website (Hero, Navbar, and main page) to use the new internal path, providing faster access with improved caching.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/RaheemJnr/pocket-node/pull/269?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->