### PR TITLE
fix(wallet): require biometric for mnemonic reveal (Telegram 1)

### DIFF
--- a/android/app/src/main/java/com/rjnr/pocketnode/data/migration/KeystoreV2MigrationHelper.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/migration/KeystoreV2MigrationHelper.kt
@@ -122,6 +122,67 @@ class KeystoreV2MigrationHelper(
     }
 
     /**
+     * Like [migrateWallet] but also returns the plaintext bundle to the
+     * caller in one BiometricPrompt cycle.
+     *
+     * Use case: the WalletSettings "View seed phrase" flow on a V1
+     * wallet needs to (a) get the mnemonic to the UI and (b) leave the
+     * row on V2 so future reveals are V2-gated. The naive approach is
+     * two prompts (migrate, then read). This variant collapses to one:
+     * the V1 plaintext we decrypt during migration is the same
+     * plaintext the caller wants to display, so we hand it back inside
+     * the same Result.
+     *
+     * The plaintext lives only on the caller's stack — the [Result]
+     * payload is not logged or persisted by this method.
+     */
+    suspend fun migrateWalletAndExtract(
+        walletId: String,
+        v2EncryptCipher: Cipher,
+    ): Result<WalletKeyBundle> {
+        return runCatching {
+            val entity = keyMaterialDao.getByWalletId(walletId)
+                ?: throw IllegalStateException("No key_material row for walletId=$walletId")
+
+            if (entity.kdfVersion == V2_VERSION) {
+                throw IllegalStateException(
+                    "walletId=$walletId is already on V2; use readV2Bundle instead"
+                )
+            }
+            if (entity.kdfVersion != V1_VERSION) {
+                throw IllegalStateException(
+                    "Unknown kdfVersion ${entity.kdfVersion} for walletId=$walletId; refusing to migrate"
+                )
+            }
+
+            val privateKeyHex = decryptV1PrivateKey(entity.encryptedPrivateKey, entity.iv)
+            val mnemonic = entity.encryptedMnemonic?.let { combined ->
+                decryptV1Mnemonic(combined)
+            }
+
+            val bundle = WalletKeyBundle(privateKeyHex = privateKeyHex, mnemonic = mnemonic)
+            val bundleBytes = json.encodeToString(bundle).toByteArray(Charsets.UTF_8)
+
+            val (encryptedBundle, newIv) = encryptionManager.encryptWithCipher(
+                v2EncryptCipher,
+                bundleBytes
+            )
+
+            val migrated = entity.copy(
+                encryptedPrivateKey = encryptedBundle,
+                encryptedMnemonic = null,
+                iv = newIv,
+                kdfVersion = V2_VERSION,
+                updatedAt = nowProvider()
+            )
+            keyMaterialDao.upsert(migrated)
+
+            Log.i(TAG, "Migrated wallet $walletId V1→V2 (extracted plaintext for caller)")
+            bundle
+        }
+    }
+
+    /**
      * After every wallet has been migrated, delete the V1 Keystore key and
      * record the migration-complete flag. Safe to call only when
      * [pendingWalletIds] returns an empty list.

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/wallet/WalletSettingsScreen.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/wallet/WalletSettingsScreen.kt
@@ -337,13 +337,18 @@ fun WalletSettingsScreen(
                         SettingsActionRow(
                             label = "View seed phrase",
                             onClick = {
-                                if (viewModel.requiresPinForSeedPhrase()) {
-                                    showSeedPhrase = true
-                                    onNavigateToPinVerify()
-                                } else {
-                                    showSeedPhrase = true
-                                    unlockSensitive()
-                                }
+                                // Always biometric (or device credential
+                                // fallback via V2 BiometricPrompt). The
+                                // older PIN-verify branch was the path
+                                // Radoslav flagged on Telegram (bug 1):
+                                // entering a PIN was enough to reveal
+                                // the mnemonic, with no biometric step.
+                                // unlockSensitive() routes V2 wallets
+                                // through `readKeyMaterial` and V1
+                                // wallets through `migrateWalletAndExtract`
+                                // so both end with biometric gating.
+                                showSeedPhrase = true
+                                unlockSensitive()
                             }
                         )
                     }
@@ -425,13 +430,10 @@ fun WalletSettingsScreen(
                         SettingsActionRow(
                             label = "View private key",
                             onClick = {
-                                if (viewModel.requiresPinForSeedPhrase()) {
-                                    showPrivateKey = true
-                                    onNavigateToPinVerify()
-                                } else {
-                                    showPrivateKey = true
-                                    unlockSensitive()
-                                }
+                                // Mirror the seed-phrase reveal: biometric
+                                // only, no PIN-only fast-path.
+                                showPrivateKey = true
+                                unlockSensitive()
                             }
                         )
                     }

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/wallet/WalletSettingsViewModel.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/wallet/WalletSettingsViewModel.kt
@@ -38,6 +38,9 @@ class WalletSettingsViewModel @Inject constructor(
     private val walletPreferences: WalletPreferences,
     private val walletKeyReader: WalletKeyReader,
     private val keyMaterialDao: KeyMaterialDao,
+    private val migrationHelper: com.rjnr.pocketnode.data.migration.KeystoreV2MigrationHelper,
+    private val encryptionManager: com.rjnr.pocketnode.data.crypto.KeystoreEncryptionManager,
+    private val authManager: com.rjnr.pocketnode.data.auth.AuthManager,
 ) : ViewModel() {
 
     private val walletId: String = savedStateHandle["walletId"] ?: ""
@@ -293,6 +296,64 @@ class WalletSettingsViewModel @Inject constructor(
     fun loadSensitiveData(activity: FragmentActivity) {
         viewModelScope.launch {
             val kdf = keyMaterialDao.getKdfVersion(walletId)
+            // Lazy V1 → V2 migration on first sensitive-data reveal.
+            // Previously the V1 branch fell through to the silent PIN-
+            // only load, which a Telegram user reported as "mnemonic
+            // readily available" (bug 1). The wallet stays on V1 until
+            // the user re-launches the app and triggers AuthScreen's
+            // migration runner, which is a long window where the
+            // mnemonic is one PIN entry from disclosure.
+            //
+            // The flow now: one BiometricPrompt unlocks a V2 encrypt
+            // cipher; we use it to migrate the row to V2 AND extract
+            // the plaintext bundle in the same cipher operation. After
+            // this method returns once, the wallet is on V2 and all
+            // future reveals follow the standard V2 read path with its
+            // own BiometricPrompt.
+            if (kdf == 1) {
+                val cipher = try {
+                    encryptionManager.newEncryptCipherV2()
+                } catch (e: Throwable) {
+                    Log.e(TAG, "V2 cipher creation failed", e)
+                    _uiState.update { it.copy(error = com.rjnr.pocketnode.ui.util.UiMessage.Resource(com.rjnr.pocketnode.R.string.vm_error_cannot_read_wallet_key, listOf(e.message ?: "cipher"))) }
+                    return@launch
+                }
+                val auth = authManager.authenticateForCipher(
+                    activity = activity,
+                    cipher = cipher,
+                    title = "View recovery phrase",
+                    subtitle = "Verify your identity to display this wallet's secrets",
+                )
+                when (auth) {
+                    is com.rjnr.pocketnode.data.auth.AuthManager.CipherAuthResult.Cancelled -> {
+                        _uiState.update { it.copy(error = com.rjnr.pocketnode.ui.util.UiMessage.Resource(com.rjnr.pocketnode.R.string.vm_error_auth_cancelled)) }
+                        return@launch
+                    }
+                    is com.rjnr.pocketnode.data.auth.AuthManager.CipherAuthResult.Error -> {
+                        _uiState.update { it.copy(error = com.rjnr.pocketnode.ui.util.UiMessage.Resource(com.rjnr.pocketnode.R.string.vm_error_cannot_read_wallet_key, listOf("auth ${auth.errorCode}"))) }
+                        return@launch
+                    }
+                    is com.rjnr.pocketnode.data.auth.AuthManager.CipherAuthResult.Success -> {
+                        val bundle = migrationHelper.migrateWalletAndExtract(walletId, auth.cipher)
+                            .getOrElse { e ->
+                                Log.e(TAG, "V1 → V2 migrate-and-extract failed for $walletId", e)
+                                _uiState.update {
+                                    it.copy(error = com.rjnr.pocketnode.ui.util.UiMessage.Resource(com.rjnr.pocketnode.R.string.vm_error_cannot_read_wallet_key, listOf(e.message ?: "migrate")))
+                                }
+                                return@launch
+                            }
+                        val words = bundle.mnemonic?.split(" ")
+                        _uiState.update {
+                            it.copy(
+                                privateKeyHex = bundle.privateKeyHex,
+                                mnemonicWords = words,
+                                seedPhraseUnlocked = true,
+                            )
+                        }
+                        return@launch
+                    }
+                }
+            }
             if (kdf != 2) {
                 loadSensitiveData()
                 return@launch
@@ -321,7 +382,12 @@ class WalletSettingsViewModel @Inject constructor(
                 is WalletKeyReader.MaterialResult.Success -> {
                     val keyHex = result.privateKey.joinToString("") { "%02x".format(it) }
                     val words = result.mnemonic?.split(" ")
-                    _uiState.update { it.copy(privateKeyHex = keyHex, mnemonicWords = words) }
+                    // seedPhraseUnlocked must flip here so the screen
+                    // gate (`showSeedPhrase && (seedPhraseUnlocked || !requiresPinForSeedPhrase())`)
+                    // shows the mnemonic. Previously this flag was set
+                    // only via onPinVerified, so V2 reveals worked by
+                    // accident only when no PIN was set.
+                    _uiState.update { it.copy(privateKeyHex = keyHex, mnemonicWords = words, seedPhraseUnlocked = true) }
                 }
             }
         }


### PR DESCRIPTION
## Summary

Telegram bug 1: "is there a reason why the mneumonic phrase is readily available — Settings > Backup wallet".

Root cause: the "View seed phrase" click handler had two paths — PIN-verify-then-load for wallets with a PIN, or biometric for wallets without. The PIN-verify branch ran the silent V1 load (no biometric). Since new wallets are created at \`kdfVersion=1\` and stay there until AuthScreen's migration runner fires on a cold relaunch, the typical flow (create → back up → settings) revealed the mnemonic with PIN alone.

## What ships

### New helper

\`KeystoreV2MigrationHelper.migrateWalletAndExtract(walletId, cipher)\` — same code path as the existing \`migrateWallet\` but returns the plaintext \`WalletKeyBundle\` to the caller. Lets one BiometricPrompt cycle do both the V2 migration *and* the plaintext reveal, instead of prompting twice.

### Viewmodel

\`WalletSettingsViewModel.loadSensitiveData(activity)\` now handles three cases:

| \`kdfVersion\` | Behavior |
|---|---|
| \`1\` | Generate V2 encrypt cipher → BiometricPrompt → \`migrateWalletAndExtract\` → wallet is now on V2, plaintext goes straight to UI |
| \`2\` | Existing \`readKeyMaterial\` flow (one BiometricPrompt) |
| \`null\` | Fallback to silent V1 load (no \`key_material\` row at all) |

V2 success branch now sets \`seedPhraseUnlocked = true\`. It was not set previously, which meant V2 reveals worked by accident on devices without a PIN and silently broke with one.

### Screen

\`WalletSettingsScreen\` "View seed phrase" and "View private key" click handlers route through \`unlockSensitive()\` unconditionally. The old PIN-verify branch is gone. Biometric (with device-credential fallback on API 30+) is now required for every reveal.

## After this PR

- Fresh-install user creates wallet → backs up phrase → Settings > View seed phrase → **BiometricPrompt** → phrase displayed → wallet silently upgraded to V2
- Subsequent reveals: BiometricPrompt every time
- No code path reveals the mnemonic on PIN alone

## Test plan

- [x] \`./gradlew :app:compileDebugKotlin -x cargoBuild\` BUILD SUCCESSFUL
- [x] \`./gradlew :app:testDebugUnitTest -x cargoBuild\` BUILD SUCCESSFUL
- [ ] Manual: fresh wallet → back up → Settings → View seed phrase → BiometricPrompt fires
- [ ] Manual: same wallet, second time around → V2 read with single BiometricPrompt
- [ ] Manual: device with no biometric enrolled but a device credential set → BiometricPrompt falls back to PIN/pattern correctly

Refs Telegram bug report (Radoslav, 2026-05-21)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced secure data access: seed phrase and private key viewing now consistently require biometric authentication through a unified unlock flow.

* **New Features**
  * Automatic wallet security upgrade: older wallet versions are seamlessly migrated to the latest encryption format when sensitive data is first accessed.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/RaheemJnr/pocket-node/pull/275?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->