### PR TITLE
fix(sync): handle Android 14+ FGS dataSync time-limit (matt crash)

### DIFF
--- a/android/app/src/main/java/com/rjnr/pocketnode/data/sync/SyncForegroundService.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/sync/SyncForegroundService.kt
@@ -103,6 +103,34 @@ class SyncForegroundService : Service() {
         }
     }
 
+    /**
+     * API 34 (Android 14) FGS time-limit callback for short-lived service
+     * types. `dataSync` is capped at ~6h per 24h window. When the system
+     * fires this we MUST stop the FGS or it kills the process with
+     * `ForegroundServiceDidNotStopInTimeException` on the main thread —
+     * a SystemServer-injected RuntimeException that no in-process
+     * try-catch can intercept. matt reported the symptom on a Samsung
+     * S24 Ultra after extended background time.
+     *
+     * Stopping the FGS does NOT stop the sync poll on the repository
+     * scope. If the app is foregrounded again, the next onStartCommand
+     * starts a new FGS instance and the system grants a fresh budget.
+     */
+    override fun onTimeout(startId: Int) {
+        Log.w(TAG, "FGS dataSync timeout received (startId=$startId, API 34 path). Stopping cleanly.")
+        stopSelf(startId)
+    }
+
+    /**
+     * API 35 (Android 15) variant of [onTimeout] that includes the FGS
+     * type. Same behaviour: stop the service before the system kills
+     * the process.
+     */
+    override fun onTimeout(startId: Int, fgsType: Int) {
+        Log.w(TAG, "FGS timeout received (startId=$startId, fgsType=$fgsType, API 35 path). Stopping cleanly.")
+        stopSelf(startId)
+    }
+
     override fun onDestroy() {
         super.onDestroy()
         observeJob?.cancel()


### PR DESCRIPTION
## Summary

Android 14 (API 34) caps \`FOREGROUND_SERVICE_TYPE_DATA_SYNC\` at ~6h per 24h window. When the limit is reached the system fires \`Service.onTimeout()\` — apps that ignore it have their process killed with \`ForegroundServiceDidNotStopInTimeException\`, a SystemServer-injected RuntimeException dispatched onto the main thread that no in-process try-catch can intercept.

PR #281 hardened \`startForeground\` and notification updates against the secondary \`ForegroundServiceStartNotAllowedException\`, but did not address the primary main-thread death.

matt reproduced on a Samsung S24 Ultra after extended background time:

\`\`\`
FATAL EXCEPTION: main
android.app.RemoteServiceException\$ForegroundServiceDidNotStopInTimeException:
  A foreground service of type dataSync did not stop within its timeout:
  ComponentInfo{com.rjnr.pocketnode/com.rjnr.pocketnode.data.sync.SyncForegroundService}
\`\`\`

## Fix

Override both \`onTimeout\` signatures on \`SyncForegroundService\`:

- \`onTimeout(startId)\` — API 34 (Android 14) callback
- \`onTimeout(startId, fgsType)\` — API 35 (Android 15) callback

Both call \`stopSelf(startId)\`. compileSdk=36 sees both signatures.

Stopping the FGS does NOT stop the sync poll on the repository scope. If the app is foregrounded again, the next \`onStartCommand\` starts a new FGS with a fresh budget.

## Block on v1.7.0 tag

The tag has not been pushed yet. Merging this PR before \`git tag v1.7.0 && git push --tags\` lands the fix into v1.7.0 without a version bump. Recommend merging immediately.

## Test plan

- [x] \`./gradlew :app:compileDebugKotlin -x cargoBuild\` BUILD SUCCESSFUL
- [ ] Manual: install on Samsung, leave backgrounded for 6+ hours, verify no process crash (logcat will show \"FGS dataSync timeout received... Stopping cleanly\")

Refs PR #281, Telegram bug report (matt, 2026-05-31)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sync service stability by implementing graceful timeout handling to ensure proper service termination when system-enforced limits are reached, preventing unexpected crashes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->