### PR TITLE
chore(ci): pass RELEASE_CERT_SHA256 env var to release build (#293 wiring)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -129,6 +129,12 @@ jobs:
           KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
           KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
           KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
+          # Embedded at build time and read by UpdateDownloader.verifyApkSignature
+          # before launching the system installer (#293). The release APK refuses
+          # to install any update whose signing-cert SHA-256 does not match this
+          # value, blocking URL-substitution + same-key release-channel-compromise
+          # attacks at the in-app updater boundary.
+          RELEASE_CERT_SHA256: ${{ secrets.RELEASE_CERT_SHA256 }}
         run: ./gradlew assembleRelease -x cargoBuild
 
       - name: Verify native library is packaged


### PR DESCRIPTION
PR #302 added the BuildConfig field and the verifier; the secret was added to the \`release-signing\` GitHub Environment just now. This commit plumbs the secret into the workflow's env block alongside the existing keystore creds.

After merge, the v1.7.3 release APK is the first to ship with the in-app updater's signature check armed. Existing v1.7.2 installs upgrading via the in-app updater will verify the downloaded APK's signing-cert SHA-256 against the embedded value before launching the system installer.

## Test plan

- [x] YAML parses (workflow file change only).
- [ ] On the next v1.7.3 release tag, build log shows the env var being read into \`BuildConfig.RELEASE_CERT_SHA256\`.
- [ ] Install resulting APK on a v1.7.2 device → trigger update flow → no \"signature check failed\" toast.