### PR TITLE
fix(update): scroll long release notes in UpdateDialog

### DIFF
--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/components/UpdateDialog.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/components/UpdateDialog.kt
@@ -1,11 +1,17 @@
 package com.rjnr.pocketnode.ui.components
 
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
 import com.rjnr.pocketnode.R
 import com.rjnr.pocketnode.data.update.UpdateInfo
 
@@ -30,14 +36,22 @@ fun UpdateDialog(
 
     val versionLine = stringResource(R.string.update_dialog_version_available, updateInfo.latestVersion)
     val notesLine = if (updateInfo.releaseNotes.isNotBlank()) {
-        "\n\n${updateInfo.releaseNotes.take(500)}"
+        "\n\n${updateInfo.releaseNotes}"
     } else ""
     val messageText = versionLine + notesLine + sizeText
 
     AlertDialog(
         onDismissRequest = onDismiss,
         title = { Text(stringResource(R.string.update_dialog_title)) },
-        text = { Text(messageText) },
+        text = {
+            Column(
+                modifier = Modifier
+                    .heightIn(max = 320.dp)
+                    .verticalScroll(rememberScrollState())
+            ) {
+                Text(messageText)
+            }
+        },
         confirmButton = {
             Button(onClick = onUpdate) {
                 Text(stringResource(R.string.update_dialog_action_update_now))


### PR DESCRIPTION
## Summary
- AlertDialog text slot had no scroll, so long release notes overflowed and got clipped (v1.7.3 notes are 7 paragraphs).
- Wrapped Text in a `verticalScroll` Column capped at `320.dp`.
- Dropped the `.take(500)` truncation now that the body can scroll.

## Test plan
- [ ] Trigger UpdateDialog on a stale build (v1.7.2) pointing at v1.7.3 release notes — body scrolls, no clipped lines.
- [ ] Short-notes case (e.g. one-line release) renders at natural height, no awkward whitespace.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Update dialogs now display full release notes instead of truncating them.
  * Longer release notes are scrollable within the update dialog for better readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->