### PR TITLE
fix(dao): correct APC math for withdrawing cells (Telegram 9)

### DIFF
--- a/android/app/src/main/java/com/rjnr/pocketnode/data/gateway/DaoDepositReader.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/gateway/DaoDepositReader.kt
@@ -241,11 +241,35 @@ class DaoDepositReader @Inject constructor(
             }
         }
 
-        // Compute per-deposit APC when enough time has elapsed
+        // Compute per-deposit APC when enough time has elapsed.
+        //
+        // Compensation stops accruing the moment the deposit cell is moved
+        // into the withdrawing state — using wall-clock `now` for the upper
+        // bound on a withdrawing cell understates the realised APC because
+        // we'd divide by a window longer than the actual accrual period.
+        //
+        // For a withdrawing cell: end = withdraw-block timestamp.
+        // For a deposited cell: end = wall-clock now (still accruing).
+        //
+        // Both branches above wrote `depositTimestampMs` to the original
+        // deposit's block timestamp, so the only thing that varies is the
+        // upper bound. The withdraw block header is `cellBlockHeader` in
+        // the isWithdrawing branch (we re-read it earlier in this function).
         if (compensation > 0 && depositTimestampMs > 0 && capacityShannons > 0) {
-            val elapsedDays = (System.currentTimeMillis() - depositTimestampMs) / 86_400_000.0
+            val endTimeMs = if (isWithdrawing) {
+                cellBlockHeader?.timestamp?.removePrefix("0x")?.toLong(16) ?: System.currentTimeMillis()
+            } else {
+                System.currentTimeMillis()
+            }
+            val elapsedDays = (endTimeMs - depositTimestampMs) / 86_400_000.0
             if (elapsedDays >= 1.0) {
                 apc = (compensation.toDouble() / capacityShannons) / (elapsedDays / 365.25) * 100.0
+                Log.d(
+                    TAG,
+                    "APC for $cellId: compensation=$compensation capacity=$capacityShannons " +
+                        "elapsedDays=${"%.2f".format(elapsedDays)} apc=${"%.4f".format(apc)}% " +
+                        "(isWithdrawing=$isWithdrawing)"
+                )
             }
         }
 


### PR DESCRIPTION
## Summary

Telegram bug 9: user (georgiev) reported \"dao apc is wrong i think, it's says 1.55%\". Investigation found a real bug in the math for withdrawing cells.

## Root cause

[DaoDepositReader.kt:246](android/app/src/main/java/com/rjnr/pocketnode/data/gateway/DaoDepositReader.kt#L246) used \`(now - depositTime)\` as elapsed time for the APC calc:

\`\`\`kotlin
val elapsedDays = (System.currentTimeMillis() - depositTimestampMs) / 86_400_000.0
apc = (compensation / capacity) / (elapsedDays / 365.25) * 100.0
\`\`\`

For a **deposited** cell that's still accruing, \`now\` is the correct endpoint.

For a **withdrawing** cell, compensation stops accruing the moment the deposit transitions to withdrawing. Wall-clock keeps advancing past that point, so dividing by a longer window understates the realised APC.

## Fix

Branch on \`isWithdrawing\`. For withdrawing cells, use the **withdraw-block header timestamp** as the endpoint (same source the compensation amount itself comes from). For deposited cells, keep wall-clock \`now\`.

\`\`\`kotlin
val endTimeMs = if (isWithdrawing) {
    cellBlockHeader?.timestamp?.removePrefix(\"0x\")?.toLong(16)
        ?: System.currentTimeMillis()
} else {
    System.currentTimeMillis()
}
val elapsedDays = (endTimeMs - depositTimestampMs) / 86_400_000.0
\`\`\`

Also added DEBUG-level logging of \`(compensation, capacity, elapsedDays, apc, isWithdrawing)\` so a future APC report can be cross-checked against logcat without needing instrumentation.

## Caveat

This may not move 1.55% all the way to the user's expected number — actual CKB DAO compensation has been declining as secondary issuance progresses, and values in the 1.5-2.0% range are within normal. But the **math is now correct for the withdrawing case**, which is the only branch with an identifiable error.

## Test plan

- [x] \`./gradlew :app:compileDebugKotlin -x cargoBuild\` BUILD SUCCESSFUL
- [x] \`./gradlew :app:testDebugUnitTest -x cargoBuild\` BUILD SUCCESSFUL
- [ ] Manual: deposit cell — verify APC reads from logcat match expected (~1.7-2%)
- [ ] Manual: withdrawing cell — verify APC reads higher than before this PR (now correctly uses withdraw timestamp as endpoint)

Refs Telegram bug report (georgiev, 2026-05-21)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Improved accuracy of deposit calculations to properly account for different withdrawal states.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/RaheemJnr/pocket-node/pull/276?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->