### PR TITLE
fix(security): clipboard auto-clear for raw-key copy + FLAG_SECURE on secret screens (#317)

### DIFF
--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/onboarding/MnemonicBackupScreen.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/onboarding/MnemonicBackupScreen.kt
@@ -755,25 +755,14 @@ private fun RawKeyBackupInfo(
                     Spacer(Modifier.height(4.dp))
                     Button(
                         onClick = {
-                            clipboardManager.setText(androidx.compose.ui.text.AnnotatedString(privateKeyHex))
+                            // Clipboard timeout to match the mnemonic backup
+                            // behaviour added in #181. The clear runs on a
+                            // process-lifetime scope so navigating away from
+                            // this screen can't cancel it (#317 Codex review).
+                            com.rjnr.pocketnode.ui.util.SensitiveClipboard
+                                .copyWithTimeout(context, privateKeyHex)
                             scope.launch {
                                 snackbarHostState.showSnackbar("Private key copied. Clipboard will clear in 60s.")
-                                // Clipboard timeout to match the mnemonic backup
-                                // behaviour added in #181. 60s window matches the
-                                // standard "ample to paste, short enough to limit
-                                // exposure" trade-off used elsewhere.
-                                kotlinx.coroutines.delay(60_000L)
-                                runCatching {
-                                    val cm = context.getSystemService(android.content.Context.CLIPBOARD_SERVICE)
-                                        as android.content.ClipboardManager
-                                    // Only clear if the clipboard still contains
-                                    // our key — don't blow away something the
-                                    // user copied in the meantime.
-                                    val current = cm.primaryClip?.getItemAt(0)?.text?.toString()
-                                    if (current == privateKeyHex) {
-                                        cm.setPrimaryClip(android.content.ClipData.newPlainText("", ""))
-                                    }
-                                }
                             }
                         },
                         modifier = Modifier.fillMaxWidth()

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/onboarding/MnemonicImportScreen.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/onboarding/MnemonicImportScreen.kt
@@ -296,6 +296,21 @@ fun MnemonicImportScreen(
     val uiState by viewModel.uiState.collectAsState()
     val snackbarHostState = remember { SnackbarHostState() }
     val clipboardManager = LocalClipboardManager.current
+
+    // FLAG_SECURE: secret material (mnemonic / raw key) is entered or shown
+    // on this screen — block screenshots, screen recording, and the recents
+    // thumbnail (#317).
+    val secureView = androidx.compose.ui.platform.LocalView.current
+    DisposableEffect(Unit) {
+        val window = (secureView.context as? android.app.Activity)?.window
+        window?.setFlags(
+            android.view.WindowManager.LayoutParams.FLAG_SECURE,
+            android.view.WindowManager.LayoutParams.FLAG_SECURE
+        )
+        onDispose {
+            window?.clearFlags(android.view.WindowManager.LayoutParams.FLAG_SECURE)
+        }
+    }
     // MainActivity extends FragmentActivity; required to drive the
     // V2 BiometricPrompt CryptoObject flow on import (#289).
     val activity = androidx.compose.ui.platform.LocalContext.current as FragmentActivity

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/wallet/AddWalletScreen.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/wallet/AddWalletScreen.kt
@@ -39,6 +39,7 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -73,6 +74,21 @@ fun AddWalletScreen(
 ) {
     val uiState by viewModel.uiState.collectAsState()
     val snackbarHostState = remember { SnackbarHostState() }
+
+    // FLAG_SECURE: secret material (mnemonic / raw key) is entered or shown
+    // on this screen — block screenshots, screen recording, and the recents
+    // thumbnail (#317).
+    val secureView = androidx.compose.ui.platform.LocalView.current
+    DisposableEffect(Unit) {
+        val window = (secureView.context as? android.app.Activity)?.window
+        window?.setFlags(
+            android.view.WindowManager.LayoutParams.FLAG_SECURE,
+            android.view.WindowManager.LayoutParams.FLAG_SECURE
+        )
+        onDispose {
+            window?.clearFlags(android.view.WindowManager.LayoutParams.FLAG_SECURE)
+        }
+    }
     // MainActivity extends FragmentActivity; required for V2 BiometricPrompt (#289).
     val activity = androidx.compose.ui.platform.LocalContext.current
         as androidx.fragment.app.FragmentActivity

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/wallet/WalletSettingsScreen.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/wallet/WalletSettingsScreen.kt
@@ -57,6 +57,7 @@ import com.rjnr.pocketnode.R
 import com.rjnr.pocketnode.data.database.entity.WalletEntity
 import com.rjnr.pocketnode.ui.util.resolveString
 import com.rjnr.pocketnode.ui.components.WalletAvatar
+import com.rjnr.pocketnode.ui.util.SensitiveClipboard
 import kotlinx.coroutines.launch
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -427,23 +428,12 @@ fun WalletSettingsScreen(
                                     Spacer(Modifier.height(8.dp))
                                     Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
                                         OutlinedButton(onClick = {
-                                            clipboardManager.setText(androidx.compose.ui.text.AnnotatedString(keyHex))
+                                            // Timed clear on a process-lifetime scope so it
+                                            // survives navigating away from this screen
+                                            // (#290/#317 + Codex review on #322).
+                                            SensitiveClipboard.copyWithTimeout(context, keyHex)
                                             scope.launch {
                                                 snackbarHostState.showSnackbar("Private key copied. Clipboard will clear in 60s.")
-                                                // Timed clear matching the raw-key copy
-                                                // path in MnemonicBackupScreen (#290/#317).
-                                                kotlinx.coroutines.delay(60_000L)
-                                                runCatching {
-                                                    val cm = context.getSystemService(android.content.Context.CLIPBOARD_SERVICE)
-                                                        as android.content.ClipboardManager
-                                                    // Only clear if the clipboard still holds
-                                                    // our key — don't blow away something the
-                                                    // user copied in the meantime.
-                                                    val current = cm.primaryClip?.getItemAt(0)?.text?.toString()
-                                                    if (current == keyHex) {
-                                                        cm.setPrimaryClip(android.content.ClipData.newPlainText("", ""))
-                                                    }
-                                                }
                                             }
                                         }) {
                                             Text(stringResource(R.string.wallet_settings_copy))

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/wallet/WalletSettingsScreen.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/wallet/WalletSettingsScreen.kt
@@ -57,6 +57,7 @@ import com.rjnr.pocketnode.R
 import com.rjnr.pocketnode.data.database.entity.WalletEntity
 import com.rjnr.pocketnode.ui.util.resolveString
 import com.rjnr.pocketnode.ui.components.WalletAvatar
+import kotlinx.coroutines.launch
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -69,8 +70,24 @@ fun WalletSettingsScreen(
     val snackbarHostState = remember { SnackbarHostState() }
     val clipboardManager = androidx.compose.ui.platform.LocalClipboardManager.current
     val context = androidx.compose.ui.platform.LocalContext.current
+    val scope = androidx.compose.runtime.rememberCoroutineScope()
     var showSeedPhrase by rememberSaveable { mutableStateOf(false) }
     var showAddAccountDialog by remember { mutableStateOf(false) }
+
+    // FLAG_SECURE: this screen can render the full mnemonic and raw private
+    // key after biometric unlock — block screenshots, screen recording, and
+    // the recents thumbnail, matching MnemonicBackupScreen (#317).
+    val view = androidx.compose.ui.platform.LocalView.current
+    androidx.compose.runtime.DisposableEffect(Unit) {
+        val window = (view.context as? android.app.Activity)?.window
+        window?.setFlags(
+            android.view.WindowManager.LayoutParams.FLAG_SECURE,
+            android.view.WindowManager.LayoutParams.FLAG_SECURE
+        )
+        onDispose {
+            window?.clearFlags(android.view.WindowManager.LayoutParams.FLAG_SECURE)
+        }
+    }
 
     // V2-aware: route the "view recovery phrase" / "view private key"
     // taps through the activity-bound entry point so a CryptoObject
@@ -411,6 +428,23 @@ fun WalletSettingsScreen(
                                     Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
                                         OutlinedButton(onClick = {
                                             clipboardManager.setText(androidx.compose.ui.text.AnnotatedString(keyHex))
+                                            scope.launch {
+                                                snackbarHostState.showSnackbar("Private key copied. Clipboard will clear in 60s.")
+                                                // Timed clear matching the raw-key copy
+                                                // path in MnemonicBackupScreen (#290/#317).
+                                                kotlinx.coroutines.delay(60_000L)
+                                                runCatching {
+                                                    val cm = context.getSystemService(android.content.Context.CLIPBOARD_SERVICE)
+                                                        as android.content.ClipboardManager
+                                                    // Only clear if the clipboard still holds
+                                                    // our key — don't blow away something the
+                                                    // user copied in the meantime.
+                                                    val current = cm.primaryClip?.getItemAt(0)?.text?.toString()
+                                                    if (current == keyHex) {
+                                                        cm.setPrimaryClip(android.content.ClipData.newPlainText("", ""))
+                                                    }
+                                                }
+                                            }
                                         }) {
                                             Text(stringResource(R.string.wallet_settings_copy))
                                         }

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/util/SensitiveClipboard.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/util/SensitiveClipboard.kt
@@ -1,0 +1,59 @@
+package com.rjnr.pocketnode.ui.util
+
+import android.content.ClipData
+import android.content.ClipboardManager
+import android.content.Context
+import android.os.PersistableBundle
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+
+/**
+ * Copies secret material (private keys, mnemonics) to the clipboard with a
+ * timed auto-clear that survives navigation.
+ *
+ * The clear job runs on a process-lifetime scope, NOT a composable's
+ * `rememberCoroutineScope` — a composable scope is cancelled when the user
+ * leaves the screen, which is exactly the common "copy key, navigate away to
+ * paste it" flow, and the key would then sit in the clipboard indefinitely
+ * (#317 Codex review).
+ *
+ * Also marks the clip sensitive (`android.content.extra.IS_SENSITIVE`) so
+ * Android 13+ suppresses the clipboard preview overlay.
+ */
+object SensitiveClipboard {
+
+    const val CLEAR_DELAY_MS = 60_000L
+
+    // Process-lifetime scope: lives until the process dies. If the process is
+    // killed before the delay fires the clear is lost — acceptable residual
+    // shared by any in-process timer; the system clipboard outlives us anyway.
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Main)
+
+    fun copyWithTimeout(context: Context, secret: String) {
+        val cm = context.applicationContext
+            .getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
+        val clip = ClipData.newPlainText("", secret).apply {
+            description.extras = PersistableBundle().apply {
+                // ClipDescription.EXTRA_IS_SENSITIVE is API 33; the string
+                // literal is the documented back-compat form.
+                putBoolean("android.content.extra.IS_SENSITIVE", true)
+            }
+        }
+        cm.setPrimaryClip(clip)
+
+        scope.launch {
+            delay(CLEAR_DELAY_MS)
+            runCatching {
+                // Only clear if the clipboard still holds our secret — don't
+                // blow away something the user copied in the meantime.
+                val current = cm.primaryClip?.getItemAt(0)?.text?.toString()
+                if (current == secret) {
+                    cm.setPrimaryClip(ClipData.newPlainText("", ""))
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- **Clipboard**: the raw private-key Copy button in WalletSettingsScreen wrote the full key hex with no timeout — the exact mitigation #290 added to MnemonicBackupScreen was missing here. Now: warning snackbar + 60s clear that only wipes the clipboard if it still holds our key.
- **FLAG_SECURE**: only MnemonicBackupScreen was protected. Added the same DisposableEffect set/clear to the three other screens that render or accept seed/key material: WalletSettingsScreen (full mnemonic + revealed private key), MnemonicImportScreen (seed entry), AddWalletScreen (mnemonic/raw-key import).

Found by internal security sweep; tracked as #317.

## Testing
- `compileDebugKotlin` green
- `testDebugUnitTest` green (33 tasks)

Closes #317

🤖 Generated with [Claude Code](https://claude.com/claude-code)