### PR TITLE
fix(ci): upgrade-smoke seed walk blocked by #303 no-device-lock dialog

### DIFF
--- a/android/app/src/androidTest/java/com/rjnr/pocketnode/UpgradeSmokeTest.kt
+++ b/android/app/src/androidTest/java/com/rjnr/pocketnode/UpgradeSmokeTest.kt
@@ -101,6 +101,12 @@ class UpgradeSmokeTest {
             clickButton("onboarding-recover", "Recover from Seed Phrase", ONBOARDING_TIMEOUT_MS)
         )
 
+        // #303 added an informed-consent dialog ("Continue without a device
+        // lock?") that intercepts both Create and Recover when the device has
+        // no lock set — which is always true on the CI emulator. Click through
+        // it; best-effort because a lock-enrolled device never shows it.
+        clickButton("onboarding-no-lock-continue", "Continue anyway", 5_000L)
+
         assertTrue(
             "Import paste button not found",
             clickButton("import-paste", "Paste from Clipboard", ONBOARDING_TIMEOUT_MS)

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/onboarding/OnboardingScreen.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/onboarding/OnboardingScreen.kt
@@ -232,11 +232,16 @@ fun OnboardingScreen(
                 )
             },
             confirmButton = {
-                TextButton(onClick = {
-                    showNoDeviceLockWarning = false
-                    pendingNoLockAction?.invoke()
-                    pendingNoLockAction = null
-                }) {
+                TextButton(
+                    onClick = {
+                        showNoDeviceLockWarning = false
+                        pendingNoLockAction?.invoke()
+                        pendingNoLockAction = null
+                    },
+                    // Upgrade-smoke harness clicks through this dialog: the CI
+                    // emulator has no device lock, so it appears on every run.
+                    modifier = Modifier.uaTestTag("onboarding-no-lock-continue")
+                ) {
                     Text("Continue anyway")
                 }
             },


### PR DESCRIPTION
## Summary
Every PR's smoke job currently fails at **Import paste button not found** — including #310, which touches only `scripts/`, proving the harness is broken against main rather than any PR regressing.

Root cause: #303 (e73ae60) added the "Continue without a device lock?" informed-consent dialog that intercepts both Create and Recover taps when the device has no lock — which is always the case on the CI emulator. The seed walk taps `onboarding-recover`, the dialog swallows it, and the import screen never appears.

Fix:
- `uaTestTag("onboarding-no-lock-continue")` on the dialog's Continue-anyway button
- `UpgradeSmokeTest.seedFreshWallet` clicks through it best-effort (5s, non-fatal) before expecting the paste button, so lock-enrolled devices that never show the dialog are unaffected

After merge, rerun smoke on #309/#310/#311 — their failures should clear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)