### PR TITLE
fix(backup): opportunistic PIN backup on first V2 read (#295)

### DIFF
--- a/android/app/src/main/java/com/rjnr/pocketnode/data/wallet/WalletKeyReader.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/wallet/WalletKeyReader.kt
@@ -11,6 +11,7 @@ import com.rjnr.pocketnode.data.migration.KeyStoreMigrationHelper
 import javax.inject.Inject
 import javax.inject.Singleton
 import org.nervos.ckb.utils.Numeric
+import kotlinx.coroutines.launch
 
 /**
  * Activity-aware bridge between a ViewModel and the (V1 or V2)
@@ -269,21 +270,37 @@ class WalletKeyReader @Inject constructor(
     ) {
         if (keyBackupManager.hasBackup(walletId)) return
         val sessionPin = authManager.getSessionPin() ?: return
-        try {
-            val material = KeyMaterial(
-                privateKey = data.privateKeyHex,
-                mnemonic = data.mnemonic,
-                walletType = data.walletType,
-                mnemonicBackedUp = data.mnemonicBackedUp,
-            )
-            keyBackupManager.writeBackup(walletId, material, sessionPin)
-            Log.i(TAG, "Opportunistic backup populated for $walletId after V2 read")
-        } catch (e: Throwable) {
-            Log.w(TAG, "Opportunistic backup write failed for $walletId", e)
-        } finally {
-            java.util.Arrays.fill(sessionPin, ' ')
+        // Fire-and-forget on an IO scope: callers invoke the read paths from
+        // viewModelScope on Main, and KeyBackupManager.writeBackup runs a
+        // 600k-iteration PBKDF2 plus a file write -- synchronous execution
+        // would freeze the UI right after the biometric prompt on the user's
+        // first send/reveal (Codex review on #311).
+        backupScope.launch {
+            try {
+                val material = KeyMaterial(
+                    privateKey = data.privateKeyHex,
+                    mnemonic = data.mnemonic,
+                    walletType = data.walletType,
+                    mnemonicBackedUp = data.mnemonicBackedUp,
+                )
+                keyBackupManager.writeBackup(walletId, material, sessionPin)
+                Log.i(TAG, "Opportunistic backup populated for $walletId after V2 read")
+            } catch (e: Throwable) {
+                Log.w(TAG, "Opportunistic backup write failed for $walletId", e)
+            } finally {
+                java.util.Arrays.fill(sessionPin, ' ')
+            }
         }
     }
+
+    /**
+     * Process-lifetime scope for opportunistic backup writes. SupervisorJob
+     * so one failed write can't cancel later ones; Dispatchers.IO for the
+     * PBKDF2 + disk work.
+     */
+    private val backupScope = kotlinx.coroutines.CoroutineScope(
+        kotlinx.coroutines.SupervisorJob() + kotlinx.coroutines.Dispatchers.IO
+    )
 
     companion object {
         private const val TAG = "WalletKeyReader"

--- a/android/app/src/main/java/com/rjnr/pocketnode/data/wallet/WalletKeyReader.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/wallet/WalletKeyReader.kt
@@ -6,6 +6,7 @@ import androidx.fragment.app.FragmentActivity
 import com.rjnr.pocketnode.data.auth.AuthManager
 import com.rjnr.pocketnode.data.crypto.KeystoreEncryptionManager
 import com.rjnr.pocketnode.data.database.dao.KeyMaterialDao
+import com.rjnr.pocketnode.data.migration.DecryptedKeyData
 import com.rjnr.pocketnode.data.migration.KeyStoreMigrationHelper
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -39,6 +40,7 @@ class WalletKeyReader @Inject constructor(
     private val keyStoreMigrationHelper: KeyStoreMigrationHelper,
     private val encryptionManager: KeystoreEncryptionManager,
     private val authManager: AuthManager,
+    private val keyBackupManager: KeyBackupManager,
 ) {
 
     sealed class Result {
@@ -176,6 +178,7 @@ class WalletKeyReader @Inject constructor(
                     Log.e(TAG, "V2 material decrypt failed for $walletId", e)
                     null
                 } ?: return MaterialResult.NotAvailable("V2 decrypt failed for $walletId")
+                tryOpportunisticBackup(walletId, data)
                 MaterialResult.Success(
                     privateKey = Numeric.hexStringToByteArray(data.privateKeyHex),
                     mnemonic = data.mnemonic,
@@ -235,8 +238,50 @@ class WalletKeyReader @Inject constructor(
                     Log.e(TAG, "V2 decrypt failed for $walletId", e)
                     null
                 } ?: return Result.NotAvailable("V2 decrypt failed for $walletId")
+                tryOpportunisticBackup(walletId, data)
                 Result.Success(Numeric.hexStringToByteArray(data.privateKeyHex))
             }
+        }
+    }
+
+    /**
+     * Lazy PIN-encrypted backup population for V2 wallets (#295).
+     *
+     * `SecuritySettingsViewModel.onPinCreated` silently skips V2 wallets in
+     * its post-PIN-setup population loop because writing a backup requires
+     * a biometric-authed read. As a result, V2 wallets created on v1.7.x
+     * have no PIN-recoverable backup blob until the user explicitly reveals
+     * their seed phrase. This means a user who creates a wallet, sets a
+     * PIN, and never reveals the seed has nothing to fall back on for PIN
+     * recovery.
+     *
+     * Fix: any time a V2 read completes successfully, we already hold
+     * the full plaintext material under a biometric prompt the user just
+     * authed — write the backup blob opportunistically if it does not
+     * already exist. Requires a cached session PIN ([AuthManager.getSessionPin]);
+     * skipped silently if the user is biometric-only this session. Failures
+     * are logged and swallowed — backup population is defense-in-depth, not
+     * blocking the caller.
+     */
+    private fun tryOpportunisticBackup(
+        walletId: String,
+        data: DecryptedKeyData,
+    ) {
+        if (keyBackupManager.hasBackup(walletId)) return
+        val sessionPin = authManager.getSessionPin() ?: return
+        try {
+            val material = KeyMaterial(
+                privateKey = data.privateKeyHex,
+                mnemonic = data.mnemonic,
+                walletType = data.walletType,
+                mnemonicBackedUp = data.mnemonicBackedUp,
+            )
+            keyBackupManager.writeBackup(walletId, material, sessionPin)
+            Log.i(TAG, "Opportunistic backup populated for $walletId after V2 read")
+        } catch (e: Throwable) {
+            Log.w(TAG, "Opportunistic backup write failed for $walletId", e)
+        } finally {
+            java.util.Arrays.fill(sessionPin, ' ')
         }
     }
 


### PR DESCRIPTION
## Summary
- V2 wallets had no PIN-encrypted backup blob until the user voluntarily revealed their seed phrase. `SecuritySettingsViewModel.onPinCreated` silently skips V2 wallets in its population loop because writing a backup needs a biometric-authed read it cannot prompt for.
- A user who created a V2 wallet → set a PIN → never revealed the seed had no PIN-recovery path.
- Fix: `WalletKeyReader` now opportunistically populates the backup on any successful V2 read. We already hold the plaintext material under a biometric prompt the user just authed; `AuthManager.getSessionPin()` gives us the cached PIN. Combine the two → write the backup. Zero extra prompts.

## Behavior
- ✅ V2 wallet + reveal seed (any biometric-authed read) → backup written if session PIN available.
- ✅ V2 wallet + send / add sub-account → same.
- Skipped silently when session PIN is not cached (biometric-only session) or when a backup already exists.
- Backup-write failures are logged and swallowed — defense in depth, not on the caller's critical path.

## Test plan
- [ ] Fresh install → create V2 wallet → set PIN → no other action → confirm `KeyBackupManager` returns null (`adb logcat -s SecuritySettingsVM WalletKeyReader`).
- [ ] Same flow + reveal seed once → backup blob exists → simulated device-reset + PIN restore works.
- [ ] V1 wallet + set PIN → backup written by the existing loop (unchanged).
- [ ] Wallet with no PIN → backup not written (correct; no PIN means no PIN-recovery).

Closes #295