### PR TITLE
fix(wallet): "Add" button + delete-active + single-wallet msg (Telegram 2, 5, 6)

### DIFF
--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/navigation/NavGraph.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/navigation/NavGraph.kt
@@ -76,7 +76,18 @@ sealed class Screen(val route: String) {
     object WalletDetail : Screen("wallet_detail/{walletId}") {
         fun createRoute(walletId: String) = "wallet_detail/$walletId"
     }
-    object AddWallet : Screen("add_wallet")
+    object AddWallet : Screen("add_wallet?parentId={parentId}") {
+        const val BASE = "add_wallet"
+        /**
+         * Build the route with an optional pre-selected parent wallet.
+         * When [parentId] is non-null AddWalletScreen jumps straight to
+         * the HD Sub-Account form with that wallet selected — the
+         * "Add" button on a parent wallet card uses this to skip the
+         * mode picker and the parent picker.
+         */
+        fun createRoute(parentId: String? = null): String =
+            if (parentId.isNullOrBlank()) BASE else "$BASE?parentId=$parentId"
+    }
     object InitialPinSetup : Screen("initial_pin_setup")
     object ForgotPin : Screen("forgot_pin")
     object Faq : Screen("faq?anchor={anchor}") {
@@ -496,7 +507,9 @@ fun CkbNavGraph(
         composable(Screen.WalletManager.route) {
             WalletManagerScreen(
                 onNavigateBack = { navController.popBackStack() },
-                onNavigateToAddWallet = { navController.navigate(Screen.AddWallet.route) },
+                onNavigateToAddWallet = { parentId ->
+                    navController.navigate(Screen.AddWallet.createRoute(parentId))
+                },
                 onNavigateToWalletDetail = { walletId ->
                     navController.navigate(Screen.WalletDetail.createRoute(walletId))
                 }
@@ -545,7 +558,16 @@ fun CkbNavGraph(
             )
         }
 
-        composable(Screen.AddWallet.route) {
+        composable(
+            route = Screen.AddWallet.route,
+            arguments = listOf(
+                navArgument("parentId") {
+                    type = NavType.StringType
+                    nullable = true
+                    defaultValue = null
+                }
+            ),
+        ) {
             AddWalletScreen(
                 onNavigateBack = { navController.popBackStack() },
                 onWalletCreated = {

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/wallet/AddWalletScreen.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/wallet/AddWalletScreen.kt
@@ -74,7 +74,13 @@ fun AddWalletScreen(
     val uiState by viewModel.uiState.collectAsState()
     val snackbarHostState = remember { SnackbarHostState() }
     // 0 = menu, 1 = new wallet, 2 = import mnemonic, 3 = import key, 4 = sub-account
-    var selectedMode by remember { mutableIntStateOf(0) }
+    // When the route carries a `parentId` query arg the user came in from
+    // the WalletManager per-row "Add" button (Telegram bug 2). Skip the
+    // mode picker and land directly on the sub-account form, with the
+    // parent pre-selected by AddWalletViewModel.
+    var selectedMode by remember {
+        mutableIntStateOf(if (viewModel.preselectedParentId != null) 4 else 0)
+    }
 
     LaunchedEffect(uiState.createdWallet) {
         if (uiState.createdWallet != null) {

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/wallet/AddWalletViewModel.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/wallet/AddWalletViewModel.kt
@@ -1,5 +1,6 @@
 package com.rjnr.pocketnode.ui.screens.wallet
 
+import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.rjnr.pocketnode.data.database.entity.WalletEntity
@@ -33,10 +34,21 @@ data class AddWalletUiState(
 
 @HiltViewModel
 class AddWalletViewModel @Inject constructor(
+    savedStateHandle: SavedStateHandle,
     private val walletRepository: WalletRepository,
     private val gatewayRepository: GatewayRepository,
     private val mnemonicManager: MnemonicManager
 ) : ViewModel() {
+
+    /**
+     * Optional parent-wallet hint forwarded from the WalletManager
+     * per-row "Add" button (Telegram bug 2). Null means "user opened
+     * the Add screen from the FAB", in which case we land on the mode
+     * picker. Non-null means "user wanted to add a sub-account to this
+     * specific parent", and we jump straight to the sub-account form
+     * with the parent pre-selected.
+     */
+    val preselectedParentId: String? = savedStateHandle["parentId"]
 
     private val _uiState = MutableStateFlow(AddWalletUiState())
     val uiState: StateFlow<AddWalletUiState> = _uiState.asStateFlow()
@@ -45,7 +57,17 @@ class AddWalletViewModel @Inject constructor(
         viewModelScope.launch {
             val mnemonicRoots = walletRepository.getAll()
                 .filter { it.type == "mnemonic" && it.parentWalletId == null }
-            _uiState.update { it.copy(parentWallets = mnemonicRoots) }
+            _uiState.update {
+                it.copy(
+                    parentWallets = mnemonicRoots,
+                    // Pre-select the parent if the route arg pointed at one
+                    // that still exists. Stale arg (wallet deleted between
+                    // navigation and arrival) silently falls back to no
+                    // selection so the user lands on the parent picker.
+                    selectedParentId = preselectedParentId
+                        ?.takeIf { id -> mnemonicRoots.any { p -> p.walletId == id } },
+                )
+            }
         }
     }
 

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/wallet/WalletManagerScreen.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/wallet/WalletManagerScreen.kt
@@ -52,7 +52,13 @@ import com.rjnr.pocketnode.ui.components.WalletGroup
 @Composable
 fun WalletManagerScreen(
     onNavigateBack: () -> Unit = {},
-    onNavigateToAddWallet: () -> Unit = {},
+    /**
+     * Navigate to the Add Wallet screen. When [parentId] is non-null,
+     * the destination jumps straight to the HD Sub-Account form with
+     * that wallet pre-selected — used by the per-row "Add" button on
+     * each parent wallet card.
+     */
+    onNavigateToAddWallet: (parentId: String?) -> Unit = {},
     onNavigateToWalletDetail: (String) -> Unit = {},
     viewModel: WalletManagerViewModel = hiltViewModel()
 ) {
@@ -82,7 +88,7 @@ fun WalletManagerScreen(
             )
         },
         floatingActionButton = {
-            FloatingActionButton(onClick = onNavigateToAddWallet) {
+            FloatingActionButton(onClick = { onNavigateToAddWallet(null) }) {
                 Icon(Lucide.Plus, contentDescription = stringResource(R.string.wallet_manager_add_cd))
             }
         },
@@ -100,7 +106,14 @@ fun WalletManagerScreen(
             items(uiState.walletGroups, key = { it.wallet.walletId }) { group ->
                 WalletGroupCard(
                     group = group,
-                    onAddSubAccount = { viewModel.switchWallet(group.wallet.walletId) },
+                    // Previously: `viewModel.switchWallet(...)` — that
+                    // silently switched to the wallet that owned the
+                    // button (often already active), so the button
+                    // appeared dead. Navigate to AddWallet with this
+                    // parent pre-selected so the user lands on the
+                    // sub-account form ready to name the new account.
+                    // (Telegram bug 2)
+                    onAddSubAccount = { onNavigateToAddWallet(group.wallet.walletId) },
                     onOpenSettings = { onNavigateToWalletDetail(group.wallet.walletId) }
                 )
             }

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/wallet/WalletSettingsViewModel.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/wallet/WalletSettingsViewModel.kt
@@ -167,6 +167,47 @@ class WalletSettingsViewModel @Inject constructor(
     fun confirmDelete() {
         viewModelScope.launch {
             try {
+                val current = _uiState.value.wallet
+                val isActive = current?.isActive == true ||
+                    walletPreferences.getActiveWalletId() == walletId
+
+                if (isActive) {
+                    // Auto-switch to a sibling before delete. The previous
+                    // behaviour was to refuse with "Cannot delete the active
+                    // wallet" — a UX dead-end since the user can't tell what
+                    // "switch first" means when they only see the one
+                    // settings screen. (Telegram bug 5)
+                    val candidates = walletRepository.getAll()
+                        .filter { it.walletId != walletId }
+
+                    if (candidates.isEmpty()) {
+                        // Last wallet on the device. We do NOT delete here
+                        // because doing so would leave the app in a no-
+                        // wallet state without resetting the PIN, which is
+                        // a worse trap than the original guard. Direct the
+                        // user at the Forgot-PIN destructive recovery flow
+                        // which handles wipe + PIN reset + process restart
+                        // together. (Telegram bug 6)
+                        _uiState.update {
+                            it.copy(
+                                showDeleteConfirm = false,
+                                error = com.rjnr.pocketnode.ui.util.UiMessage.Resource(
+                                    com.rjnr.pocketnode.R.string.vm_error_delete_last_wallet,
+                                ),
+                            )
+                        }
+                        return@launch
+                    }
+
+                    // Prefer a parent (top-level) wallet so the user doesn't
+                    // end up on an orphaned-feeling sub-account, but fall
+                    // back to any sibling if all that's left are sub-
+                    // accounts of other parents.
+                    val next = candidates.firstOrNull { it.parentWalletId == null }
+                        ?: candidates.first()
+                    walletRepository.switchActiveWallet(next.walletId)
+                }
+
                 walletRepository.deleteWallet(walletId)
                 _uiState.update { it.copy(showDeleteConfirm = false, deleted = true) }
             } catch (e: Exception) {

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -258,6 +258,7 @@
     <string name="vm_error_delete_sub_accounts_first_one">This wallet has 1 sub-account. Delete it first before removing the parent.</string>
     <string name="vm_error_delete_sub_accounts_first_other">This wallet has %1$d sub-accounts. Delete them first before removing the parent.</string>
     <string name="vm_error_delete_failed">Delete failed: %1$s</string>
+    <string name="vm_error_delete_last_wallet">This is your only wallet. Use Forgot PIN from the lock screen if you want to erase everything and start over from your recovery phrase.</string>
     <string name="vm_error_reopen_for_biometric">Reopen this screen — biometric unlock required for V2 wallets</string>
     <string name="vm_error_auth_cancelled">Authentication cancelled</string>
     <string name="vm_error_cannot_read_wallet_key">Cannot read wallet key: %1$s</string>


### PR DESCRIPTION
## Summary

Three Telegram bug reports converging on the wallet manager flow.

| # | Reported | Severity |
|---|----------|----------|
| 2 | "Add" button on each parent card does nothing | HIGH |
| 5 | Can't delete the active wallet — dead-end error | HIGH |
| 6 | Can't delete the only wallet — message unclear | LOW |

## What's fixed

### Bug 2

[WalletManagerScreen.kt:103](android/app/src/main/java/com/rjnr/pocketnode/ui/screens/wallet/WalletManagerScreen.kt#L103) had `onAddSubAccount = { viewModel.switchWallet(...) }` — silently switching to the wallet that owned the button (usually already active), so the button looked dead.

- `Screen.AddWallet` gains an optional `parentId` query arg with a `createRoute(parentId)` helper.
- `AddWalletViewModel` reads the arg via `SavedStateHandle` and pre-fills `selectedParentId` (with a sanity check that the referenced wallet still exists).
- `AddWalletScreen` jumps to `selectedMode = 4` (sub-account form) on first composition when the arg is present, skipping both the mode picker and the parent picker.
- Per-row "Add" button now calls `onNavigateToAddWallet(group.wallet.walletId)`.

### Bug 5

`WalletSettingsViewModel.confirmDelete()` previously called `walletRepository.deleteWallet(walletId)` directly, which threw `IllegalStateException("Cannot delete the active wallet. Switch to another wallet first.")`. Now:

1. Detects the active case
2. Picks a sibling (parent preferred over sub-account)
3. Calls `switchActiveWallet(sibling)` first
4. Then proceeds with the standard `deleteWallet(walletId)` path

The active-wallet guard in `WalletRepository.deleteWallet` stays put as an integrity check.

### Bug 6

When only one wallet exists, instead of the silent-fail dead-end, surface a clear message that points the user at the destructive Forgot-PIN flow (which handles wallet wipe + PIN reset + process restart together). New `vm_error_delete_last_wallet` string.

## Test plan

- [x] `./gradlew :app:compileDebugKotlin -x cargoBuild` BUILD SUCCESSFUL
- [x] `./gradlew :app:testDebugUnitTest -x cargoBuild` BUILD SUCCESSFUL
- [ ] Manual: open Wallets → tap "Add" on a parent wallet → AddWallet opens directly to the sub-account form with that parent pre-selected
- [ ] Manual: 2 wallets, on the active one → Settings → Delete → confirms → app switches to the sibling and deletes
- [ ] Manual: 1 wallet → Settings → Delete → confirms → snackbar suggests Forgot-PIN

Refs Telegram bug report (Radoslav, 2026-05-21)