### PR TITLE
fix(backup): require PIN + reveal-on-tap + clipboard timeout for raw-key backup (#290)

### DIFF
--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/navigation/NavGraph.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/navigation/NavGraph.kt
@@ -169,7 +169,11 @@ fun CkbNavGraph(
                         launchSingleTop = true
                     }
                 },
-                onNavigateBack = { navController.popBackStack() }
+                onNavigateBack = { navController.popBackStack() },
+                onNavigateToPinVerify = {
+                    navController.navigate(Screen.PinEntry.createRoute("verify"))
+                },
+                pinVerifiedFlow = backStackEntry.savedStateHandle,
             )
         }
 
@@ -261,6 +265,19 @@ fun CkbNavGraph(
                                     navController.popBackStack()
                                 }
                                 previousRoute == Screen.WalletDetail.route -> {
+                                    navController.previousBackStackEntry
+                                        ?.savedStateHandle
+                                        ?.set("pin_verified", true)
+                                    navController.popBackStack()
+                                }
+                                previousRoute != null &&
+                                    (previousRoute == Screen.MnemonicBackup.route ||
+                                        previousRoute.startsWith("${Screen.MnemonicBackup.BASE}?") ||
+                                        previousRoute.startsWith("${Screen.MnemonicBackup.BASE}/")) -> {
+                                    // Raw-key backup PIN gate (#290). The screen
+                                    // consumes the flag in a LaunchedEffect and
+                                    // calls viewModel.onPinVerified() to fetch
+                                    // the key.
                                     navController.previousBackStackEntry
                                         ?.savedStateHandle
                                         ?.set("pin_verified", true)

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/onboarding/MnemonicBackupScreen.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/onboarding/MnemonicBackupScreen.kt
@@ -45,13 +45,23 @@ data class MnemonicBackupUiState(
     val verifyPositions: List<Int> = emptyList(),
     val verifyOptions: Map<Int, List<String>> = emptyMap(),
     val userSelections: Map<Int, String> = emptyMap(),
-    val error: String? = null
+    val error: String? = null,
+    /**
+     * True when a raw_key wallet's private key is gated behind PIN entry
+     * (Settings → Backup Wallet path on an install with a PIN set). False
+     * when no PIN exists yet (onboarding edge case for raw-key imports
+     * pre-PIN-setup) or when the PIN has already been verified.
+     */
+    val pinRequiredForPrivateKey: Boolean = false,
+    /** True once the user has revealed the private key in this session. */
+    val privateKeyRevealed: Boolean = false,
 )
 
 @HiltViewModel
 class MnemonicBackupViewModel @Inject constructor(
     private val repository: GatewayRepository,
-    private val walletRepository: com.rjnr.pocketnode.data.wallet.WalletRepository
+    private val walletRepository: com.rjnr.pocketnode.data.wallet.WalletRepository,
+    private val pinManager: com.rjnr.pocketnode.data.auth.PinManager,
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow(MnemonicBackupUiState())
@@ -72,17 +82,21 @@ class MnemonicBackupViewModel @Inject constructor(
             val words = repository.getMnemonic()
             if (words.isNullOrEmpty()) {
                 // For raw_key or sub-account wallets, this is expected — not an error.
-                // Only raw-key wallets need the private key for the dedicated raw-key backup screen.
-                val privateKeyHex = if (walletType == "raw_key" && !isSubAccount) {
-                    try {
-                        repository.getPrivateKey().toHex()
-                    } catch (_: Exception) {
-                        null
+                // Only raw-key wallets need the private key for the dedicated raw-key
+                // backup screen, and only behind a PIN gate when a PIN exists (#290).
+                if (walletType == "raw_key" && !isSubAccount) {
+                    if (pinManager.hasPin()) {
+                        // Defer the private-key fetch until the user passes PIN
+                        // verification. The screen renders a "Reveal private key"
+                        // button that routes through PinEntryScreen; on return
+                        // [onPinVerified] is invoked and the key is fetched.
+                        _uiState.update { it.copy(pinRequiredForPrivateKey = true) }
+                    } else {
+                        // No PIN set yet (onboarding edge case for raw-key imports).
+                        // Same behaviour as pre-#290: fetch and display directly.
+                        fetchPrivateKey()
                     }
-                } else {
-                    null
                 }
-                _uiState.update { it.copy(privateKeyHex = privateKeyHex) }
                 return@launch
             }
             val random = java.util.Random(System.nanoTime())
@@ -101,6 +115,25 @@ class MnemonicBackupViewModel @Inject constructor(
                 it.copy(words = words, verifyPositions = positions, verifyOptions = options)
             }
         }
+    }
+
+    /**
+     * Called from [MnemonicBackupScreen] after the user returns from
+     * [PinEntryScreen] with a `pin_verified=true` savedStateHandle flag
+     * (#290). Fetches the private key and unmasks the reveal UI.
+     */
+    fun onPinVerified() {
+        if (!_uiState.value.pinRequiredForPrivateKey) return
+        viewModelScope.launch { fetchPrivateKey() }
+    }
+
+    private suspend fun fetchPrivateKey() {
+        val privateKeyHex = try {
+            repository.getPrivateKey().toHex()
+        } catch (_: Exception) {
+            null
+        }
+        _uiState.update { it.copy(privateKeyHex = privateKeyHex, privateKeyRevealed = true) }
     }
 
     fun advanceToVerify() {
@@ -148,11 +181,24 @@ class MnemonicBackupViewModel @Inject constructor(
 fun MnemonicBackupScreen(
     onNavigateToHome: () -> Unit,
     onNavigateBack: () -> Unit,
+    onNavigateToPinVerify: () -> Unit = {},
+    pinVerifiedFlow: androidx.lifecycle.SavedStateHandle? = null,
     simplified: Boolean = false,
     viewModel: MnemonicBackupViewModel = hiltViewModel()
 ) {
     val uiState by viewModel.uiState.collectAsState()
     val snackbarHostState = remember { SnackbarHostState() }
+
+    // Returning from PinEntryScreen: consume the pin_verified flag set by
+    // the verify-mode pop-back path (NavGraph route). On true, fetch the
+    // raw-key wallet's private key and unmask the reveal UI (#290).
+    LaunchedEffect(pinVerifiedFlow) {
+        val verified = pinVerifiedFlow?.get<Boolean>("pin_verified") == true
+        if (verified) {
+            pinVerifiedFlow.remove<Boolean>("pin_verified")
+            viewModel.onPinVerified()
+        }
+    }
 
     // FLAG_SECURE to prevent screenshots of mnemonic
     val view = LocalView.current
@@ -214,6 +260,8 @@ fun MnemonicBackupScreen(
             uiState.walletType == "raw_key" -> {
                 RawKeyBackupInfo(
                     privateKeyHex = uiState.privateKeyHex,
+                    pinRequiredForReveal = uiState.pinRequiredForPrivateKey && !uiState.privateKeyRevealed,
+                    onRequestPinVerify = onNavigateToPinVerify,
                     snackbarHostState = snackbarHostState,
                     onNavigateBack = onNavigateBack,
                     modifier = Modifier.padding(padding)
@@ -473,12 +521,18 @@ private fun MnemonicSuccessStep(
 @Composable
 private fun RawKeyBackupInfo(
     privateKeyHex: String?,
+    pinRequiredForReveal: Boolean,
+    onRequestPinVerify: () -> Unit,
     snackbarHostState: SnackbarHostState,
     onNavigateBack: () -> Unit,
     modifier: Modifier = Modifier
 ) {
     val clipboardManager = androidx.compose.ui.platform.LocalClipboardManager.current
+    val context = androidx.compose.ui.platform.LocalContext.current
     val scope = rememberCoroutineScope()
+    // Reveal-on-tap: after PIN verification the key is in `privateKeyHex` but
+    // the user must explicitly request it to be displayed on screen (#290).
+    var revealedOnScreen by remember { mutableStateOf(false) }
 
     Column(
         modifier = modifier
@@ -506,7 +560,18 @@ private fun RawKeyBackupInfo(
             }
         }
 
-        if (privateKeyHex != null) {
+        if (pinRequiredForReveal) {
+            // PIN gate: user must verify PIN before the VM fetches the key.
+            // Tapping the button navigates to PinEntryScreen; on success the
+            // savedStateHandle "pin_verified" flag flips and the VM's
+            // onPinVerified() is called from the screen's LaunchedEffect.
+            Button(
+                onClick = onRequestPinVerify,
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                Text("Reveal private key")
+            }
+        } else if (privateKeyHex != null) {
             Card(
                 colors = CardDefaults.cardColors(
                     containerColor = MaterialTheme.colorScheme.errorContainer
@@ -519,19 +584,46 @@ private fun RawKeyBackupInfo(
                         color = MaterialTheme.colorScheme.onErrorContainer
                     )
                     Spacer(Modifier.height(8.dp))
-                    val masked = privateKeyHex.take(8) + "••••••••••••••••" + privateKeyHex.takeLast(8)
+                    // Full mask by default — show only the placeholder until the
+                    // user explicitly taps to reveal. Previous behaviour showed
+                    // 16 hex chars (8 leading + 8 trailing) which is enough to
+                    // narrow a brute-force search (#290).
+                    val display = if (revealedOnScreen) privateKeyHex else "•".repeat(privateKeyHex.length)
                     Text(
-                        text = masked,
+                        text = display,
                         style = MaterialTheme.typography.bodySmall,
                         fontFamily = FontFamily.Monospace,
                         color = MaterialTheme.colorScheme.onErrorContainer
                     )
                     Spacer(Modifier.height(12.dp))
+                    TextButton(
+                        onClick = { revealedOnScreen = !revealedOnScreen },
+                        modifier = Modifier.fillMaxWidth()
+                    ) {
+                        Text(if (revealedOnScreen) "Hide" else "Tap to reveal")
+                    }
+                    Spacer(Modifier.height(4.dp))
                     Button(
                         onClick = {
                             clipboardManager.setText(androidx.compose.ui.text.AnnotatedString(privateKeyHex))
                             scope.launch {
-                                snackbarHostState.showSnackbar("Private key copied to clipboard")
+                                snackbarHostState.showSnackbar("Private key copied. Clipboard will clear in 60s.")
+                                // Clipboard timeout to match the mnemonic backup
+                                // behaviour added in #181. 60s window matches the
+                                // standard "ample to paste, short enough to limit
+                                // exposure" trade-off used elsewhere.
+                                kotlinx.coroutines.delay(60_000L)
+                                runCatching {
+                                    val cm = context.getSystemService(android.content.Context.CLIPBOARD_SERVICE)
+                                        as android.content.ClipboardManager
+                                    // Only clear if the clipboard still contains
+                                    // our key — don't blow away something the
+                                    // user copied in the meantime.
+                                    val current = cm.primaryClip?.getItemAt(0)?.text?.toString()
+                                    if (current == privateKeyHex) {
+                                        cm.setPrimaryClip(android.content.ClipData.newPlainText("", ""))
+                                    }
+                                }
                             }
                         },
                         modifier = Modifier.fillMaxWidth()

--- a/android/app/src/test/java/com/rjnr/pocketnode/ui/screens/onboarding/MnemonicBackupViewModelTest.kt
+++ b/android/app/src/test/java/com/rjnr/pocketnode/ui/screens/onboarding/MnemonicBackupViewModelTest.kt
@@ -1,0 +1,167 @@
+package com.rjnr.pocketnode.ui.screens.onboarding
+
+import com.rjnr.pocketnode.data.auth.PinManager
+import com.rjnr.pocketnode.data.database.entity.WalletEntity
+import com.rjnr.pocketnode.data.gateway.GatewayRepository
+import com.rjnr.pocketnode.data.wallet.WalletRepository
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * Tests for [MnemonicBackupViewModel] PIN gate on the raw-key backup path
+ * (#290). Pre-#290, `loadMnemonic` fetched the private key directly in
+ * the VM's `init` block — anyone navigating to MnemonicBackupScreen for a
+ * raw_key wallet from Settings could see the key with no re-auth. The fix
+ * defers the fetch behind a `pinRequiredForPrivateKey` UI flag that the
+ * screen surfaces as a "Reveal private key" button gated by
+ * [PinEntryScreen] verification.
+ *
+ * The onboarding path (raw_key import before PIN setup) is unchanged: when
+ * `PinManager.hasPin() == false`, the key is fetched directly so the user
+ * can complete the simplified backup flow.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class MnemonicBackupViewModelTest {
+
+    private val testDispatcher = StandardTestDispatcher()
+    private lateinit var repository: GatewayRepository
+    private lateinit var walletRepository: WalletRepository
+    private lateinit var pinManager: PinManager
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(testDispatcher)
+        repository = mockk(relaxed = true)
+        walletRepository = mockk(relaxed = true)
+        pinManager = mockk(relaxed = true)
+    }
+
+    @After
+    fun tearDown() { Dispatchers.resetMain() }
+
+    private fun rawKeyEntity() = mockk<WalletEntity>(relaxed = true).also {
+        every { it.type } returns "raw_key"
+        every { it.parentWalletId } returns null
+    }
+
+    @Test
+    fun `raw_key wallet with PIN does not fetch private key until onPinVerified`() = runTest {
+        coEvery { walletRepository.getActive() } returns rawKeyEntity()
+        coEvery { repository.getMnemonic() } returns null  // raw_key has no mnemonic
+        every { pinManager.hasPin() } returns true
+
+        val vm = MnemonicBackupViewModel(repository, walletRepository, pinManager)
+        advanceUntilIdle()
+
+        // Pre-PIN: gate is set, private key NOT fetched.
+        coVerify(exactly = 0) { repository.getPrivateKey() }
+        val pre = vm.uiState.value
+        assertTrue("PIN must be required", pre.pinRequiredForPrivateKey)
+        assertNull(pre.privateKeyHex)
+        assertFalse(pre.privateKeyRevealed)
+
+        // After PIN verify → the screen calls onPinVerified() and the key is fetched.
+        coEvery { repository.getPrivateKey() } returns byteArrayOf(0xaa.toByte(), 0xbb.toByte())
+        vm.onPinVerified()
+        advanceUntilIdle()
+
+        coVerify(exactly = 1) { repository.getPrivateKey() }
+        val post = vm.uiState.value
+        assertEquals("aabb", post.privateKeyHex)
+        assertTrue(post.privateKeyRevealed)
+    }
+
+    @Test
+    fun `raw_key wallet WITHOUT PIN fetches private key directly (onboarding path)`() = runTest {
+        // Pre-PIN-setup edge case: a raw-key import shown its backup screen
+        // before the user has set a PIN. Same UX as pre-#290.
+        coEvery { walletRepository.getActive() } returns rawKeyEntity()
+        coEvery { repository.getMnemonic() } returns null
+        every { pinManager.hasPin() } returns false
+        coEvery { repository.getPrivateKey() } returns byteArrayOf(0xcc.toByte(), 0xdd.toByte())
+
+        val vm = MnemonicBackupViewModel(repository, walletRepository, pinManager)
+        advanceUntilIdle()
+
+        coVerify(exactly = 1) { repository.getPrivateKey() }
+        val state = vm.uiState.value
+        assertFalse(state.pinRequiredForPrivateKey)
+        assertEquals("ccdd", state.privateKeyHex)
+        assertTrue(state.privateKeyRevealed)
+    }
+
+    @Test
+    fun `mnemonic wallet does not trigger the raw-key PIN gate`() = runTest {
+        val mnemonicEntity = mockk<WalletEntity>(relaxed = true).also {
+            every { it.type } returns "mnemonic"
+            every { it.parentWalletId } returns null
+        }
+        coEvery { walletRepository.getActive() } returns mnemonicEntity
+        coEvery { repository.getMnemonic() } returns listOf(
+            "abandon", "abandon", "abandon", "abandon", "abandon", "abandon",
+            "abandon", "abandon", "abandon", "abandon", "abandon", "about"
+        )
+        every { pinManager.hasPin() } returns true
+
+        val vm = MnemonicBackupViewModel(repository, walletRepository, pinManager)
+        advanceUntilIdle()
+
+        coVerify(exactly = 0) { repository.getPrivateKey() }
+        val state = vm.uiState.value
+        assertFalse(state.pinRequiredForPrivateKey)
+        assertEquals(12, state.words.size)
+    }
+
+    @Test
+    fun `sub-account wallet does not trigger the raw-key PIN gate`() = runTest {
+        val sub = mockk<WalletEntity>(relaxed = true).also {
+            every { it.type } returns "raw_key"
+            every { it.parentWalletId } returns "parent-id"
+        }
+        coEvery { walletRepository.getActive() } returns sub
+        coEvery { repository.getMnemonic() } returns null
+        every { pinManager.hasPin() } returns true
+
+        val vm = MnemonicBackupViewModel(repository, walletRepository, pinManager)
+        advanceUntilIdle()
+
+        coVerify(exactly = 0) { repository.getPrivateKey() }
+        val state = vm.uiState.value
+        assertFalse(state.pinRequiredForPrivateKey)
+        assertTrue(state.isSubAccount)
+    }
+
+    @Test
+    fun `onPinVerified is a no-op when PIN gate is not active`() = runTest {
+        coEvery { walletRepository.getActive() } returns rawKeyEntity()
+        coEvery { repository.getMnemonic() } returns null
+        every { pinManager.hasPin() } returns false  // no gate
+        coEvery { repository.getPrivateKey() } returns byteArrayOf(0x01)
+
+        val vm = MnemonicBackupViewModel(repository, walletRepository, pinManager)
+        advanceUntilIdle()
+        // One fetch from init (no-PIN path).
+        coVerify(exactly = 1) { repository.getPrivateKey() }
+
+        vm.onPinVerified()
+        advanceUntilIdle()
+        // No second fetch — gate isn't active.
+        coVerify(exactly = 1) { repository.getPrivateKey() }
+    }
+}


### PR DESCRIPTION
## Summary

Codex security review #290. Pre-fix: navigating to MnemonicBackupScreen for a raw_key wallet on a PIN-protected install fetched the private key in the VM's \`init\`, displayed 16 hex chars of partial reveal, and copied the full key to the system clipboard with no timeout. No PIN gate.

Three changes:

1. **PIN gate** — VM defers \`getPrivateKey()\` behind a \`pinRequiredForPrivateKey\` flag when raw_key + non-sub-account + \`PinManager.hasPin()\`. Screen renders "Reveal private key" → \`PinEntryScreen\` → on success the savedStateHandle \`pin_verified\` flag flips and \`onPinVerified()\` fetches the key. NavGraph adds \`Screen.MnemonicBackup\` to PinEntry's verify-mode previous-route allow-list. Onboarding edge case (raw_key import pre-PIN-setup) is preserved with no gate.
2. **Mask + reveal-on-tap** — full-length \`•\` placeholder by default; "Tap to reveal" / "Hide" toggle. Replaces the previous 8-leading + 8-trailing partial leak.
3. **Clipboard timeout** — Copy schedules a 60 s coroutine that clears the clipboard if it still contains the key. Matches the mnemonic backup behaviour from #181.

## Tests

\`MnemonicBackupViewModelTest\` (MockK, no Robolectric) pins:
- raw_key + hasPin → no fetch in init, gate active.
- After \`onPinVerified()\` → exactly one fetch, key revealed.
- raw_key + !hasPin (onboarding) → direct fetch.
- mnemonic + sub-account paths do not engage the gate.
- \`onPinVerified()\` is a no-op when the gate isn't active.

Full \`:app:testDebugUnitTest\` green.

## Test plan

- [x] Unit tests green.
- [ ] Upgrade-smoke (auto).
- [ ] Manual: Settings → Backup Wallet on a raw_key wallet → "Reveal private key" button → PIN entry → key shown masked → "Tap to reveal" → key visible → Copy → snackbar with timeout note → wait 60s → paste returns empty (or whatever was copied in the meantime, if it was overwritten).
- [ ] Manual: raw_key import flow before PIN setup → backup screen shows key directly (no gate).

## Notes

FLAG_SECURE was already applied to the screen pre-#290 — not changed.

Closes #290.