### PR TITLE
fix(onboarding): wallet name prompt + drop simplified backup (Telegram 3, 4)

### DIFF
--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/navigation/NavGraph.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/navigation/NavGraph.kt
@@ -574,7 +574,14 @@ fun CkbNavGraph(
                     navController.popBackStack(Screen.Main.route, inclusive = false)
                 },
                 onNewMnemonicWalletCreated = {
-                    navController.navigate(Screen.MnemonicBackup.createRoute(simplified = true)) {
+                    // Use the same 3-step backup flow as first-wallet
+                    // onboarding (display → verify → success) instead
+                    // of the `simplified` single-screen shortcut. The
+                    // shortcut was reported as an inconsistency
+                    // (Telegram bug 4): first-wallet creation prompts
+                    // for verification, but adding a new parent wallet
+                    // from inside the app did not. Aligned now.
+                    navController.navigate(Screen.MnemonicBackup.createRoute(simplified = false)) {
                         popUpTo(Screen.Main.route) { inclusive = false }
                     }
                 }

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/onboarding/OnboardingScreen.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/onboarding/OnboardingScreen.kt
@@ -27,6 +27,14 @@ fun OnboardingScreen(
     val uiState by viewModel.uiState.collectAsState()
     val snackbarHostState = remember { SnackbarHostState() }
 
+    // "Name your wallet" dialog state. Captured before the wallet is
+    // actually created so the user-supplied name flows through into
+    // WalletRepository.createWallet. The AddWallet flow has always
+    // prompted for a name; this matches that surface so the two
+    // wallet-creation entry points behave consistently (Telegram bug 3).
+    var showNameDialog by remember { mutableStateOf(false) }
+    var pendingWalletName by remember { mutableStateOf("My Wallet") }
+
     // After wallet creation, navigate to backup screen (not Home)
     LaunchedEffect(uiState.isWalletCreated) {
         if (uiState.isWalletCreated) {
@@ -106,7 +114,7 @@ fun OnboardingScreen(
                 title = "Create New Wallet",
                 description = "Generate a new wallet with a 12-word recovery phrase.",
                 icon = Lucide.Plus,
-                onClick = { viewModel.createNewWallet() },
+                onClick = { showNameDialog = true },
                 isLoading = uiState.isLoading,
                 modifier = Modifier.uaTestTag("onboarding-create-new")
             )
@@ -132,6 +140,43 @@ fun OnboardingScreen(
                 textAlign = TextAlign.Center
             )
         }
+    }
+
+    if (showNameDialog) {
+        AlertDialog(
+            onDismissRequest = { showNameDialog = false },
+            title = { Text("Name your wallet") },
+            text = {
+                Column {
+                    Text(
+                        text = "Give this wallet a label so you can spot it if you add more later.",
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                    Spacer(modifier = Modifier.height(12.dp))
+                    OutlinedTextField(
+                        value = pendingWalletName,
+                        onValueChange = { pendingWalletName = it },
+                        singleLine = true,
+                        label = { Text("Wallet name") },
+                        modifier = Modifier.fillMaxWidth(),
+                    )
+                }
+            },
+            confirmButton = {
+                TextButton(onClick = {
+                    showNameDialog = false
+                    viewModel.createNewWallet(pendingWalletName)
+                }) {
+                    Text("Create")
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { showNameDialog = false }) {
+                    Text("Cancel")
+                }
+            },
+        )
     }
 }
 

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/onboarding/OnboardingViewModel.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/onboarding/OnboardingViewModel.kt
@@ -60,7 +60,13 @@ class OnboardingViewModel @Inject constructor(
     private fun canCreateV2BoundKey(): Boolean =
         authManager.isBiometricEnrolled() || authManager.hasDeviceCredential()
 
-    fun createNewWallet() {
+    /**
+     * Create the first wallet. [name] is captured from the onboarding
+     * "Name your wallet" step (Telegram bug 3); falls back to "My
+     * Wallet" if the user submitted empty so the call never produces a
+     * blank-named wallet row.
+     */
+    fun createNewWallet(name: String = "My Wallet") {
         if (!canCreateV2BoundKey()) {
             _uiState.update {
                 it.copy(
@@ -72,10 +78,11 @@ class OnboardingViewModel @Inject constructor(
             }
             return
         }
+        val trimmed = name.trim().ifBlank { "My Wallet" }
         viewModelScope.launch {
             _uiState.update { it.copy(isLoading = true, error = null) }
             try {
-                val (entity, _) = walletRepository.createWallet("My Wallet")
+                val (entity, _) = walletRepository.createWallet(trimmed)
                 Log.d(TAG, "Created wallet entity: ${entity.walletId}")
                 repository.onActiveWalletChanged(entity)
                 _uiState.update { it.copy(isLoading = false, isWalletCreated = true) }


### PR DESCRIPTION
## Summary

Two consistency complaints from the Telegram report.

| # | Reported | Severity |
|---|----------|----------|
| 3 | First-wallet creation hardcodes the name; second wallet asks | MED |
| 4 | First-wallet asks for mnemonic verify; second-wallet path skips it | MED |

## What's fixed

### Bug 3 — name prompt parity

\`OnboardingScreen\` now shows an AlertDialog asking for the wallet name before tapping into the wallet generation flow. Default value is "My Wallet" so a user who just hits Create gets the same behavior as before. \`OnboardingViewModel.createNewWallet\` accepts the name with a fallback to "My Wallet" if the field is blank.

Adds the same name surface that AddWalletScreen already presents for subsequent wallets.

### Bug 4 — backup verify parity

\`NavGraph.onNewMnemonicWalletCreated\` (the AddWallet → "New Wallet" path) used \`Screen.MnemonicBackup.createRoute(simplified = true)\` which routed to a single-screen display-only flow. The flag now passes \`simplified = false\` so the user goes through the same 3-step display → verify → success flow as first-wallet onboarding.

The \`simplified\` flag itself is kept on \`MnemonicBackup\` because the screen still uses it for the post-import path that doesn't need a verify step (the user confirmed the phrase on import). No other call sites pass \`simplified = true\`.

## Test plan

- [x] \`./gradlew :app:compileDebugKotlin -x cargoBuild\` BUILD SUCCESSFUL
- [x] \`./gradlew :app:testDebugUnitTest -x cargoBuild\` BUILD SUCCESSFUL
- [ ] Manual: fresh install → onboarding → tap "Create New Wallet" → name dialog opens → submit → mnemonic backup shows the 3-step flow including verify
- [ ] Manual: existing install with 1 wallet → Wallets → FAB → "New Wallet" → mnemonic backup shows the same 3-step flow (was display-only before)

Refs Telegram bug report (Radoslav, 2026-05-21)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Name wallets during creation instead of using defaults.
  * Parent wallet preselection when adding new wallets.
  * Added safety protection preventing deletion of the last wallet on device.

* **Improvements**
  * New wallet backup flow now uses comprehensive multi-step process like initial setup.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/RaheemJnr/pocket-node/pull/274?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->