### PR TITLE
ci(release): build Rust JNI in release workflow (#308)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,8 @@ permissions:
 jobs:
   release:
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    # Cold cargo build of rocksdb + light-client takes ~10-15 min uncached.
+    timeout-minutes: 60
     environment: release-signing
 
     steps:
@@ -86,6 +87,37 @@ jobs:
       - name: Setup Android SDK
         uses: android-actions/setup-android@v3
 
+      - name: Setup Android NDK
+        # NDK r27c (27.0.12077973) — matches AGP 8.13.2 default. Bump in
+        # lockstep with AGP. nttld/setup-ndk handles license + full extraction;
+        # sdkmanager produced partial installs missing the llvm toolchain
+        # ("clang not found in NDK").
+        id: setup-ndk
+        uses: nttld/setup-ndk@v1
+        with:
+          ndk-version: r27c
+          add-to-path: false
+      - name: Export ANDROID_NDK_HOME
+        env:
+          NDK_PATH: ${{ steps.setup-ndk.outputs.ndk-path }}
+        run: echo "ANDROID_NDK_HOME=$NDK_PATH" >> $GITHUB_ENV
+
+      - name: Set up Rust (stable + Android targets)
+        # Two ABIs only — matches RUST_TARGETS in build-android-jni.sh.
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: aarch64-linux-android,armv7-linux-androideabi
+
+      - name: Cache Cargo target
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            external/ckb-light-client/target
+          key: cargo-${{ hashFiles('external/ckb-light-client/Cargo.lock') }}
+          restore-keys: cargo-
+
       - name: Cache Gradle
         uses: actions/cache@v4
         with:
@@ -118,10 +150,6 @@ jobs:
           KEYSTORE_BASE64: ${{ secrets.KEYSTORE_BASE64 }}
         run: echo "$KEYSTORE_BASE64" | base64 -d > android/app/release.jks
 
-      # NOTE: -x cargoBuild skips the Rust JNI build. The pre-built .so files
-      # must be present in android/app/src/main/jniLibs/ (checked below).
-      # Full CI native build will be enabled once the light-client-db-common
-      # dependency is resolved upstream.
       - name: Build signed release APK
         working-directory: android
         env:
@@ -135,17 +163,18 @@ jobs:
           # value, blocking URL-substitution + same-key release-channel-compromise
           # attacks at the in-app updater boundary.
           RELEASE_CERT_SHA256: ${{ secrets.RELEASE_CERT_SHA256 }}
-        run: ./gradlew assembleRelease -x cargoBuild
+        run: ./gradlew assembleRelease
 
       - name: Verify native library is packaged
         run: |
           APK=$(find android/app/build/outputs/apk/release -name '*.apk' | head -1)
-          if ! unzip -l "$APK" | grep -q 'libckb_light_client_lib.so'; then
-            echo "::error::Release APK does not contain libckb_light_client_lib.so — the app will crash on JNI calls."
-            echo "Ensure pre-built .so files are in android/app/src/main/jniLibs/ before tagging a release."
-            exit 1
-          fi
-          echo "Native library found in APK."
+          for abi in arm64-v8a armeabi-v7a; do
+            if ! unzip -l "$APK" | grep -q "lib/$abi/libckb_light_client_lib.so"; then
+              echo "::error::Release APK is missing lib/$abi/libckb_light_client_lib.so — the app will crash on JNI calls."
+              exit 1
+            fi
+          done
+          echo "Native library found in APK for both ABIs."
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2


### PR DESCRIPTION
## Summary
- Release workflow now builds the Rust JNI library in CI instead of expecting gitignored pre-built `.so` files in `jniLibs/` (root cause of the v1.7.3 failure at **Verify native library is packaged**, run 27227674779).
- Setup mirrors the already-working `upgrade-smoke.yml` JNI build: NDK r27c via `nttld/setup-ndk` (sdkmanager installs were missing the llvm toolchain), Rust stable with `aarch64-linux-android` + `armv7-linux-androideabi`, cargo registry/target caching keyed on `Cargo.lock`.
- Removed `-x cargoBuild` so `preBuild` triggers the cargo build naturally; timeout bumped 30 -> 60 min for the cold rocksdb build.
- Verify step now checks both `lib/arm64-v8a/` and `lib/armeabi-v7a/` explicitly and no longer suggests the jniLibs workaround.
- Stale NOTE block about the `light-client-db-common` upstream blocker deleted (the crate is in-repo).

## Verification
- After merge: `workflow_dispatch` against an existing tag (e.g. v1.7.3), confirm both ABI `.so` files in the APK and signing cert SHA matches `RELEASE_CERT_SHA256`.
- Note: workflow_dispatch runs the workflow from main, so this must merge before it can be exercised end-to-end.

Closes #308

🤖 Generated with [Claude Code](https://claude.com/claude-code)