### PR TITLE
chore(web): hero badge v1.7 shipped

### DIFF
--- a/website/components/Hero.tsx
+++ b/website/components/Hero.tsx
@@ -20,7 +20,7 @@ export function Hero() {
         <div className="mb-8 md:mb-12">
           <span className="inline-flex items-center gap-2 border border-green/40 px-3 py-1.5 font-doto text-xs font-black uppercase tracking-widest text-green">
             <span className="block h-2 w-2 bg-green" aria-hidden />
-            v1.7 in flight · open source
+            v1.7 shipped · open source
           </span>
         </div>
 


### PR DESCRIPTION
One-line copy update on the homepage badge: v1.7 is live, not in-flight.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated hero badge status to indicate version 1.7 has shipped.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->