### PR TITLE
fix(onboarding): warning, not block, when device has no lock

### DIFF
--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/onboarding/OnboardingScreen.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/onboarding/OnboardingScreen.kt
@@ -35,6 +35,14 @@ fun OnboardingScreen(
     var showNameDialog by remember { mutableStateOf(false) }
     var pendingWalletName by remember { mutableStateOf("My Wallet") }
 
+    // No-device-lock advisory. When the device has neither biometric
+    // enrolled nor a credential set, the V2 Keystore key chain can't
+    // bind the wallet to user auth — the wallet still works, but the
+    // keys are not hardware-protected until the user enrolls something.
+    // Surface this as a warning the user can dismiss to continue, or
+    // route them to Android Settings to enable a lock.
+    var showNoDeviceLockWarning by remember { mutableStateOf(false) }
+
     // After wallet creation, navigate to backup screen (not Home)
     LaunchedEffect(uiState.isWalletCreated) {
         if (uiState.isWalletCreated) {
@@ -114,7 +122,16 @@ fun OnboardingScreen(
                 title = "Create New Wallet",
                 description = "Generate a new wallet with a 12-word recovery phrase.",
                 icon = Lucide.Plus,
-                onClick = { showNameDialog = true },
+                onClick = {
+                    // Intercept the create flow when the device has no
+                    // lock to give the user informed-consent before
+                    // landing on the name dialog. They can still proceed.
+                    if (uiState.noDeviceCredential) {
+                        showNoDeviceLockWarning = true
+                    } else {
+                        showNameDialog = true
+                    }
+                },
                 isLoading = uiState.isLoading,
                 modifier = Modifier.uaTestTag("onboarding-create-new")
             )
@@ -174,6 +191,50 @@ fun OnboardingScreen(
             dismissButton = {
                 TextButton(onClick = { showNameDialog = false }) {
                     Text("Cancel")
+                }
+            },
+        )
+    }
+
+    if (showNoDeviceLockWarning) {
+        AlertDialog(
+            onDismissRequest = { showNoDeviceLockWarning = false },
+            title = { Text("Continue without a device lock?") },
+            text = {
+                Text(
+                    text = "This phone has no PIN, pattern, password, or biometric set. " +
+                        "Your wallet will still work, but the keys cannot be hardware-protected " +
+                        "until you enable a device lock in Android Settings. The app will upgrade " +
+                        "the protection automatically once you do.",
+                    style = MaterialTheme.typography.bodyMedium,
+                )
+            },
+            confirmButton = {
+                TextButton(onClick = {
+                    showNoDeviceLockWarning = false
+                    showNameDialog = true
+                }) {
+                    Text("Continue anyway")
+                }
+            },
+            dismissButton = {
+                Row {
+                    TextButton(onClick = {
+                        showNoDeviceLockWarning = false
+                        // ACTION_SECURITY_SETTINGS lands the user on the
+                        // Security & privacy page on stock Android and on
+                        // most OEM skins. Doesn't deep-link to the lock-
+                        // screen flow but it's two taps from there.
+                        context.startActivity(
+                            android.content.Intent(android.provider.Settings.ACTION_SECURITY_SETTINGS)
+                                .addFlags(android.content.Intent.FLAG_ACTIVITY_NEW_TASK)
+                        )
+                    }) {
+                        Text("Open Settings")
+                    }
+                    TextButton(onClick = { showNoDeviceLockWarning = false }) {
+                        Text("Cancel")
+                    }
                 }
             },
         )

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/onboarding/OnboardingViewModel.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/onboarding/OnboardingViewModel.kt
@@ -67,17 +67,16 @@ class OnboardingViewModel @Inject constructor(
      * blank-named wallet row.
      */
     fun createNewWallet(name: String = "My Wallet") {
-        if (!canCreateV2BoundKey()) {
-            _uiState.update {
-                it.copy(
-                    error = com.rjnr.pocketnode.ui.util.UiMessage.Resource(
-                        com.rjnr.pocketnode.R.string.vm_error_no_device_credential,
-                    ),
-                    noDeviceCredential = true,
-                )
-            }
-            return
-        }
+        // No more hard block on missing device credential. The previous
+        // gate (introduced in #213 sub-PR 6) refused creation outright
+        // because the V2 Keystore key needs *some* credential to bind to.
+        // In practice the wallet still works without one — it stays on
+        // kdfVersion=1 until a credential is enrolled, at which point the
+        // existing AuthScreen migration runner upgrades it.
+        //
+        // The UI now shows a warning dialog (Cancel / Open Settings /
+        // Continue anyway) when noDeviceCredential is true, so the user
+        // sees an informed consent surface but is not blocked.
         val trimmed = name.trim().ifBlank { "My Wallet" }
         viewModelScope.launch {
             _uiState.update { it.copy(isLoading = true, error = null) }


### PR DESCRIPTION
## Summary

User-reported on the smoke build: a fresh Pixel 7 Pro emulator with no device lock showed a snackbar reading \"Set a screen lock... try again\" when tapping Create New Wallet — a UX dead-end with no path forward inside the app.

Reverts the hard block from #213 sub-PR 6. The wallet still works without a device lock; it just stays on kdfVersion=1 until the user enrolls a credential, at which point the existing AuthScreen migration runner upgrades it automatically.

## What changes

- \`OnboardingViewModel.createNewWallet\` no longer returns early on \`!canCreateV2BoundKey\`. Wallets create at \`kdfVersion=1\` like any other wallet under v1.6.x would have.

- \`OnboardingScreen\` intercepts the Create New Wallet tap when \`noDeviceCredential\` is true and surfaces a three-button dialog:

  | Action | Result |
  |--------|--------|
  | Cancel | Back to onboarding |
  | Open Settings | \`Intent.ACTION_SECURITY_SETTINGS\` |
  | Continue anyway | Proceeds to the name dialog |

\"Continue anyway\" is the informed-consent surface — the user knows the trade-off and chooses to proceed. \"Open Settings\" is the friendly nudge for users who didn't realise they had no lock set.

## Test plan

- [x] \`./gradlew :app:compileDebugKotlin -x cargoBuild\` BUILD SUCCESSFUL
- [x] APK rebuilt for smoke testing
- [ ] Manual: fresh emulator without device lock → Create New Wallet → warning dialog → Continue anyway → name dialog → wallet creates
- [ ] Manual: same emulator → Open Settings → Android Security settings opens
- [ ] Manual: enroll a PIN/biometric → close app → reopen → Create New Wallet → no warning, V2 path takes over

Refs #213

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a security warning dialog during wallet creation when device lock is not enabled. Users can now choose to continue, open device security settings, or cancel the operation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/RaheemJnr/pocket-node/pull/277?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->