### PR TITLE
fix(onboarding): restore software-only fallback for users without a device lock (#289 follow-up)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -129,6 +129,12 @@ jobs:
           KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
           KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
           KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
+          # Embedded at build time and read by UpdateDownloader.verifyApkSignature
+          # before launching the system installer (#293). The release APK refuses
+          # to install any update whose signing-cert SHA-256 does not match this
+          # value, blocking URL-substitution + same-key release-channel-compromise
+          # attacks at the in-app updater boundary.
+          RELEASE_CERT_SHA256: ${{ secrets.RELEASE_CERT_SHA256 }}
         run: ./gradlew assembleRelease -x cargoBuild
 
       - name: Verify native library is packaged

--- a/android/app/src/main/java/com/rjnr/pocketnode/data/migration/KeystoreV2MigrationRunner.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/migration/KeystoreV2MigrationRunner.kt
@@ -151,6 +151,39 @@ class KeystoreV2MigrationRunner @Inject constructor(
                 Log.w(TAG, "KeyPermanentlyInvalidatedException for $walletId; recording, continuing", e)
                 failedWalletIds += walletId
                 continue
+            } catch (e: java.security.InvalidAlgorithmParameterException) {
+                // Android Keystore wraps "Secure lock screen must be enabled to create
+                // keys requiring user authentication" inside InvalidAlgorithmParameterException
+                // when getOrCreateKeystoreKeyV2 fires keyGen.init. Session-fatal: the next
+                // wallet's newEncryptCipherV2 will throw the same. AuthViewModel.runMigrationIfNeeded
+                // pre-checks for credential availability and skips the runner in this case, but
+                // a race (user removed the device lock between check and runMigration) could
+                // still land us here. Abort the run rather than crashing the host process.
+                val cause = e.cause as? IllegalStateException
+                if (cause?.message?.contains("Secure lock screen", ignoreCase = true) == true) {
+                    val remaining = pending.size - pending.indexOf(walletId)
+                    Log.w(TAG, "No secure lock on device; aborting V2 migration with $remaining wallets untouched", e)
+                    return Outcome.Failed(
+                        pendingCount = failedWalletIds.size + remaining,
+                        failedWalletIds = failedWalletIds.toList(),
+                        reason = "Device lock removed mid-run; re-enable in Android Settings and retry"
+                    )
+                }
+                throw e
+            } catch (e: IllegalStateException) {
+                // Same Keystore "Secure lock screen" path on devices/SDKs where the
+                // exception isn't wrapped in InvalidAlgorithmParameterException.
+                // (Observed on API 33 Pixel emulator during v1.7.3 testing.)
+                if (e.message?.contains("Secure lock screen", ignoreCase = true) == true) {
+                    val remaining = pending.size - pending.indexOf(walletId)
+                    Log.w(TAG, "No secure lock on device; aborting V2 migration with $remaining wallets untouched", e)
+                    return Outcome.Failed(
+                        pendingCount = failedWalletIds.size + remaining,
+                        failedWalletIds = failedWalletIds.toList(),
+                        reason = "Device lock removed mid-run; re-enable in Android Settings and retry"
+                    )
+                }
+                throw e
             }
         }
 

--- a/android/app/src/main/java/com/rjnr/pocketnode/data/transaction/TransactionBuilder.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/transaction/TransactionBuilder.kt
@@ -188,11 +188,14 @@ class TransactionBuilder @Inject constructor(
                 // different amount that allows for a valid change output, OR
                 // send the full balance minus fee (which yields an exact fit
                 // with no change output at all).
-                val changeCkb = change / 100_000_000.0
+                val changeCkbStr = java.math.BigDecimal(change)
+                    .divide(java.math.BigDecimal(100_000_000))
+                    .stripTrailingZeros()
+                    .toPlainString()
                 val minCkb = MIN_CELL_CAPACITY / 100_000_000
-                Log.w(TAG, "  Dust change refused: $change shannons (${"%.4f".format(changeCkb)} CKB) below min $MIN_CELL_CAPACITY")
+                Log.w(TAG, "  Dust change refused: $change shannons ($changeCkbStr CKB) below min $MIN_CELL_CAPACITY")
                 throw IllegalStateException(
-                    "Dust change refused: this send would leave ${"%.4f".format(changeCkb)} CKB of change " +
+                    "Dust change refused: this send would leave $changeCkbStr CKB of change " +
                         "below the $minCkb CKB minimum cell capacity, which would be silently absorbed as " +
                         "transaction fee. Try sending a slightly different amount or sending your full balance " +
                         "minus the fee."
@@ -278,11 +281,17 @@ class TransactionBuilder @Inject constructor(
                 outputs.add(CellOutput(capacity = "0x${change.toString(16)}", lock = senderScript))
                 outputsData.add("0x")
             }
-            else -> throw IllegalStateException(
-                "Dust change refused: this DAO deposit would leave ${"%.4f".format(change / 100_000_000.0)} CKB " +
-                    "below the ${MIN_CELL_CAPACITY / 100_000_000} CKB minimum, which would be silently absorbed " +
-                    "as transaction fee. Adjust the deposit amount and retry."
-            )
+            else -> {
+                val changeCkbStr = java.math.BigDecimal(change)
+                    .divide(java.math.BigDecimal(100_000_000))
+                    .stripTrailingZeros()
+                    .toPlainString()
+                throw IllegalStateException(
+                    "Dust change refused: this DAO deposit would leave $changeCkbStr CKB " +
+                        "below the ${MIN_CELL_CAPACITY / 100_000_000} CKB minimum, which would be silently absorbed " +
+                        "as transaction fee. Adjust the deposit amount and retry."
+                )
+            }
         }
 
         val secp256k1Dep = when (network) {
@@ -352,11 +361,17 @@ class TransactionBuilder @Inject constructor(
                 outputs.add(CellOutput(capacity = "0x${change.toString(16)}", lock = senderScript))
                 outputsData.add("0x")
             }
-            else -> throw IllegalStateException(
-                "Dust change refused: this DAO withdraw would leave ${"%.4f".format(change / 100_000_000.0)} CKB " +
-                    "below the ${MIN_CELL_CAPACITY / 100_000_000} CKB minimum, which would be silently absorbed " +
-                    "as transaction fee. Use a wallet cell with a slightly different capacity to cover the fee."
-            )
+            else -> {
+                val changeCkbStr = java.math.BigDecimal(change)
+                    .divide(java.math.BigDecimal(100_000_000))
+                    .stripTrailingZeros()
+                    .toPlainString()
+                throw IllegalStateException(
+                    "Dust change refused: this DAO withdraw would leave $changeCkbStr CKB " +
+                        "below the ${MIN_CELL_CAPACITY / 100_000_000} CKB minimum, which would be silently absorbed " +
+                        "as transaction fee. Use a wallet cell with a slightly different capacity to cover the fee."
+                )
+            }
         }
 
         val secp256k1Dep = when (network) {

--- a/android/app/src/main/java/com/rjnr/pocketnode/data/wallet/WalletKeyReader.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/wallet/WalletKeyReader.kt
@@ -146,6 +146,18 @@ class WalletKeyReader @Inject constructor(
         } catch (e: KeyPermanentlyInvalidatedException) {
             Log.w(TAG, "V2 key invalidated by biometric enrollment change for $walletId")
             return MaterialResult.KeyInvalidated
+        } catch (e: IllegalStateException) {
+            // Android Keystore throws this when getOrCreateKeystoreKeyV2 is
+            // asked to mint a key on a device with no secure lock. Should
+            // not normally happen on the V2 read side — the V2 key exists
+            // already if a V2 row was ever written. Defensive catch so a
+            // post-restore or post-keystore-wipe state degrades to
+            // KeyInvalidated (re-import recovery) instead of crashing.
+            if (e.message?.contains("Secure lock screen", ignoreCase = true) == true) {
+                Log.w(TAG, "V2 key missing and cannot be recreated (no secure lock) for $walletId", e)
+                return MaterialResult.KeyInvalidated
+            }
+            throw e
         }
         val authResult = authManager.authenticateForCipher(
             activity = activity,
@@ -197,6 +209,14 @@ class WalletKeyReader @Inject constructor(
             // re-import flow to the user.
             Log.w(TAG, "V2 key invalidated by biometric enrollment change for $walletId")
             return Result.KeyInvalidated
+        } catch (e: IllegalStateException) {
+            // Defense in depth: V2 key missing AND no secure lock to
+            // recreate it. Same degraded path as KPIE — re-import recovers.
+            if (e.message?.contains("Secure lock screen", ignoreCase = true) == true) {
+                Log.w(TAG, "V2 key missing and cannot be recreated (no secure lock) for $walletId", e)
+                return Result.KeyInvalidated
+            }
+            throw e
         }
         val authResult = authManager.authenticateForCipher(
             activity = activity,

--- a/android/app/src/main/java/com/rjnr/pocketnode/data/wallet/WalletKeyWriter.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/wallet/WalletKeyWriter.kt
@@ -6,6 +6,7 @@ import androidx.fragment.app.FragmentActivity
 import com.rjnr.pocketnode.data.auth.AuthManager
 import com.rjnr.pocketnode.data.crypto.KeystoreEncryptionManager
 import com.rjnr.pocketnode.data.database.dao.KeyMaterialDao
+import com.rjnr.pocketnode.data.migration.KeyStoreMigrationHelper
 import com.rjnr.pocketnode.data.migration.KeystoreV2MigrationHelper
 import com.rjnr.pocketnode.data.migration.WalletKeyBundle
 import java.util.Arrays
@@ -32,6 +33,7 @@ import kotlinx.coroutines.withContext
 class WalletKeyWriter @Inject constructor(
     private val keyMaterialDao: KeyMaterialDao,
     private val keystoreV2MigrationHelper: KeystoreV2MigrationHelper,
+    private val keyStoreMigrationHelper: KeyStoreMigrationHelper,
     private val encryptionManager: KeystoreEncryptionManager,
     private val authManager: AuthManager,
     private val keyBackupManager: KeyBackupManager,
@@ -48,6 +50,14 @@ class WalletKeyWriter @Inject constructor(
          */
         object KeyInvalidated : Result()
         data class WriteFailed(val cause: Throwable) : Result()
+        /**
+         * V2 Keystore key cannot be created because the device has no
+         * biometric enrollment AND no device PIN/pattern/password. The
+         * onboarding screen should gate on this before reaching the writer
+         * but the result is here as defense-in-depth. Caller surfaces a
+         * dialog directing the user to Android Settings → Security.
+         */
+        object NoSecureLock : Result()
     }
 
     /**
@@ -97,6 +107,20 @@ class WalletKeyWriter @Inject constructor(
         } catch (e: KeyPermanentlyInvalidatedException) {
             Log.w(TAG, "V2 key invalidated when generating cipher for $walletId", e)
             return Result.KeyInvalidated
+        } catch (e: IllegalStateException) {
+            // Android Keystore throws IllegalStateException("Secure lock
+            // screen must be enabled to create keys requiring user
+            // authentication") when the V2 key (setUserAuthenticationRequired
+            // = true) is asked to generate on a device with no biometric
+            // enrolled AND no device PIN/pattern/password. The onboarding
+            // screen gates on this state, but a race (or a third-party
+            // entry point) could still reach here. Surface a typed result
+            // instead of letting the raw exception bubble up as a toast.
+            if (e.message?.contains("Secure lock screen", ignoreCase = true) == true) {
+                Log.w(TAG, "V2 key creation refused: no secure lock on device", e)
+                return Result.NoSecureLock
+            }
+            throw e
         }
 
         val authResult = authManager.authenticateForCipher(
@@ -164,6 +188,49 @@ class WalletKeyWriter @Inject constructor(
 
                     Result.Success
                 }
+            }
+        }
+    }
+
+    /**
+     * Write a new wallet at kdfVersion=1 (software-only encryption, no
+     * BiometricPrompt) for users whose device has no biometric AND no
+     * device PIN/pattern/password set. The Android Keystore refuses to
+     * mint the V2 key in that environment ("Secure lock screen must be
+     * enabled..."), so [persistNewWallet] would otherwise hard-fail and
+     * lock these users out of the app entirely.
+     *
+     * The wallet row is identical to the legacy v1.6.x format: V1 row at
+     * `kdfVersion=1`, encrypted under the unrestricted Keystore key. The
+     * existing AuthScreen migration loop in [AuthViewModel] will pick up
+     * the row and upgrade it to V2 the moment the user enables a device
+     * lock and cold-starts the app.
+     *
+     * Callers gate on [AuthManager.hasDeviceCredential] / biometric
+     * enrollment and pick this method when neither is available; the
+     * Onboarding/MnemonicImport screens surface a "Continue without a
+     * device lock?" dialog with informed-consent copy.
+     */
+    suspend fun persistNewWalletV1Fallback(
+        walletId: String,
+        bundle: WalletKeyBundle,
+        walletType: String,
+        mnemonicBackedUp: Boolean,
+    ): Result {
+        return withContext(NonCancellable) {
+            try {
+                keyStoreMigrationHelper.migrateWallet(
+                    walletId = walletId,
+                    privateKeyHex = bundle.privateKeyHex,
+                    mnemonic = bundle.mnemonic,
+                    walletType = walletType,
+                    mnemonicBackedUp = mnemonicBackedUp,
+                )
+                Log.i(TAG, "Wrote new V1 wallet row for $walletId (no device credential)")
+                Result.Success
+            } catch (e: Throwable) {
+                Log.e(TAG, "V1 fallback write failed for $walletId", e)
+                Result.WriteFailed(e)
             }
         }
     }

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/navigation/NavGraph.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/navigation/NavGraph.kt
@@ -189,7 +189,7 @@ fun CkbNavGraph(
             )
         }
 
-        composable(Screen.Auth.route) {
+        composable(Screen.Auth.route) { backStackEntry ->
             AuthScreen(
                 onAuthSuccess = {
                     navController.navigate(destinationAfterWalletReady()) {
@@ -198,7 +198,8 @@ fun CkbNavGraph(
                 },
                 onNavigateToPinVerify = {
                     navController.navigate(Screen.PinEntry.createRoute("verify"))
-                }
+                },
+                pinUnlockFlow = backStackEntry.savedStateHandle,
             )
         }
 
@@ -281,6 +282,22 @@ fun CkbNavGraph(
                                     navController.previousBackStackEntry
                                         ?.savedStateHandle
                                         ?.set("pin_verified", true)
+                                    navController.popBackStack()
+                                }
+                                previousRoute == Screen.Auth.route -> {
+                                    // User unlocked via PIN from AuthScreen. Pop back
+                                    // to AuthScreen and signal success via savedStateHandle
+                                    // so the AuthScreen LaunchedEffect can flip
+                                    // `authSuccess` and trigger `runMigrationIfNeeded`.
+                                    // Without this hook the V1→V2 migration loop was
+                                    // silently dead for every PIN-only user (#289
+                                    // follow-up bug found during v1.7.3 testing —
+                                    // pre-fix the previous route's `else` branch
+                                    // navigated straight to Screen.Main and popped
+                                    // AuthScreen, so its LaunchedEffect never fired).
+                                    navController.previousBackStackEntry
+                                        ?.savedStateHandle
+                                        ?.set("pin_unlock_success", true)
                                     navController.popBackStack()
                                 }
                                 else -> {

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/auth/AuthScreen.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/auth/AuthScreen.kt
@@ -40,11 +40,25 @@ import androidx.hilt.navigation.compose.hiltViewModel
 fun AuthScreen(
     onAuthSuccess: () -> Unit = {},
     onNavigateToPinVerify: () -> Unit = {},
+    pinUnlockFlow: androidx.lifecycle.SavedStateHandle? = null,
     viewModel: AuthViewModel = hiltViewModel()
 ) {
     val uiState by viewModel.uiState.collectAsState()
     val snackbarHostState = remember { SnackbarHostState() }
     val context = LocalContext.current
+
+    // Returning from PinEntryScreen via the verify-mode pop-back path.
+    // NavGraph sets pin_unlock_success=true on AuthScreen's savedStateHandle
+    // when previousRoute was Auth, so we mirror the biometric-success
+    // entrypoint and flip the VM state — that wakes the migration loop
+    // [LaunchedEffect(uiState.authSuccess)] below (#289 follow-up).
+    LaunchedEffect(pinUnlockFlow) {
+        val ok = pinUnlockFlow?.get<Boolean>("pin_unlock_success") == true
+        if (ok) {
+            pinUnlockFlow.remove<Boolean>("pin_unlock_success")
+            viewModel.onPinUnlockSuccess()
+        }
+    }
 
     // Capture localized strings now — the prompt builder runs from a
     // non-@Composable callback site, which can't call stringResource().

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/auth/AuthViewModel.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/auth/AuthViewModel.kt
@@ -97,6 +97,24 @@ class AuthViewModel @Inject constructor(
             // written after the prefs flag was set. `pendingWalletIds()` is now the
             // sole source of truth and is safe to call cheaply on every unlock.
             val pending = migrationHelper.pendingWalletIds()
+            if (pending.isNotEmpty() &&
+                !authManager.isBiometricEnrolled() &&
+                !authManager.hasDeviceCredential()
+            ) {
+                // V1 row(s) exist but the device has no secure lock — the V2
+                // Keystore key cannot be minted (Android throws
+                // IllegalStateException("Secure lock screen must be enabled...")
+                // from KeyStore2ParameterUtils.getRootSid). Skip the runner;
+                // the migration will succeed automatically the next time the
+                // user enables a device lock and cold-starts. Without this
+                // gate the runner crashes the app on every unlock — found
+                // during v1.7.3 testing after importing a wallet via the
+                // V1 fallback path and switching network (which force-kills
+                // the process and re-enters AuthScreen).
+                Log.i(TAG, "Skipping V1→V2 migration: ${pending.size} pending but no device credential")
+                onComplete()
+                return@launch
+            }
             if (pending.isEmpty()) {
                 // Empty DB (fresh install on v1.7.0) — finalize to mark
                 // the migration complete so future starts don't re-check.

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/auth/AuthViewModel.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/auth/AuthViewModel.kt
@@ -56,6 +56,19 @@ class AuthViewModel @Inject constructor(
         _uiState.update { it.copy(authSuccess = true) }
     }
 
+    /**
+     * Called by [com.rjnr.pocketnode.ui.screens.auth.AuthScreen] when the
+     * user returns from [PinEntryScreen] with a successful PIN verify.
+     * Mirrors [onBiometricSuccess] — both unlock paths must end here so
+     * the AuthScreen `LaunchedEffect(authSuccess)` fires
+     * [runMigrationIfNeeded]. Without this hook the V1→V2 migration loop
+     * was silently dead for any user who didn't use biometric (#289
+     * follow-up bug found during v1.7.3 testing).
+     */
+    fun onPinUnlockSuccess() {
+        _uiState.update { it.copy(authSuccess = true) }
+    }
+
     fun onBiometricFailed(errorMessage: String) {
         _uiState.update { it.copy(error = UiMessage.Raw(errorMessage)) }
     }

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/onboarding/MnemonicBackupScreen.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/onboarding/MnemonicBackupScreen.kt
@@ -55,6 +55,15 @@ data class MnemonicBackupUiState(
     val pinRequiredForPrivateKey: Boolean = false,
     /** True once the user has revealed the private key in this session. */
     val privateKeyRevealed: Boolean = false,
+    /**
+     * True when a V2 mnemonic wallet's recovery phrase is gated behind
+     * PIN entry. The screen renders a "Reveal recovery phrase" button
+     * that routes through [PinEntryScreen]; on return we fetch via
+     * `WalletKeyReader` and populate [words]. False when the wallet is
+     * V1 (legacy/no-device-lock fallback) and `repository.getMnemonic()`
+     * succeeded directly.
+     */
+    val pinRequiredForMnemonic: Boolean = false,
 )
 
 @HiltViewModel
@@ -62,6 +71,7 @@ class MnemonicBackupViewModel @Inject constructor(
     private val repository: GatewayRepository,
     private val walletRepository: com.rjnr.pocketnode.data.wallet.WalletRepository,
     private val pinManager: com.rjnr.pocketnode.data.auth.PinManager,
+    private val walletKeyReader: com.rjnr.pocketnode.data.wallet.WalletKeyReader,
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow(MnemonicBackupUiState())
@@ -79,7 +89,20 @@ class MnemonicBackupViewModel @Inject constructor(
             val isSubAccount = activeWallet?.parentWalletId != null
             _uiState.update { it.copy(walletType = walletType, isSubAccount = isSubAccount) }
 
-            val words = repository.getMnemonic()
+            // V2 wallets (kdfVersion=2) cannot decrypt without an authenticated
+            // Cipher. repository.getMnemonic() routes through the V1-only read
+            // path and throws V2KeyMaterialRequiresAuthException, which would
+            // crash the app on every cold start for a freshly-created V2
+            // mnemonic wallet that hasn't been backed up yet. Catch and gate
+            // behind reveal-on-tap: the screen renders a "Reveal recovery
+            // phrase" button that routes through PinEntryScreen, and on PIN
+            // verify we fetch the words via WalletKeyReader (#289 follow-up).
+            val words = try {
+                repository.getMnemonic()
+            } catch (e: com.rjnr.pocketnode.data.migration.V2KeyMaterialRequiresAuthException) {
+                _uiState.update { it.copy(pinRequiredForMnemonic = true) }
+                return@launch
+            }
             if (words.isNullOrEmpty()) {
                 // For raw_key or sub-account wallets, this is expected — not an error.
                 // Only raw-key wallets need the private key for the dedicated raw-key
@@ -113,6 +136,69 @@ class MnemonicBackupViewModel @Inject constructor(
             }
             _uiState.update {
                 it.copy(words = words, verifyPositions = positions, verifyOptions = options)
+            }
+        }
+    }
+
+    /**
+     * Called from [MnemonicBackupScreen] when the user taps the
+     * "Reveal recovery phrase" button on a V2 mnemonic wallet. Drives a
+     * BiometricPrompt via [WalletKeyReader] (no PinEntryScreen detour —
+     * the V2 key is the gate). On success the words are populated and
+     * the standard verify+confirm flow continues.
+     */
+    fun revealMnemonicForV2(activity: androidx.fragment.app.FragmentActivity) {
+        if (!_uiState.value.pinRequiredForMnemonic) return
+        viewModelScope.launch {
+            val active = walletRepository.getActive() ?: return@launch
+            val result = walletKeyReader.readKeyMaterial(
+                activity = activity,
+                walletId = active.walletId,
+                promptTitle = "Reveal recovery phrase",
+                promptSubtitle = "Authenticate to view your wallet's seed phrase.",
+            )
+            when (result) {
+                is com.rjnr.pocketnode.data.wallet.WalletKeyReader.MaterialResult.Success -> {
+                    val mnemonic = result.mnemonic
+                    if (mnemonic.isNullOrBlank()) {
+                        _uiState.update { it.copy(error = "Recovery phrase not available for this wallet.") }
+                        return@launch
+                    }
+                    val words = mnemonic.split(" ")
+                    val random = java.util.Random(System.nanoTime())
+                    val positions = words.indices.toList().shuffled(random).take(3).sorted()
+                    val options = positions.associateWith { pos ->
+                        val correct = words[pos]
+                        val decoys = words.filterIndexed { i, _ -> i != pos }
+                            .distinct()
+                            .filter { it != correct }
+                            .shuffled(random)
+                            .take(3)
+                        val choices = mutableListOf(correct).apply { addAll(decoys) }
+                        choices.apply { shuffle(random) }.toList()
+                    }
+                    _uiState.update {
+                        it.copy(
+                            words = words,
+                            verifyPositions = positions,
+                            verifyOptions = options,
+                            pinRequiredForMnemonic = false,
+                        )
+                    }
+                }
+                is com.rjnr.pocketnode.data.wallet.WalletKeyReader.MaterialResult.Cancelled -> {
+                    // Silent — user dismissed the prompt; the reveal button
+                    // stays visible so they can retry.
+                }
+                is com.rjnr.pocketnode.data.wallet.WalletKeyReader.MaterialResult.AuthError -> {
+                    _uiState.update { it.copy(error = "Authentication error: ${result.message}") }
+                }
+                is com.rjnr.pocketnode.data.wallet.WalletKeyReader.MaterialResult.KeyInvalidated -> {
+                    _uiState.update { it.copy(error = "Your device's biometric enrollment changed and your wallet key was wiped. Re-import from your recovery phrase to recover.") }
+                }
+                is com.rjnr.pocketnode.data.wallet.WalletKeyReader.MaterialResult.NotAvailable -> {
+                    _uiState.update { it.copy(error = "Recovery phrase not available: ${result.reason}") }
+                }
             }
         }
     }
@@ -188,6 +274,7 @@ fun MnemonicBackupScreen(
 ) {
     val uiState by viewModel.uiState.collectAsState()
     val snackbarHostState = remember { SnackbarHostState() }
+    val activity = androidx.compose.ui.platform.LocalContext.current as androidx.fragment.app.FragmentActivity
 
     // Returning from PinEntryScreen: consume the pin_verified flag set by
     // the verify-mode pop-back path (NavGraph route). On true, fetch the
@@ -267,6 +354,14 @@ fun MnemonicBackupScreen(
                     modifier = Modifier.padding(padding)
                 )
             }
+            // V2 wallet whose mnemonic needs a BiometricPrompt before reveal (#289 follow-up).
+            uiState.pinRequiredForMnemonic -> {
+                MnemonicRevealGate(
+                    onReveal = { viewModel.revealMnemonicForV2(activity) },
+                    error = uiState.error,
+                    modifier = Modifier.padding(padding)
+                )
+            }
             // Simplified mode (post-creation)
             simplified -> {
                 MnemonicDisplayStep(
@@ -301,6 +396,61 @@ fun MnemonicBackupScreen(
                     )
                 }
             }
+        }
+    }
+}
+
+/**
+ * Pre-reveal gate shown for V2 mnemonic wallets: the wallet's recovery
+ * phrase lives behind an authenticated Cipher and cannot be decrypted
+ * silently in the VM's `init` like a V1 wallet's can. The user taps the
+ * button, BiometricPrompt fires (managed by `WalletKeyReader`), and on
+ * success the standard verify+confirm flow renders (#289 follow-up).
+ */
+@Composable
+private fun MnemonicRevealGate(
+    onReveal: () -> Unit,
+    error: String?,
+    modifier: Modifier = Modifier
+) {
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .padding(24.dp),
+        verticalArrangement = Arrangement.spacedBy(16.dp)
+    ) {
+        Card(
+            colors = CardDefaults.cardColors(
+                containerColor = MaterialTheme.colorScheme.surfaceVariant
+            )
+        ) {
+            Column(modifier = Modifier.padding(16.dp)) {
+                Text(
+                    text = "Your recovery phrase is the only way to restore this wallet on another device.",
+                    style = MaterialTheme.typography.bodyMedium,
+                )
+                Spacer(Modifier.height(8.dp))
+                Text(
+                    text = "Tap below and authenticate to view the 12 words. Write them down somewhere safe — we cannot recover them for you.",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+        }
+
+        Button(
+            onClick = onReveal,
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            Text("Reveal recovery phrase")
+        }
+
+        if (!error.isNullOrBlank()) {
+            Text(
+                text = error,
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.error
+            )
         }
     }
 }

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/onboarding/MnemonicImportScreen.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/onboarding/MnemonicImportScreen.kt
@@ -60,6 +60,7 @@ class MnemonicImportViewModel @Inject constructor(
     private val mnemonicManager: MnemonicManager,
     private val walletRepository: WalletRepository,
     private val walletKeyWriter: WalletKeyWriter,
+    private val authManager: com.rjnr.pocketnode.data.auth.AuthManager,
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow(MnemonicImportUiState())
@@ -130,22 +131,37 @@ class MnemonicImportViewModel @Inject constructor(
             return
         }
 
+        // Same V1 software-only fallback as OnboardingViewModel.createNewWallet.
+        // The Welcome screen surfaced an informed-consent "Continue without a
+        // device lock?" dialog before navigating here, so the user has
+        // already opted in. AuthScreen migration loop auto-upgrades the V1
+        // row to V2 when they enable a device lock later (#289 follow-up).
+        val useV1Fallback = !canCreateV2BoundKey()
         viewModelScope.launch {
             _uiState.update { it.copy(isImporting = true, error = null) }
             val result = walletRepository.importFromMnemonic(
                 words = words,
                 name = "Imported Wallet",
                 persistKeys = { walletId, bundle ->
-                    walletKeyWriter.persistNewWallet(
-                        activity = activity,
-                        walletId = walletId,
-                        bundle = bundle,
-                        walletType = KeyManager.WALLET_TYPE_MNEMONIC,
-                        // The user just typed the seed phrase in, so by definition
-                        // they hold a copy of it (or know where it is). Skip the
-                        // post-onboarding backup nag.
-                        mnemonicBackedUp = true,
-                    )
+                    if (useV1Fallback) {
+                        walletKeyWriter.persistNewWalletV1Fallback(
+                            walletId = walletId,
+                            bundle = bundle,
+                            walletType = KeyManager.WALLET_TYPE_MNEMONIC,
+                            mnemonicBackedUp = true,
+                        )
+                    } else {
+                        walletKeyWriter.persistNewWallet(
+                            activity = activity,
+                            walletId = walletId,
+                            bundle = bundle,
+                            walletType = KeyManager.WALLET_TYPE_MNEMONIC,
+                            // The user just typed the seed phrase in, so by definition
+                            // they hold a copy of it (or know where it is). Skip the
+                            // post-onboarding backup nag.
+                            mnemonicBackedUp = true,
+                        )
+                    }
                 },
             )
             result.onSuccess { entity ->
@@ -176,16 +192,26 @@ class MnemonicImportViewModel @Inject constructor(
     }
 
     fun importPrivateKey(activity: FragmentActivity, hex: String) {
+        val useV1Fallback = !canCreateV2BoundKey()
         viewModelScope.launch {
             _uiState.update { it.copy(isImporting = true, showPrivateKeyDialog = false, error = null) }
             val result = walletRepository.importRawKey(hex, "Imported Wallet") { walletId, bundle ->
-                walletKeyWriter.persistNewWallet(
-                    activity = activity,
-                    walletId = walletId,
-                    bundle = bundle,
-                    walletType = KeyManager.WALLET_TYPE_RAW_KEY,
-                    mnemonicBackedUp = false,
-                )
+                if (useV1Fallback) {
+                    walletKeyWriter.persistNewWalletV1Fallback(
+                        walletId = walletId,
+                        bundle = bundle,
+                        walletType = KeyManager.WALLET_TYPE_RAW_KEY,
+                        mnemonicBackedUp = false,
+                    )
+                } else {
+                    walletKeyWriter.persistNewWallet(
+                        activity = activity,
+                        walletId = walletId,
+                        bundle = bundle,
+                        walletType = KeyManager.WALLET_TYPE_RAW_KEY,
+                        mnemonicBackedUp = false,
+                    )
+                }
             }
             result.onSuccess { entity ->
                 Log.d(TAG, "Imported raw key wallet entity: ${entity.walletId}")
@@ -205,6 +231,15 @@ class MnemonicImportViewModel @Inject constructor(
             }
         }
     }
+
+    /**
+     * Same check as OnboardingViewModel.canCreateV2BoundKey: V2 Keystore key
+     * can only be minted on a device with an enrolled biometric OR a device
+     * lock (PIN/pattern/password). Returning false routes the import through
+     * the V1 software-only fallback.
+     */
+    private fun canCreateV2BoundKey(): Boolean =
+        authManager.isBiometricEnrolled() || authManager.hasDeviceCredential()
 
     companion object {
         /**

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/onboarding/OnboardingScreen.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/onboarding/OnboardingScreen.kt
@@ -47,6 +47,9 @@ fun OnboardingScreen(
     // Surface this as a warning the user can dismiss to continue, or
     // route them to Android Settings to enable a lock.
     var showNoDeviceLockWarning by remember { mutableStateOf(false) }
+    // Captured at click time so the dialog's "Continue anyway" knows which
+    // path to resume (Create wallet → name dialog vs Recover → import nav).
+    var pendingNoLockAction by remember { mutableStateOf<(() -> Unit)?>(null) }
 
     // After wallet creation, navigate to backup screen (not Home)
     LaunchedEffect(uiState.isWalletCreated) {
@@ -132,6 +135,7 @@ fun OnboardingScreen(
                     // lock to give the user informed-consent before
                     // landing on the name dialog. They can still proceed.
                     if (uiState.noDeviceCredential) {
+                        pendingNoLockAction = { showNameDialog = true }
                         showNoDeviceLockWarning = true
                     } else {
                         showNameDialog = true
@@ -147,7 +151,18 @@ fun OnboardingScreen(
                 title = "Recover from Seed Phrase",
                 description = "Import wallet using your 12-word recovery phrase.",
                 icon = Lucide.KeyRound,
-                onClick = onNavigateToImport,
+                onClick = {
+                    // Same V2-Keystore informed-consent gate as Create New
+                    // Wallet. The import path also writes via WalletKeyWriter
+                    // and will pick the V1 software-only fallback when the
+                    // device has no lock set.
+                    if (uiState.noDeviceCredential) {
+                        pendingNoLockAction = onNavigateToImport
+                        showNoDeviceLockWarning = true
+                    } else {
+                        onNavigateToImport()
+                    }
+                },
                 isLoading = uiState.isLoading,
                 modifier = Modifier.uaTestTag("onboarding-recover")
             )
@@ -207,17 +222,20 @@ fun OnboardingScreen(
             title = { Text("Continue without a device lock?") },
             text = {
                 Text(
-                    text = "This phone has no PIN, pattern, password, or biometric set. " +
-                        "Your wallet will still work, but the keys cannot be hardware-protected " +
-                        "until you enable a device lock in Android Settings. The app will upgrade " +
-                        "the protection automatically once you do.",
+                    text = "This phone has no PIN, pattern, password, or biometric set.\n\n" +
+                        "Your wallet will still work, but the keys will be stored in a software-only " +
+                        "encryption layer that protects against casual theft of the device but is " +
+                        "not hardware-bound to your fingerprint or PIN.\n\n" +
+                        "If you enable a device lock later, the app will upgrade your wallet to " +
+                        "hardware-backed protection automatically on the next launch.",
                     style = MaterialTheme.typography.bodyMedium,
                 )
             },
             confirmButton = {
                 TextButton(onClick = {
                     showNoDeviceLockWarning = false
-                    showNameDialog = true
+                    pendingNoLockAction?.invoke()
+                    pendingNoLockAction = null
                 }) {
                     Text("Continue anyway")
                 }
@@ -237,7 +255,10 @@ fun OnboardingScreen(
                     }) {
                         Text("Open Settings")
                     }
-                    TextButton(onClick = { showNoDeviceLockWarning = false }) {
+                    TextButton(onClick = {
+                        showNoDeviceLockWarning = false
+                        pendingNoLockAction = null
+                    }) {
                         Text("Cancel")
                     }
                 }

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/onboarding/OnboardingViewModel.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/onboarding/OnboardingViewModel.kt
@@ -77,29 +77,52 @@ class OnboardingViewModel @Inject constructor(
      * retry by tapping again.
      */
     fun createNewWallet(activity: FragmentActivity, name: String = "My Wallet") {
-        // No more hard block on missing device credential. The previous
-        // gate (introduced in #213 sub-PR 6) refused creation outright
-        // because the V2 Keystore key needs *some* credential to bind to.
-        // In practice the wallet still works without one — it stays on
-        // kdfVersion=1 until a credential is enrolled, at which point the
-        // existing AuthScreen migration runner upgrades it.
+        // Post-#289 there is no V1 write path: WalletRepository.createWallet
+        // funnels through WalletKeyWriter → KeystoreV2MigrationHelper.writeNewV2Row
+        // which mints a fresh V2 Keystore key with setUserAuthenticationRequired(true).
+        // Without an enrolled biometric or device credential, the keystore
+        // refuses the key creation with IllegalStateException("Secure lock
+        // screen must be enabled to create keys requiring user authentication").
         //
-        // The UI now shows a warning dialog (Cancel / Open Settings /
-        // Continue anyway) when noDeviceCredential is true, so the user
-        // sees an informed consent surface but is not blocked.
+        // The Screen surfaces a dialog before this fn is reached
+        // (showNoDeviceLockWarning when uiState.noDeviceCredential is true)
+        // directing the user to Android Settings → Security to enable a
+        // device lock. Defense-in-depth: the writer also catches the
+        // IllegalStateException and surfaces a friendly error here in case
+        // the device-credential state changes between the gate check and
+        // the actual key creation (#289 no-secure-lock follow-up).
         val trimmed = name.trim().ifBlank { "My Wallet" }
+        // Re-check at call time, not just at VM init — the user may have
+        // come back from Android Settings after enabling a device lock and
+        // we want to prefer V2 if they did.
+        val useV1Fallback = !canCreateV2BoundKey()
         viewModelScope.launch {
             _uiState.update { it.copy(isLoading = true, error = null) }
             val result = walletRepository.createWallet(
                 name = trimmed,
                 persistKeys = { walletId, bundle ->
-                    walletKeyWriter.persistNewWallet(
-                        activity = activity,
-                        walletId = walletId,
-                        bundle = bundle,
-                        walletType = KeyManager.WALLET_TYPE_MNEMONIC,
-                        mnemonicBackedUp = false,
-                    )
+                    if (useV1Fallback) {
+                        // Software-only V1 path. The Onboarding screen
+                        // already showed an informed-consent dialog
+                        // ("Continue without a device lock?") before we
+                        // reach this point. AuthScreen's migration loop
+                        // will upgrade the row to V2 the moment the user
+                        // enables a device lock and cold-starts the app.
+                        walletKeyWriter.persistNewWalletV1Fallback(
+                            walletId = walletId,
+                            bundle = bundle,
+                            walletType = KeyManager.WALLET_TYPE_MNEMONIC,
+                            mnemonicBackedUp = false,
+                        )
+                    } else {
+                        walletKeyWriter.persistNewWallet(
+                            activity = activity,
+                            walletId = walletId,
+                            bundle = bundle,
+                            walletType = KeyManager.WALLET_TYPE_MNEMONIC,
+                            mnemonicBackedUp = false,
+                        )
+                    }
                 },
             )
             result.onSuccess { entity ->

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/send/SendViewModel.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/send/SendViewModel.kt
@@ -265,8 +265,14 @@ class SendViewModel @Inject constructor(
         val minCapacity = 61_00000000L
 
         val warning = if (potentialChange in 1 until minCapacity) {
-            val lostCkb = potentialChange / 100_000_000.0
-            "Warning: Your remaining %.4f CKB is below the 61 CKB minimum and will be lost as a fee.".format(lostCkb)
+            // Strip trailing zeros so "50.0000" reads as "50", "50.5" stays
+            // "50.5", and a precise dust amount like "60.99999500" reads
+            // as "60.999995". Matches typical wallet UX for amounts.
+            val lostCkb = java.math.BigDecimal(potentialChange)
+                .divide(java.math.BigDecimal(100_000_000))
+                .stripTrailingZeros()
+                .toPlainString()
+            "Warning: Your remaining $lostCkb CKB is below the 61 CKB minimum and will be lost as a fee."
         } else {
             null
         }

--- a/android/app/src/test/java/com/rjnr/pocketnode/data/wallet/WalletKeyWriterTest.kt
+++ b/android/app/src/test/java/com/rjnr/pocketnode/data/wallet/WalletKeyWriterTest.kt
@@ -67,9 +67,22 @@ class WalletKeyWriterTest {
         prefs = ctx.getSharedPreferences("test_v2_writer", Context.MODE_PRIVATE)
         prefs.edit().clear().commit()
         helper = KeystoreV2MigrationHelper(keyMaterialDao, encryptionManager, prefs)
+        // KeyStoreMigrationHelper backs the V1 software-only fallback path
+        // added for users without a device lock. Tests below exercise the V2
+        // path; the V1 helper is wired but not invoked.
+        val v1Helper = com.rjnr.pocketnode.data.migration.KeyStoreMigrationHelper(
+            keyMaterialDao, encryptionManager, prefs
+        )
         authManager = mockk(relaxed = true)
         keyBackupManager = mockk(relaxed = true)
-        writer = WalletKeyWriter(keyMaterialDao, helper, encryptionManager, authManager, keyBackupManager)
+        writer = WalletKeyWriter(
+            keyMaterialDao = keyMaterialDao,
+            keystoreV2MigrationHelper = helper,
+            keyStoreMigrationHelper = v1Helper,
+            encryptionManager = encryptionManager,
+            authManager = authManager,
+            keyBackupManager = keyBackupManager,
+        )
         activity = mockk(relaxed = true)
     }
 

--- a/android/app/src/test/java/com/rjnr/pocketnode/ui/screens/onboarding/MnemonicBackupViewModelTest.kt
+++ b/android/app/src/test/java/com/rjnr/pocketnode/ui/screens/onboarding/MnemonicBackupViewModelTest.kt
@@ -43,6 +43,7 @@ class MnemonicBackupViewModelTest {
     private lateinit var repository: GatewayRepository
     private lateinit var walletRepository: WalletRepository
     private lateinit var pinManager: PinManager
+    private lateinit var walletKeyReader: com.rjnr.pocketnode.data.wallet.WalletKeyReader
 
     @Before
     fun setUp() {
@@ -50,6 +51,7 @@ class MnemonicBackupViewModelTest {
         repository = mockk(relaxed = true)
         walletRepository = mockk(relaxed = true)
         pinManager = mockk(relaxed = true)
+        walletKeyReader = mockk(relaxed = true)
     }
 
     @After
@@ -66,7 +68,7 @@ class MnemonicBackupViewModelTest {
         coEvery { repository.getMnemonic() } returns null  // raw_key has no mnemonic
         every { pinManager.hasPin() } returns true
 
-        val vm = MnemonicBackupViewModel(repository, walletRepository, pinManager)
+        val vm = MnemonicBackupViewModel(repository, walletRepository, pinManager, walletKeyReader)
         advanceUntilIdle()
 
         // Pre-PIN: gate is set, private key NOT fetched.
@@ -96,7 +98,7 @@ class MnemonicBackupViewModelTest {
         every { pinManager.hasPin() } returns false
         coEvery { repository.getPrivateKey() } returns byteArrayOf(0xcc.toByte(), 0xdd.toByte())
 
-        val vm = MnemonicBackupViewModel(repository, walletRepository, pinManager)
+        val vm = MnemonicBackupViewModel(repository, walletRepository, pinManager, walletKeyReader)
         advanceUntilIdle()
 
         coVerify(exactly = 1) { repository.getPrivateKey() }
@@ -119,7 +121,7 @@ class MnemonicBackupViewModelTest {
         )
         every { pinManager.hasPin() } returns true
 
-        val vm = MnemonicBackupViewModel(repository, walletRepository, pinManager)
+        val vm = MnemonicBackupViewModel(repository, walletRepository, pinManager, walletKeyReader)
         advanceUntilIdle()
 
         coVerify(exactly = 0) { repository.getPrivateKey() }
@@ -138,7 +140,7 @@ class MnemonicBackupViewModelTest {
         coEvery { repository.getMnemonic() } returns null
         every { pinManager.hasPin() } returns true
 
-        val vm = MnemonicBackupViewModel(repository, walletRepository, pinManager)
+        val vm = MnemonicBackupViewModel(repository, walletRepository, pinManager, walletKeyReader)
         advanceUntilIdle()
 
         coVerify(exactly = 0) { repository.getPrivateKey() }
@@ -154,7 +156,7 @@ class MnemonicBackupViewModelTest {
         every { pinManager.hasPin() } returns false  // no gate
         coEvery { repository.getPrivateKey() } returns byteArrayOf(0x01)
 
-        val vm = MnemonicBackupViewModel(repository, walletRepository, pinManager)
+        val vm = MnemonicBackupViewModel(repository, walletRepository, pinManager, walletKeyReader)
         advanceUntilIdle()
         // One fetch from init (no-PIN path).
         coVerify(exactly = 1) { repository.getPrivateKey() }


### PR DESCRIPTION
## Summary

Bug surfaced during testing of v1.7.2 on a Pixel 7 Pro emulator with no biometric and no device PIN: wallet creation flashed a raw toast \`java.lang.IllegalStateException: Secure lock screen must be enabled to create keys requiring user authentication\` and the user was locked out of the app entirely.

#289 deleted the V1 write path so every new wallet would land at \`kdfVersion=2\`. That's the right default for the majority case, but it accidentally turned the device-lock-free state into a hard block. Some users intentionally don't set a device PIN; Pocket Node ran fine without one pre-#289.

## Fix

Conditional V1 fallback for the no-device-credential case:

- New \`WalletKeyWriter.persistNewWalletV1Fallback\` delegates to the existing \`KeyStoreMigrationHelper.migrateWallet\` path (the same one \`WalletMigrationHelper\` already uses for ESP→Room legacy migration). Software-only encryption, no BiometricPrompt, no V2 Keystore key.
- \`OnboardingViewModel\` re-checks \`canCreateV2BoundKey()\` at call time and picks the V1 fallback when both biometric AND device credential are absent.
- \`OnboardingScreen\` "no device lock" dialog wording corrected — was misleading about post-#289 behaviour. Recover-from-Seed button now gates on the same dialog. Dialog routes "Continue anyway" through a captured pending action so it resumes the right path.
- \`WalletKeyWriter.persistNewWallet\` catches the keystore \`IllegalStateException\` defensively and returns \`Result.NoSecureLock\` instead of letting the raw stack trace toast through. Defense in depth.

## #289 stays closed

1. V2-Keystore default preserved for every device that can use it.
2. V1 fallback is no longer silent — explicit informed-consent dialog with corrected wording.
3. AuthViewModel migration runner (short-circuit dropped in #289) auto-upgrades the V1 row to V2 on the next cold start after the user enables a device lock. Same convergence path as a v1.6.x-upgraded V1 row.

## Test plan

- [x] Full unit test suite green.
- [ ] Upgrade-smoke (auto).
- [ ] Manual on emulator with NO device lock + NO biometric: Welcome → Create New Wallet → "Continue without a device lock?" dialog → "Continue anyway" → name dialog → wallet creates successfully. \`select walletId, kdfVersion from key_material\` returns \`kdfVersion=1\`.
- [ ] Same emulator, set device PIN in Android Settings → force-stop app → cold start. AuthScreen migration runner picks up the V1 row and prompts BiometricPrompt (device-credential fallback). On success the row flips to \`kdfVersion=2\`.
- [ ] Manual on emulator WITH device PIN: Welcome → Create New Wallet → name dialog (no warning dialog) → BiometricPrompt → wallet at \`kdfVersion=2\` directly.
- [ ] Manual Recover-from-Seed path: same dialog on no-device-lock device, "Continue anyway" navigates to import screen as expected (not to name dialog).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Software-only fallback wallet creation when device has no biometrics or lock screen.
  * PIN-gated mnemonic reveal for authenticated wallets; explicit reveal action added.
  * Onboarding “Continue anyway” now correctly resumes the pending action.
  * PIN unlock now signals migration success so PIN-only users complete migrations.

* **Bug Fixes**
  * Clearer user-facing messaging and handling when device lock prevents key operations.
  * Cleaner formatting for small-change amounts in transaction warnings/errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->