### PR TITLE
chore(website): override postcss to 8.5.10 (dependabot)

### DIFF
--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -2653,34 +2653,6 @@
         }
       }
     },
-    "node_modules/next/node_modules/postcss": {
-      "version": "8.4.31",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
-      "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/postcss/"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/postcss"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "nanoid": "^3.3.6",
-        "picocolors": "^1.0.0",
-        "source-map-js": "^1.0.2"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14"
-      }
-    },
     "node_modules/node-releases": {
       "version": "2.0.45",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.45.tgz",

--- a/website/package.json
+++ b/website/package.json
@@ -20,6 +20,9 @@
     "rehype-slug": "6.0.0",
     "rehype-autolink-headings": "7.1.0"
   },
+  "overrides": {
+    "postcss": "8.5.10"
+  },
   "devDependencies": {
     "@tailwindcss/typography": "0.5.15",
     "@types/node": "22.10.1",


### PR DESCRIPTION
## Summary
- Dependabot flags postcss < 8.5.10 (XSS via unescaped `</style>` in stringify output) via `next@15.5.18`'s pinned `postcss 8.4.31` in `website/package-lock.json`.
- Adds an npm `overrides` entry forcing 8.5.10 everywhere; lockfile regenerated, only 8.5.10 resolves now.
- `npm run build` green.
- The other two dependabot alerts (uuid, elliptic) live in `scripts/batch-send/` and die with #312.

🤖 Generated with [Claude Code](https://claude.com/claude-code)