### PR TITLE
fix(ci): checkout release tag by verified commit SHA, not unqualified name (#291)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,11 +60,21 @@ jobs:
 
           echo "Validated release tag $RELEASE_TAG at $TAG_COMMIT."
           echo "release_tag=$RELEASE_TAG" >> "$GITHUB_OUTPUT"
+          echo "tag_commit=$TAG_COMMIT" >> "$GITHUB_OUTPUT"
 
       - name: Checkout validated release tag
+        # Check out the verified commit SHA (not the unqualified tag name).
+        # An unqualified ref can be resolved by Git/checkout-action to a
+        # branch first when a branch shares the tag's short name — an attacker
+        # with branch-create + workflow-dispatch perms could create branch
+        # v1.7.0 alongside tag v1.7.0, dispatch the workflow with input
+        # v1.7.0, pass the tag-provenance validation (which inspects
+        # refs/tags/v1.7.0), and then have checkout resolve to the malicious
+        # branch with release-signing secrets available. SHAs are
+        # unambiguous and cannot be shadowed. (#291)
         uses: actions/checkout@v4
         with:
-          ref: ${{ steps.validate_tag.outputs.release_tag }}
+          ref: ${{ steps.validate_tag.outputs.tag_commit }}
           fetch-depth: 0
 
       - name: Set up JDK 17


### PR DESCRIPTION
## Summary

Codex security review finding #291. The release workflow validates the supplied tag exists and is reachable from \`main\`, then checks out using the unqualified tag NAME as ref. Branches and tags can share short names; a branch could shadow the tag and run with the release-signing secret store.

## Attack

1. Attacker creates branch \`v1.7.0\` (matching an existing valid tag) carrying malicious build code.
2. Dispatches the release workflow with input \`v1.7.0\`.
3. Tag-provenance validation inspects \`refs/tags/v1.7.0\` → passes.
4. \`actions/checkout\` resolves the unqualified \`v1.7.0\` ref to the BRANCH first.
5. Build runs from the malicious branch with \`release-signing\` env exposed.

## Fix

\`validate_tag\` already computes \`TAG_COMMIT\` (the SHA from \`git rev-list -n 1\`). Emit it as a step output and use it as the checkout ref. SHAs are unambiguous and cannot be branch-shadowed.

\`\`\`yaml
- echo "release_tag=\$RELEASE_TAG" >> "\$GITHUB_OUTPUT"
+ echo "tag_commit=\$TAG_COMMIT" >> "\$GITHUB_OUTPUT"
  ...
- ref: \${{ steps.validate_tag.outputs.release_tag }}
+ ref: \${{ steps.validate_tag.outputs.tag_commit }}
\`\`\`

Inline comment documents the rationale so the next maintainer doesn't revert it.

## Test plan

- [x] Workflow YAML parses (single-file change, comment-only otherwise).
- [ ] Upgrade-smoke (auto).
- [ ] Next release tag (v1.7.3 or later) exercises the SHA-checkout path end-to-end. Existing v1.7.2 build pipeline already shipped, so this lands silent until the next release-workflow dispatch.

## Notes

Same class of finding as #182 (also Codex), different leg. Defense-in-depth for the release-signing secret store.

The plan also suggested an optional CI job on a fork that creates a shadow branch and confirms the workflow ignores it — out of scope for this PR. Useful as a separate hardening issue if someone wants to set up a permanent attack-fixture against the release workflow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced security of the release process with improved tag validation and commit verification to prevent potential tampering during releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->