### PR TITLE
fix(auth): destructive Forgot-PIN recovery (Telegram bugs 7, 8)

### DIFF
--- a/android/app/src/main/java/com/rjnr/pocketnode/data/wallet/WalletPreferences.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/wallet/WalletPreferences.kt
@@ -225,6 +225,15 @@ class WalletPreferences @Inject constructor(
         prefs.edit().putString(KEY_ACTIVE_WALLET_ID, walletId).apply()
     }
 
+    /**
+     * Drop the persisted active-wallet pointer. Used by the Forgot-PIN
+     * factory-reset path so that the active-wallet guard in
+     * [WalletRepository.deleteWallet] does not block bulk deletion.
+     */
+    fun clearActiveWalletId() {
+        prefs.edit().remove(KEY_ACTIVE_WALLET_ID).apply()
+    }
+
     // --- Sync strategy (M3 multi-wallet) ---
 
     fun getSyncStrategy(): SyncStrategy {

--- a/android/app/src/main/java/com/rjnr/pocketnode/data/wallet/WalletRepository.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/wallet/WalletRepository.kt
@@ -338,4 +338,47 @@ class WalletRepository @Inject constructor(
     }
 
     suspend fun walletCount(): Int = walletDao.count()
+
+    /**
+     * Destructive recovery path for the Forgot-PIN flow. Wipes every
+     * wallet (parents + sub-accounts), all wallet-scoped Room caches,
+     * and all stored key material from the device. Does NOT touch the
+     * PIN itself ([PinManager.removePin] is the caller's responsibility)
+     * or the process JNI state (the caller should restart the process
+     * after this returns to flush the embedded light client).
+     *
+     * The user's funds remain on-chain — only their seed phrase can
+     * restore the wallet after this runs.
+     *
+     * Implementation notes
+     *
+     *   - Iterates the wallet list rather than truncating the Room
+     *     tables because individual [deleteWallet] calls handle each
+     *     wallet's keys, caches, and sub-accounts in a transaction.
+     *     A bulk DELETE would orphan key material under
+     *     EncryptedSharedPreferences / Room key_material.
+     *   - Active-wallet guard in [deleteWallet] is bypassed by
+     *     clearing the active-wallet preference first; this is the
+     *     only place where that guard is intentionally skipped.
+     */
+    suspend fun factoryReset() {
+        // Clear both the preference pointer and the DB row's `isActive`
+        // flag up front so the per-wallet delete loop doesn't re-throw
+        // "Cannot delete the active wallet" on the currently-active row.
+        walletPreferences.clearActiveWalletId()
+        walletDao.deactivateAll()
+        // Snapshot the wallet list before mutation; iterating the live
+        // result would skip rows as deletions land.
+        val parents = walletDao.getAll().filter { it.parentWalletId == null }
+        for (parent in parents) {
+            val subs = walletDao.getSubAccountsList(parent.walletId)
+            for (sub in subs) {
+                runCatching { deleteWallet(sub.walletId) }
+                    .onFailure { Log.w(TAG, "factoryReset: sub ${sub.walletId} delete failed", it) }
+            }
+            runCatching { deleteWallet(parent.walletId) }
+                .onFailure { Log.w(TAG, "factoryReset: parent ${parent.walletId} delete failed", it) }
+        }
+        Log.d(TAG, "factoryReset: ${parents.size} parent wallet(s) wiped")
+    }
 }

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/navigation/NavGraph.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/navigation/NavGraph.kt
@@ -78,6 +78,7 @@ sealed class Screen(val route: String) {
     }
     object AddWallet : Screen("add_wallet")
     object InitialPinSetup : Screen("initial_pin_setup")
+    object ForgotPin : Screen("forgot_pin")
     object Faq : Screen("faq?anchor={anchor}") {
         fun routeWithAnchor(anchor: String?): String =
             if (anchor.isNullOrBlank()) "faq" else "faq?anchor=$anchor"
@@ -264,9 +265,15 @@ fun CkbNavGraph(
                     }
                 },
                 onForgotPin = {
-                    navController.navigate(Screen.MnemonicImport.route) {
-                        popUpTo(Screen.Auth.route) { inclusive = true }
-                    }
+                    // Destructive recovery: route to the confirmation
+                    // screen rather than the regular import flow. Keep
+                    // Auth on the back stack so the user can return if
+                    // they remember the PIN. The previous wiring popped
+                    // Auth via `inclusive = true` which (a) trapped the
+                    // back arrow and (b) navigated to a screen that
+                    // refused already-imported phrases — the locked-out
+                    // user's recovery path was a dead end.
+                    navController.navigate(Screen.ForgotPin.route)
                 },
                 onNavigateBack = { navController.popBackStack() }
             )
@@ -529,6 +536,12 @@ fun CkbNavGraph(
                         launchSingleTop = true
                     }
                 }
+            )
+        }
+
+        composable(Screen.ForgotPin.route) {
+            com.rjnr.pocketnode.ui.screens.auth.ForgotPinScreen(
+                onBack = { navController.popBackStack() },
             )
         }
 

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/auth/ForgotPinScreen.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/auth/ForgotPinScreen.kt
@@ -1,0 +1,150 @@
+package com.rjnr.pocketnode.ui.screens.auth
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Warning
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import com.composables.icons.lucide.ArrowLeft
+import com.composables.icons.lucide.Lucide
+import com.rjnr.pocketnode.R
+
+/**
+ * Confirmation screen for the Forgot-PIN destructive recovery flow.
+ *
+ * The previous Forgot-PIN wire routed the user to the standard
+ * `MnemonicImport` screen which then refused the import as
+ * "already imported" — a dead-end for any user actually locked out
+ * (reported via Telegram).
+ *
+ * This screen makes the destructive cost explicit before any state
+ * is touched: every local wallet, key, and cache is wiped; only the
+ * 12-word recovery phrase can restore access. After the user
+ * confirms, [ForgotPinViewModel.executeReset] runs the wipe and
+ * restarts the process so onboarding starts fresh.
+ *
+ * Back navigation works from this screen — the caller no longer
+ * `popUpTo(Auth) inclusive=true`-s on the way in, so the user can
+ * always return to the PIN entry if they remember the PIN after
+ * arriving here.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ForgotPinScreen(
+    onBack: () -> Unit,
+    viewModel: ForgotPinViewModel = hiltViewModel(),
+) {
+    val uiState by viewModel.uiState.collectAsState()
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text(stringResource(R.string.forgot_pin_title)) },
+                navigationIcon = {
+                    IconButton(onClick = onBack, enabled = !uiState.isResetting) {
+                        Icon(Lucide.ArrowLeft, contentDescription = stringResource(R.string.forgot_pin_back_cd))
+                    }
+                },
+            )
+        }
+    ) { padding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(padding)
+                .padding(horizontal = 24.dp, vertical = 24.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(20.dp),
+        ) {
+            Icon(
+                imageVector = Icons.Default.Warning,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.error,
+                modifier = Modifier.size(56.dp),
+            )
+
+            Text(
+                text = stringResource(R.string.forgot_pin_heading),
+                style = MaterialTheme.typography.headlineSmall,
+                fontWeight = FontWeight.SemiBold,
+            )
+
+            Text(
+                text = stringResource(R.string.forgot_pin_body),
+                style = MaterialTheme.typography.bodyLarge,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+
+            Text(
+                text = stringResource(R.string.forgot_pin_reassurance),
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+
+            uiState.error?.let { error ->
+                Text(
+                    text = error,
+                    color = MaterialTheme.colorScheme.error,
+                    style = MaterialTheme.typography.bodySmall,
+                )
+            }
+
+            Spacer(modifier = Modifier.height(8.dp))
+
+            Button(
+                onClick = { viewModel.executeReset() },
+                enabled = !uiState.isResetting,
+                colors = ButtonDefaults.buttonColors(
+                    containerColor = MaterialTheme.colorScheme.error,
+                    contentColor = MaterialTheme.colorScheme.onError,
+                ),
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                if (uiState.isResetting) {
+                    CircularProgressIndicator(
+                        modifier = Modifier.size(18.dp),
+                        color = MaterialTheme.colorScheme.onError,
+                        strokeWidth = 2.dp,
+                    )
+                    Spacer(modifier = Modifier.height(8.dp))
+                    Text(stringResource(R.string.forgot_pin_resetting))
+                } else {
+                    Text(stringResource(R.string.forgot_pin_confirm))
+                }
+            }
+
+            TextButton(
+                onClick = onBack,
+                enabled = !uiState.isResetting,
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                Text(stringResource(R.string.forgot_pin_cancel))
+            }
+        }
+    }
+}

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/auth/ForgotPinViewModel.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/auth/ForgotPinViewModel.kt
@@ -1,0 +1,96 @@
+package com.rjnr.pocketnode.ui.screens.auth
+
+import android.content.Context
+import android.content.Intent
+import android.util.Log
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.rjnr.pocketnode.data.auth.PinManager
+import com.rjnr.pocketnode.data.gateway.CacheManager
+import com.rjnr.pocketnode.data.gateway.DaoSyncManager
+import com.rjnr.pocketnode.data.wallet.WalletRepository
+import dagger.hilt.android.lifecycle.HiltViewModel
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+private const val TAG = "ForgotPinViewModel"
+
+/**
+ * Destructive recovery for a user who has forgotten their PIN.
+ *
+ * Wipes every wallet, every cache, the PIN itself, and then restarts
+ * the process so the embedded light client comes back up clean and
+ * the user lands on the onboarding flow with a fresh slate.
+ *
+ * The user's funds are unaffected — they live on-chain. Only the
+ * device-local key material is destroyed. The user re-enters their
+ * 12-word recovery phrase on the onboarding flow to restore access.
+ */
+@HiltViewModel
+class ForgotPinViewModel @Inject constructor(
+    @ApplicationContext private val context: Context,
+    private val walletRepository: WalletRepository,
+    private val pinManager: PinManager,
+    private val cacheManager: CacheManager,
+    private val daoSyncManager: DaoSyncManager,
+) : ViewModel() {
+
+    data class UiState(
+        val isResetting: Boolean = false,
+        val error: String? = null,
+    )
+
+    private val _uiState = MutableStateFlow(UiState())
+    val uiState: StateFlow<UiState> = _uiState.asStateFlow()
+
+    /**
+     * Confirmed reset. Wipes local state in this order:
+     *
+     *   1. Wallets + per-wallet caches + key material
+     *   2. Room caches (header / DAO)
+     *   3. PIN (force=true since the wallet's encrypted backup is also gone)
+     *   4. Process restart so the JNI light client re-initialises cleanly
+     *
+     * Step 4 never returns; the launching activity is started before
+     * killProcess so the OS visibly relaunches the app onto the
+     * onboarding entry point.
+     */
+    fun executeReset() {
+        if (_uiState.value.isResetting) return
+        _uiState.update { it.copy(isResetting = true, error = null) }
+
+        viewModelScope.launch {
+            try {
+                walletRepository.factoryReset()
+                cacheManager.clearAll()
+                daoSyncManager.clearAll()
+                pinManager.removePin(force = true)
+                Log.d(TAG, "factoryReset complete; restarting process")
+
+                // ProcessPhoenix-style restart mirroring switchNetwork in
+                // GatewayRepository. JNI state cannot be re-initialised
+                // in the same process lifetime, and even if it could the
+                // sync polling loop has stale references to wallets that
+                // no longer exist — a process restart is the cleanest
+                // way to land the user on a deterministic blank state.
+                val intent = context.packageManager.getLaunchIntentForPackage(context.packageName)!!
+                intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK)
+                context.startActivity(intent)
+                android.os.Process.killProcess(android.os.Process.myPid())
+            } catch (e: Throwable) {
+                Log.e(TAG, "factoryReset failed", e)
+                _uiState.update {
+                    it.copy(
+                        isResetting = false,
+                        error = e.message ?: "Reset failed. Try again.",
+                    )
+                }
+            }
+        }
+    }
+}

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -147,6 +147,14 @@
     <string name="auth_locked_cd">Locked</string>
     <string name="auth_unlock_fingerprint">Unlock with Fingerprint</string>
     <string name="auth_use_pin">Use PIN</string>
+    <string name="forgot_pin_title">Reset wallet</string>
+    <string name="forgot_pin_back_cd">Back</string>
+    <string name="forgot_pin_heading">Forgot your PIN?</string>
+    <string name="forgot_pin_body">Resetting will erase every wallet, key, and cache stored on this device. The only way to restore access afterwards is your 12-word recovery phrase.</string>
+    <string name="forgot_pin_reassurance">Your CKB stays on the blockchain. Only the device-local data is removed.</string>
+    <string name="forgot_pin_confirm">Erase wallet and start over</string>
+    <string name="forgot_pin_resetting">Resetting…</string>
+    <string name="forgot_pin_cancel">Cancel</string>
     <!-- endregion -->
 
     <!-- region: Recovery -->


### PR DESCRIPTION
## Summary

Two Telegram bug reports fixed with one flow change.

| # | Reported | Severity |
|---|----------|----------|
| 8 | Forgot PIN → enter seed → "already imported", recovery impossible | CRITICAL |
| 7 | Back arrow on the Forgot-PIN landing page doesn't work | HIGH |

Both root-caused to a single line in `NavGraph.kt`:

\`\`\`kotlin
onForgotPin = {
    navController.navigate(Screen.MnemonicImport.route) {
        popUpTo(Screen.Auth.route) { inclusive = true }  // ← trapped the back arrow
    }
}
\`\`\`

The destination was the regular import screen, which refused already-imported phrases (bug 8). The `popUpTo` removed Auth from the back stack so the back arrow had nothing to pop (bug 7).

## What ships

- **`ForgotPinScreen` + `ForgotPinViewModel`** — confirmation surface that explains the destructive cost ("every local wallet, key, and cache is wiped; only the recovery phrase can restore access") before any state is touched.
- **`WalletRepository.factoryReset()`** — iterates parents + sub-accounts, reusing the existing per-wallet `deleteWallet` so key + cache cleanup runs inside transactions (a bulk DELETE would orphan EncryptedSharedPreferences / `key_material`). The active-wallet guard is bypassed once, on purpose, by clearing the active-wallet pref + `deactivateAll`-ing the DB rows first.
- **`WalletPreferences.clearActiveWalletId()`** — small helper for the bypass.
- **NavGraph wiring** — `onForgotPin` now routes to `Screen.ForgotPin` *without* popping Auth. Back arrow restored.
- **Reset sequence** — mirrors `GatewayRepository.switchNetwork`: ProcessPhoenix-style relaunch + `Process.killProcess`. The user lands on the onboarding entry point with a clean slate and can re-import via their recovery phrase.

## Test plan

- [x] `./gradlew :app:compileDebugKotlin -x cargoBuild` BUILD SUCCESSFUL
- [x] `./gradlew :app:testDebugUnitTest -x cargoBuild` BUILD SUCCESSFUL
- [ ] Manual: tap Forgot PIN on the auth screen → confirmation screen appears, back arrow works, Cancel returns to PIN entry
- [ ] Manual: tap Erase → app restarts on the onboarding flow, importing the previously-imported seed succeeds (no "already imported" error)
- [ ] Manual: tap Forgot PIN on a multi-wallet device → all wallets and sub-accounts gone after restart

Refs Telegram bug report (Radoslav, 2026-05-21)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Forgot PIN" recovery option allowing users to reset the app when their PIN is forgotten, clearing all local data and returning to the initial setup state for a fresh start.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/RaheemJnr/pocket-node/pull/272?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->