### PR TITLE
fix(security): require PIN before toggling auth-before-send (#292)

### DIFF
--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/settings/SecuritySettingsScreen.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/settings/SecuritySettingsScreen.kt
@@ -55,10 +55,14 @@ fun SecuritySettingsScreen(
     val snackbarHostState = remember { SnackbarHostState() }
     var showRemoveDialog by remember { mutableStateOf(false) }
     var optimisticBiometric by remember { mutableStateOf<Boolean?>(null) }
+    var optimisticAuthBeforeSend by remember { mutableStateOf<Boolean?>(null) }
 
     // Clear optimistic override when real state arrives
     LaunchedEffect(uiState.isBiometricEnabled) {
         optimisticBiometric = null
+    }
+    LaunchedEffect(uiState.isAuthBeforeSendEnabled) {
+        optimisticAuthBeforeSend = null
     }
 
     val context = androidx.compose.ui.platform.LocalContext.current
@@ -297,9 +301,18 @@ fun SecuritySettingsScreen(
                         }
 
                         Switch(
-                            checked = uiState.isAuthBeforeSendEnabled,
+                            checked = optimisticAuthBeforeSend ?: uiState.isAuthBeforeSendEnabled,
                             onCheckedChange = { enabled ->
-                                viewModel.toggleAuthBeforeSend(enabled)
+                                // Per-operation auth toggle is itself a security state
+                                // change. Both enable AND disable route through
+                                // PinEntryScreen so a local attacker with a brief
+                                // unlocked-session window cannot turn the gate off
+                                // and immediately send (#292).
+                                optimisticAuthBeforeSend = enabled
+                                val action = if (enabled) PendingSecurityAction.ENABLE_AUTH_BEFORE_SEND
+                                    else PendingSecurityAction.DISABLE_AUTH_BEFORE_SEND
+                                viewModel.setPendingAction(action)
+                                onNavigateToPinVerify()
                             },
                             enabled = uiState.hasPin
                         )

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/settings/SecuritySettingsViewModel.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/settings/SecuritySettingsViewModel.kt
@@ -22,7 +22,13 @@ import javax.inject.Inject
 enum class PendingSecurityAction {
     REMOVE_PIN,
     ENABLE_BIOMETRIC,
-    DISABLE_BIOMETRIC
+    DISABLE_BIOMETRIC,
+    // Both enable and disable need a PIN gate. Disabling auth-before-send
+    // is itself a security state change: a local attacker with a brief
+    // unlocked-session window must not be able to turn off the
+    // per-operation gate that protects transaction signing (#292).
+    ENABLE_AUTH_BEFORE_SEND,
+    DISABLE_AUTH_BEFORE_SEND,
 }
 
 data class SecuritySettingsUiState(
@@ -83,6 +89,8 @@ class SecuritySettingsViewModel @Inject constructor(
             PendingSecurityAction.REMOVE_PIN -> removePin()
             PendingSecurityAction.ENABLE_BIOMETRIC -> toggleBiometric(true)
             PendingSecurityAction.DISABLE_BIOMETRIC -> toggleBiometric(false)
+            PendingSecurityAction.ENABLE_AUTH_BEFORE_SEND -> applyAuthBeforeSend(true)
+            PendingSecurityAction.DISABLE_AUTH_BEFORE_SEND -> applyAuthBeforeSend(false)
             null -> {}
         }
         savedStateHandle.remove<String>(KEY_PENDING_ACTION)
@@ -115,7 +123,18 @@ class SecuritySettingsViewModel @Inject constructor(
         }
     }
 
-    fun toggleAuthBeforeSend(enabled: Boolean) {
+    /**
+     * Apply the auth-before-send preference. PRIVATE — invoked only via
+     * [executePendingAction] after the user verifies their PIN in
+     * `PinEntryScreen`. The UI must NOT call this directly; the Switch
+     * `onCheckedChange` handler routes through [setPendingAction] +
+     * navigate-to-PIN-verify to enforce the gate (#292).
+     *
+     * The "no PIN → refuse to enable" pre-check is performed at the screen
+     * layer (the Switch is disabled when `hasPin == false`) and again here
+     * defensively in case the screen wiring drifts.
+     */
+    private fun applyAuthBeforeSend(enabled: Boolean) {
         if (enabled && !pinManager.hasPin()) {
             _uiState.update { it.copy(error = UiMessage.Resource(R.string.vm_error_set_pin_first_send)) }
             return

--- a/android/app/src/test/java/com/rjnr/pocketnode/ui/screens/settings/SecuritySettingsViewModelTest.kt
+++ b/android/app/src/test/java/com/rjnr/pocketnode/ui/screens/settings/SecuritySettingsViewModelTest.kt
@@ -1,0 +1,154 @@
+package com.rjnr.pocketnode.ui.screens.settings
+
+import androidx.lifecycle.SavedStateHandle
+import com.rjnr.pocketnode.data.auth.AuthManager
+import com.rjnr.pocketnode.data.database.dao.WalletDao
+import com.rjnr.pocketnode.data.auth.PinManager
+import com.rjnr.pocketnode.data.wallet.KeyBackupManager
+import com.rjnr.pocketnode.data.wallet.KeyManager
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * Tests for [SecuritySettingsViewModel.applyAuthBeforeSend] PIN-gate
+ * routing introduced by #292. The toggle no longer applies immediately
+ * from the Switch; both ENABLE and DISABLE route through
+ * [PinEntryScreen] via [SecuritySettingsViewModel.setPendingAction] +
+ * [SecuritySettingsViewModel.executePendingAction].
+ *
+ * The Switch handler stages the pending action and navigates to PIN
+ * verification; only after the user enters the correct PIN does the
+ * navigation chain call [SecuritySettingsViewModel.executePendingAction]
+ * which invokes the real `applyAuthBeforeSend(enabled)` setter.
+ *
+ * Pre-#292 a local attacker with a brief unlocked-session window could
+ * flip the Switch off and immediately send a transaction without re-auth.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class SecuritySettingsViewModelTest {
+
+    private val testDispatcher = StandardTestDispatcher()
+    private lateinit var savedStateHandle: SavedStateHandle
+    private lateinit var authManager: AuthManager
+    private lateinit var pinManager: PinManager
+    private lateinit var keyBackupManager: KeyBackupManager
+    private lateinit var keyManager: KeyManager
+    private lateinit var walletDao: WalletDao
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(testDispatcher)
+        savedStateHandle = SavedStateHandle()
+        authManager = mockk(relaxed = true)
+        pinManager = mockk(relaxed = true)
+        keyBackupManager = mockk(relaxed = true)
+        keyManager = mockk(relaxed = true)
+        walletDao = mockk(relaxed = true)
+
+        every { authManager.isBiometricAvailable() } returns AuthManager.BiometricStatus.AVAILABLE
+        every { authManager.isBiometricEnabled() } returns false
+        every { authManager.isAuthBeforeSendEnabled() } returns false
+        every { pinManager.hasPin() } returns true
+        coEvery { walletDao.count() } returns 0
+        every { keyBackupManager.hasAnyBackups() } returns false
+    }
+
+    @After
+    fun tearDown() { Dispatchers.resetMain() }
+
+    private fun newViewModel() = SecuritySettingsViewModel(
+        savedStateHandle = savedStateHandle,
+        authManager = authManager,
+        pinManager = pinManager,
+        keyBackupManager = keyBackupManager,
+        keyManager = keyManager,
+        walletDao = walletDao,
+    )
+
+    @Test
+    fun `setPendingAction does not apply auth-before-send until executePendingAction runs`() = runTest {
+        val vm = newViewModel()
+        advanceUntilIdle()
+
+        vm.setPendingAction(PendingSecurityAction.ENABLE_AUTH_BEFORE_SEND)
+        advanceUntilIdle()
+
+        // Pending action staged in SavedStateHandle. The Switch's onCheckedChange
+        // staged it and then navigated to PinEntryScreen. The setter MUST NOT
+        // fire yet — the user hasn't verified PIN.
+        verify(exactly = 0) { authManager.setAuthBeforeSendEnabled(any()) }
+        assertEquals(false, vm.uiState.value.isAuthBeforeSendEnabled)
+    }
+
+    @Test
+    fun `executePendingAction ENABLE_AUTH_BEFORE_SEND applies and updates UI state`() = runTest {
+        val vm = newViewModel()
+        advanceUntilIdle()
+
+        vm.setPendingAction(PendingSecurityAction.ENABLE_AUTH_BEFORE_SEND)
+        vm.executePendingAction()
+        advanceUntilIdle()
+
+        verify(exactly = 1) { authManager.setAuthBeforeSendEnabled(true) }
+        assertEquals(true, vm.uiState.value.isAuthBeforeSendEnabled)
+    }
+
+    @Test
+    fun `executePendingAction DISABLE_AUTH_BEFORE_SEND applies and updates UI state`() = runTest {
+        // Pre-condition: auth-before-send already on.
+        every { authManager.isAuthBeforeSendEnabled() } returns true
+        val vm = newViewModel()
+        advanceUntilIdle()
+
+        vm.setPendingAction(PendingSecurityAction.DISABLE_AUTH_BEFORE_SEND)
+        vm.executePendingAction()
+        advanceUntilIdle()
+
+        verify(exactly = 1) { authManager.setAuthBeforeSendEnabled(false) }
+        assertEquals(false, vm.uiState.value.isAuthBeforeSendEnabled)
+    }
+
+    @Test
+    fun `executePendingAction without setPendingAction is a no-op`() = runTest {
+        val vm = newViewModel()
+        advanceUntilIdle()
+
+        vm.executePendingAction()
+        advanceUntilIdle()
+
+        verify(exactly = 0) { authManager.setAuthBeforeSendEnabled(any()) }
+    }
+
+    @Test
+    fun `executePendingAction ENABLE without PIN surfaces error and does not apply`() = runTest {
+        // Defensive: if the Switch wiring drifts and ENABLE is staged without a PIN,
+        // applyAuthBeforeSend must refuse rather than enable a gate that requires
+        // PIN verification to operate.
+        every { pinManager.hasPin() } returns false
+        val vm = newViewModel()
+        advanceUntilIdle()
+
+        vm.setPendingAction(PendingSecurityAction.ENABLE_AUTH_BEFORE_SEND)
+        vm.executePendingAction()
+        advanceUntilIdle()
+
+        verify(exactly = 0) { authManager.setAuthBeforeSendEnabled(any()) }
+        assertEquals(false, vm.uiState.value.isAuthBeforeSendEnabled)
+        assertNotNull(vm.uiState.value.error)
+    }
+}


### PR DESCRIPTION
## Summary

Codex security finding #292. The "Authenticate before sending" Switch in `SecuritySettingsScreen` previously called `viewModel.toggleAuthBeforeSend(enabled)` directly, persisting the new preference with no verification. A local attacker with a brief unlocked-session window could flip the gate off and immediately send a transaction without re-auth.

Both ENABLE and DISABLE now route through `PinEntryScreen`, mirroring the existing `toggleBiometric` pattern:

1. `Switch.onCheckedChange` stages an optimistic UI flip + `setPendingAction(...)` + `onNavigateToPinVerify()`.
2. On PIN success the navigator calls `executePendingAction()` → new private `applyAuthBeforeSend(enabled)` that actually flips the preference.
3. On PIN cancel/back the optimistic state clears via the existing `LaunchedEffect`, so the Switch reverts.

The old public `toggleAuthBeforeSend` is gone from the VM surface; the setter is private and only reachable via the `PendingSecurityAction` enum.

## Changes

- `SecuritySettingsViewModel.kt`: added `ENABLE_AUTH_BEFORE_SEND` / `DISABLE_AUTH_BEFORE_SEND` cases to `PendingSecurityAction`; `executePendingAction` dispatches; new private `applyAuthBeforeSend(enabled)` with defensive PIN re-check.
- `SecuritySettingsScreen.kt`: added `optimisticAuthBeforeSend` state + `LaunchedEffect` clear; Switch now routes through `setPendingAction` + `onNavigateToPinVerify` like the biometric Switch above it.
- `SecuritySettingsViewModelTest.kt`: 5 new tests pinning the pending-action gate.

## Test plan

- [x] `./gradlew :app:testDebugUnitTest` — green (5 new tests pass, no regressions).
- [ ] Upgrade-smoke (auto).
- [ ] Manual: toggle Switch → PIN entry appears → enter PIN → Switch persists. Toggle Switch → cancel PIN → Switch reverts.

## Notes

Long term, transaction signing should be bound to a Keystore `CryptoObject` so this toggle becomes advisory UX rather than the gate. Tracked under #213 follow-ups.