### PR TITLE
fix(dao): phase-2 unlock rejected on-chain — witness field, since fraction, occupied capacity (#315)

### DIFF
--- a/android/app/src/main/java/com/rjnr/pocketnode/data/gateway/DaoConstants.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/gateway/DaoConstants.kt
@@ -21,6 +21,13 @@ object DaoConstants {
     const val HOURS_PER_EPOCH = 4
     const val MIN_DEPOSIT_SHANNONS = 10_200_000_000L  // 102 CKB
     const val RESERVE_SHANNONS = 6_200_000_000L       // 62 CKB
+
+    // Occupied capacity of a standard DAO deposit/withdrawing cell:
+    // 8 (capacity) + 53 (secp256k1 lock) + 33 (DAO type) + 8 (data) = 102 bytes.
+    // This is the non-interest-bearing portion in max-withdraw math; passing
+    // anything smaller inflates the computed entitlement and the unlock tx
+    // is rejected on-chain (#315, RFC-0023 worked example).
+    const val DEPOSIT_OCCUPIED_SHANNONS = 10_200_000_000L // 102 CKB
     val DAO_DEPOSIT_DATA = ByteArray(8)                // 8 zero bytes
 
     val DAO_TYPE_SCRIPT = Script(

--- a/android/app/src/main/java/com/rjnr/pocketnode/data/gateway/GatewayRepository.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/gateway/GatewayRepository.kt
@@ -1842,7 +1842,7 @@ class GatewayRepository @Inject constructor(
             depositHeader.dao,
             withdrawHeader.dao,
             deposit.capacity,
-            61_00000000L
+            DaoConstants.DEPOSIT_OCCUPIED_SHANNONS
         )
         if (maxWithdraw < 0) throw Exception("Failed to calculate max withdraw capacity")
 

--- a/android/app/src/main/java/com/rjnr/pocketnode/data/transaction/TransactionBuilder.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/transaction/TransactionBuilder.kt
@@ -423,7 +423,10 @@ class TransactionBuilder @Inject constructor(
             NetworkType.MAINNET -> CellDep.SECP256K1_MAINNET
         }
 
-        // output_type in witness = 8-byte LE index of deposit header in header_deps (index 0)
+        // input_type in witness = 8-byte LE index of the deposit header in
+        // header_deps (index 0). dao.c reads this from WitnessArgs.input_type
+        // (MolReader_WitnessArgs_get_input_type); putting it in output_type
+        // fails script verification (#315).
         val depositHeaderIndex = ByteArray(8) // 8 zero bytes = index 0
 
         val unsignedTx = Transaction(
@@ -435,7 +438,7 @@ class TransactionBuilder @Inject constructor(
             witnesses = listOf("0x")
         )
 
-        return signTransaction(unsignedTx, privateKey, 1, witnessOutputType = depositHeaderIndex)
+        return signTransaction(unsignedTx, privateKey, 1, witnessInputType = depositHeaderIndex)
     }
 
     private fun estimateTransactionSize(tx: Transaction): Int {
@@ -495,14 +498,14 @@ class TransactionBuilder @Inject constructor(
         tx: Transaction,
         privateKey: ByteArray,
         inputCount: Int,
-        witnessOutputType: ByteArray? = null
+        witnessInputType: ByteArray? = null
     ): Transaction {
         // 1. Serialize the raw transaction and compute its hash
         val rawTxBytes = serializeRawTransaction(tx)
         val txHash = blake2bHash(rawTxBytes)
 
         // 2. Create empty witness args (65 zero bytes for signature placeholder)
-        val emptyWitnessArgs = serializeWitnessArgs(ByteArray(65), null, witnessOutputType)
+        val emptyWitnessArgs = serializeWitnessArgs(ByteArray(65), witnessInputType, null)
 
         // 3. Build the signing message
         val blake2b = Blake2b()
@@ -524,7 +527,7 @@ class TransactionBuilder @Inject constructor(
         val signature = signatureData.signature
 
         // 5. Create signed witness
-        val signedWitnessArgs = serializeWitnessArgs(signature, null, witnessOutputType)
+        val signedWitnessArgs = serializeWitnessArgs(signature, witnessInputType, null)
         val signedWitnessHex = "0x" + signedWitnessArgs.joinToString("") { "%02x".format(it) }
 
         // 6. Build witnesses list

--- a/android/app/src/test/java/com/rjnr/pocketnode/data/transaction/TransactionBuilderDaoTest.kt
+++ b/android/app/src/test/java/com/rjnr/pocketnode/data/transaction/TransactionBuilderDaoTest.kt
@@ -249,6 +249,51 @@ class TransactionBuilderDaoTest {
     }
 
     @Test
+    fun `buildDaoUnlock witness carries deposit header index in input_type not output_type (#315)`() {
+        val tx = builder.buildDaoUnlock(
+            withdrawingCell = makeWithdrawingCell(),
+            maxWithdraw = 10_300_000_000L,
+            sinceValue = "0x2000180000b0000a",
+            depositBlockHash = "0x" + "aa".repeat(32),
+            withdrawBlockHash = "0x" + "bb".repeat(32),
+            senderScript = testScript,
+            privateKey = testPrivateKey,
+            network = NetworkType.TESTNET
+        )
+
+        // Parse the molecule WitnessArgs table: [totalSize u32le][off0][off1][off2]
+        // followed by lock / input_type / output_type BytesOpt fields.
+        val witness = tx.witnesses[0].removePrefix("0x")
+            .chunked(2).map { it.toInt(16).toByte() }.toByteArray()
+
+        fun u32le(offset: Int): Int =
+            (witness[offset].toInt() and 0xff) or
+                ((witness[offset + 1].toInt() and 0xff) shl 8) or
+                ((witness[offset + 2].toInt() and 0xff) shl 16) or
+                ((witness[offset + 3].toInt() and 0xff) shl 24)
+
+        val totalSize = u32le(0)
+        val lockOffset = u32le(4)
+        val inputTypeOffset = u32le(8)
+        val outputTypeOffset = u32le(12)
+        assertEquals(witness.size, totalSize)
+
+        // lock = 65-byte signature wrapped in fixvec (4-byte length prefix)
+        assertEquals(65 + 4, inputTypeOffset - lockOffset)
+
+        // input_type = Some(8-byte LE deposit header index 0): fixvec len 8 + 8 zero bytes.
+        // dao.c reads the header index from input_type (MolReader_WitnessArgs_get_input_type);
+        // a None input_type fails on-chain script verification.
+        val inputTypeField = witness.copyOfRange(inputTypeOffset, outputTypeOffset)
+        assertEquals(12, inputTypeField.size)
+        assertEquals(8, (inputTypeField[0].toInt() and 0xff))
+        assertTrue(inputTypeField.copyOfRange(4, 12).all { it == 0.toByte() })
+
+        // output_type = None (zero-length field)
+        assertEquals(totalSize, outputTypeOffset)
+    }
+
+    @Test
     fun `buildDaoUnlock output has no type script`() {
         val tx = builder.buildDaoUnlock(
             withdrawingCell = makeWithdrawingCell(),

--- a/external/ckb-light-client/light-client-lib/src/jni_bridge/dao.rs
+++ b/external/ckb-light-client/light-client-lib/src/jni_bridge/dao.rs
@@ -273,10 +273,17 @@ pub extern "C" fn Java_com_nervosnetwork_ckblightclient_LightClientNative_native
     let lock_epochs = ((deposited_epochs + 179) / 180) * 180;
     let minimal_unlock_epoch = deposit_number + lock_epochs;
 
-    // Encode as absolute epoch since value (0x20 prefix = absolute epoch flag)
-    // Since field: bits 0-23 = epoch number, bits 24-39 = index (0), bits 40-55 = length (1)
-    // With 0x20 prefix in the top byte for absolute epoch
-    let since_epoch = EpochNumberWithFraction::new(minimal_unlock_epoch, 0, 1);
+    // Encode as absolute epoch since value (0x20 prefix = absolute epoch flag).
+    // dao.c's minimal unlock point is (deposit_number + lock_epochs,
+    // deposit_index, deposit_length) — the fraction must carry the deposit
+    // epoch's index/length, not 0/1, or the on-chain script rejects with
+    // ERROR_INCORRECT_SINCE whenever deposit_index > 0 (#315). Matches
+    // ckb-sdk-rust's minimal_unlock_point.
+    let since_epoch = EpochNumberWithFraction::new(
+        minimal_unlock_epoch,
+        deposit_epoch.index(),
+        deposit_epoch.length(),
+    );
     // Absolute epoch flag: 0x2000000000000000
     let since_value = 0x2000_0000_0000_0000u64 | since_epoch.full_value();
 


### PR DESCRIPTION
## Summary
Fixes the three independent bugs from #315 that made every real mainnet DAO unlock fail on-chain script verification, stranding withdrawn deposits in the withdrawing state:

1. **Witness field** ([TransactionBuilder.kt](android/app/src/main/java/com/rjnr/pocketnode/data/transaction/TransactionBuilder.kt)): the 8-byte deposit-header index went into `WitnessArgs.output_type`; dao.c reads `input_type` (`MolReader_WitnessArgs_get_input_type`) and errors on None. `signTransaction` now takes `witnessInputType` and writes the index there in both the signing placeholder and the final witness — signature digest and witness stay consistent.
2. **Since fraction** ([dao.rs](external/ckb-light-client/light-client-lib/src/jni_bridge/dao.rs)): `nativeCalculateUnlockEpoch` emitted fraction `0/1`, below dao.c's minimal unlock point `(deposit_number + lock_epochs, deposit_index, deposit_length)` for ~1799/1800 deposits (ERROR_INCORRECT_SINCE). Now carries the deposit epoch's index/length, matching ckb-sdk-rust `minimal_unlock_point`.
3. **Occupied capacity** ([GatewayRepository.kt](android/app/src/main/java/com/rjnr/pocketnode/data/gateway/GatewayRepository.kt)): max-withdraw math used 61 CKB; standard DAO cell occupies 102 bytes (8 capacity + 53 lock + 33 type + 8 data, per RFC-0023). Overshoot exceeded the fee once a deposit was ~9h old, so by the 30-day minimum lock every unlock was rejected. New `DaoConstants.DEPOSIT_OCCUPIED_SHANNONS`.

## Why testnet smoke passed
Short-lived test deposits accrue less interest than the 0.001 CKB fee, masking bug 3; bugs 1 and 2 require an unlock attempt past the lock period with a nonzero deposit epoch index.

## Testing
- New molecule-level regression test: unlock witness carries header index in `input_type`, `output_type` = None, lock = 65-byte sig
- `testDebugUnitTest` green; `cargo check` green
- Recommended before release: testnet end-to-end deposit→withdraw→unlock with interest > fee (tracked in #315 verification plan)

Closes #315

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed DAO unlock transaction witness field construction for proper smart contract interaction
  * Corrected epoch calculation for DAO unlock operations
  * Standardized max-withdraw calculations with consistent deposit constant values

* **Tests**
  * Added test verification for DAO unlock witness encoding

<!-- end of auto-generated comment: release notes by coderabbit.ai -->