### PR TITLE
fix(wallet): drop active-wallet gate in requestDelete (Telegram 5 follow-up)

### DIFF
--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/wallet/WalletSettingsViewModel.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/wallet/WalletSettingsViewModel.kt
@@ -106,10 +106,14 @@ class WalletSettingsViewModel @Inject constructor(
 
     fun requestDelete() {
         val wallet = _uiState.value.wallet ?: return
-        if (wallet.isActive) {
-            _uiState.update { it.copy(error = com.rjnr.pocketnode.ui.util.UiMessage.Resource(com.rjnr.pocketnode.R.string.vm_error_cannot_delete_active)) }
-            return
-        }
+        // No more upfront active-wallet block. The confirmDelete path
+        // auto-switches to a sibling before deleting (PR #273), but
+        // this entry point was still gating on `wallet.isActive`, so
+        // the user hit the dead-end snackbar before ever seeing the
+        // confirmation dialog. Removed so the flow can reach
+        // confirmDelete and use the auto-switch logic.
+        // (Telegram bug 5 follow-up — original fix only covered half
+        // the path.)
         viewModelScope.launch {
             val count = walletRepository.walletCount()
             if (count <= 1) {


### PR DESCRIPTION
## Summary

Smoke-test bug report on the build that includes #273: tapping Remove on the active wallet still shows the original \"Cannot delete the active wallet. Switch to another wallet first.\" dead-end. Screenshot attached to the report.

## Root cause

#273 only patched \`confirmDelete()\` — the path that runs *after* the confirmation dialog. The upstream entry point \`requestDelete()\` still gated on \`wallet.isActive\` and threw \`vm_error_cannot_delete_active\` before the dialog ever opened:

\`\`\`kotlin
fun requestDelete() {
    val wallet = _uiState.value.wallet ?: return
    if (wallet.isActive) {
        _uiState.update { it.copy(error = ... vm_error_cannot_delete_active ...) }
        return  // ← user never reaches the dialog
    }
    ...
}
\`\`\`

## Fix

Drop the active-wallet check from \`requestDelete\`. The flow now reaches the confirmation dialog, the user confirms, \`confirmDelete\` handles the active case by switching to a sibling first, then deletes.

The single-wallet guard (\`walletCount() <= 1\` → \`vm_error_cannot_delete_last\`) still fires correctly because it runs after the active check, catches the only-wallet edge case before opening the dialog.

## Test plan

- [x] \`./gradlew :app:compileDebugKotlin -x cargoBuild\` BUILD SUCCESSFUL
- [x] \`./gradlew :app:testDebugUnitTest -x cargoBuild\` BUILD SUCCESSFUL
- [ ] Manual: 2 wallets, active wallet's Settings → Remove → dialog opens → confirm → app switches to sibling and deletes
- [ ] Manual: 1 wallet → Settings → Remove → \"This is your only wallet\" message fires (unchanged)

Refs #273, Telegram bug report (Radoslav, 2026-05-22)