### PR TITLE
fix(backup): dataExtractionRules, recovery lockout, Argon2id KDF (#319)

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -13,6 +13,7 @@
     <application
         android:name=".CkbWalletApp"
         android:allowBackup="false"
+        android:dataExtractionRules="@xml/data_extraction_rules"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"

--- a/android/app/src/main/java/com/rjnr/pocketnode/data/wallet/KeyBackupManager.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/wallet/KeyBackupManager.kt
@@ -5,6 +5,8 @@ import androidx.annotation.VisibleForTesting
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
+import org.bouncycastle.crypto.generators.Argon2BytesGenerator
+import org.bouncycastle.crypto.params.Argon2Parameters
 import java.io.File
 import java.security.SecureRandom
 import javax.crypto.Cipher
@@ -31,8 +33,20 @@ class KeyBackupManager @Inject constructor(
 ) {
     private val json = Json { ignoreUnknownKeys = true; encodeDefaults = true }
 
+    // PBKDF2 iteration count — only used when READING legacy v1 backups.
     @VisibleForTesting
     internal var kdfIterations: Int = KDF_ITERATIONS
+
+    // Argon2id parameters for v2 backups. Match PinManager's PIN-hash params
+    // (OWASP ASVS baseline: 64 MB, t=3, p=4). Overridable for fast tests.
+    @VisibleForTesting
+    internal var argon2Iterations: Int = 3
+
+    @VisibleForTesting
+    internal var argon2MemoryKb: Int = 64 * 1024
+
+    @VisibleForTesting
+    internal var argon2Parallelism: Int = 4
 
     init {
         backupDir.mkdirs()
@@ -41,7 +55,8 @@ class KeyBackupManager @Inject constructor(
     fun writeBackup(walletId: String, material: KeyMaterial, pin: CharArray) {
         val salt = ByteArray(SALT_SIZE).also { SecureRandom().nextBytes(it) }
         val iv = ByteArray(IV_SIZE).also { SecureRandom().nextBytes(it) }
-        val key = deriveKey(pin, salt)
+        // New backups are always written with the strongest KDF (Argon2id, v2).
+        val key = deriveKey(pin, salt, FORMAT_VERSION_ARGON2)
 
         val plaintext = json.encodeToString(material).toByteArray(Charsets.UTF_8)
         val cipher = Cipher.getInstance(CIPHER_TRANSFORM)
@@ -53,7 +68,7 @@ class KeyBackupManager @Inject constructor(
 
         tmpFile.outputStream().use { out ->
             out.write(MAGIC)
-            out.write(byteArrayOf(FORMAT_VERSION))
+            out.write(byteArrayOf(FORMAT_VERSION_ARGON2))
             out.write(salt)
             out.write(iv)
             out.write(ciphertext)
@@ -72,11 +87,13 @@ class KeyBackupManager @Inject constructor(
                 Log.w(TAG, "Backup file for $walletId has invalid magic header")
                 return null
             }
+            // Byte 4 selects the KDF: v1 = PBKDF2 (legacy), v2 = Argon2id.
+            val formatVersion = bytes[4]
             val salt = bytes.sliceArray(HEADER_SIZE until HEADER_SIZE + SALT_SIZE)
             val iv = bytes.sliceArray(HEADER_SIZE + SALT_SIZE until HEADER_SIZE + SALT_SIZE + IV_SIZE)
             val ciphertext = bytes.sliceArray(HEADER_SIZE + SALT_SIZE + IV_SIZE until bytes.size)
 
-            val key = deriveKey(pin, salt)
+            val key = deriveKey(pin, salt, formatVersion)
             val cipher = Cipher.getInstance(CIPHER_TRANSFORM)
             cipher.init(Cipher.DECRYPT_MODE, key, GCMParameterSpec(GCM_TAG_BITS, iv))
             val plaintext = cipher.doFinal(ciphertext)
@@ -115,7 +132,8 @@ class KeyBackupManager @Inject constructor(
 
             val salt = ByteArray(SALT_SIZE).also { SecureRandom().nextBytes(it) }
             val iv = ByteArray(IV_SIZE).also { SecureRandom().nextBytes(it) }
-            val key = deriveKey(newPin, salt)
+            // Re-encryption upgrades the blob to the current KDF (Argon2id, v2).
+            val key = deriveKey(newPin, salt, FORMAT_VERSION_ARGON2)
 
             val plaintext = json.encodeToString(material).toByteArray(Charsets.UTF_8)
             val cipher = Cipher.getInstance(CIPHER_TRANSFORM)
@@ -124,7 +142,7 @@ class KeyBackupManager @Inject constructor(
 
             tmpFile.outputStream().use { out ->
                 out.write(MAGIC)
-                out.write(byteArrayOf(FORMAT_VERSION))
+                out.write(byteArrayOf(FORMAT_VERSION_ARGON2))
                 out.write(salt)
                 out.write(iv)
                 out.write(ciphertext)
@@ -148,7 +166,15 @@ class KeyBackupManager @Inject constructor(
 
     private fun backupFile(walletId: String): File = File(backupDir, "$walletId.enc")
 
-    private fun deriveKey(pin: CharArray, salt: ByteArray): SecretKeySpec {
+    /** Derives the AES key for a backup blob using the KDF for [formatVersion]. */
+    private fun deriveKey(pin: CharArray, salt: ByteArray, formatVersion: Byte): SecretKeySpec =
+        when (formatVersion) {
+            FORMAT_VERSION_ARGON2 -> deriveKeyArgon2(pin, salt)
+            FORMAT_VERSION_PBKDF2 -> deriveKeyPbkdf2(pin, salt)
+            else -> throw IllegalStateException("Unknown backup format version $formatVersion")
+        }
+
+    private fun deriveKeyPbkdf2(pin: CharArray, salt: ByteArray): SecretKeySpec {
         val factory = SecretKeyFactory.getInstance(KDF_ALGORITHM)
         val spec = PBEKeySpec(pin, salt, kdfIterations, KEY_SIZE_BITS)
         val secret = factory.generateSecret(spec)
@@ -157,10 +183,32 @@ class KeyBackupManager @Inject constructor(
         return key
     }
 
+    private fun deriveKeyArgon2(pin: CharArray, salt: ByteArray): SecretKeySpec {
+        // Avoid String interning of the PIN.
+        val pinBytes = String(pin).toByteArray(Charsets.UTF_8)
+        try {
+            val params = Argon2Parameters.Builder(Argon2Parameters.ARGON2_id)
+                .withVersion(Argon2Parameters.ARGON2_VERSION_13)
+                .withIterations(argon2Iterations)
+                .withMemoryAsKB(argon2MemoryKb)
+                .withParallelism(argon2Parallelism)
+                .withSalt(salt)
+                .build()
+            val gen = Argon2BytesGenerator().also { it.init(params) }
+            val out = ByteArray(KEY_SIZE_BITS / 8)
+            gen.generateBytes(pinBytes, out)
+            return SecretKeySpec(out, "AES")
+        } finally {
+            pinBytes.fill(0)
+        }
+    }
+
     companion object {
         private const val TAG = "KeyBackupManager"
         val MAGIC = byteArrayOf('P'.code.toByte(), 'N'.code.toByte(), 'B'.code.toByte(), 'K'.code.toByte())
-        const val FORMAT_VERSION: Byte = 1
+        // v1 = PBKDF2-HMAC-SHA256 (read-only legacy); v2 = Argon2id (current).
+        const val FORMAT_VERSION_PBKDF2: Byte = 1
+        const val FORMAT_VERSION_ARGON2: Byte = 2
         const val HEADER_SIZE = 5
         const val SALT_SIZE = 16
         const val IV_SIZE = 12

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/recovery/RecoveryViewModel.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/recovery/RecoveryViewModel.kt
@@ -2,13 +2,17 @@ package com.rjnr.pocketnode.ui.screens.recovery
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.rjnr.pocketnode.data.auth.PinManager
 import com.rjnr.pocketnode.data.wallet.KeyBackupManager
 import com.rjnr.pocketnode.data.wallet.KeyMaterial
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import javax.inject.Inject
 
 enum class RecoveryStage {
@@ -32,9 +36,18 @@ data class RecoveredWallet(
 )
 
 @HiltViewModel
-class RecoveryViewModel @Inject constructor(
-    private val backupManager: KeyBackupManager
+class RecoveryViewModel(
+    private val backupManager: KeyBackupManager,
+    private val pinManager: PinManager,
+    private val ioDispatcher: CoroutineDispatcher
 ) : ViewModel() {
+
+    /** Hilt entry point — backup decrypt runs on [Dispatchers.IO]. */
+    @Inject
+    constructor(
+        backupManager: KeyBackupManager,
+        pinManager: PinManager
+    ) : this(backupManager, pinManager, Dispatchers.IO)
 
     private val _uiState = MutableStateFlow(RecoveryUiState())
     val uiState: StateFlow<RecoveryUiState> = _uiState
@@ -45,18 +58,65 @@ class RecoveryViewModel @Inject constructor(
         }
     }
 
+    /**
+     * Attempts to recover wallets from their PIN-encrypted backup blobs.
+     *
+     * PIN attempts are gated through [PinManager] (#319) so they share the
+     * same persistent, cross-session escalating lockout as the lock screen
+     * (30s ... permanent at 10 failures). Previously this path decrypted
+     * backups directly, throttled only by an in-memory counter that reset on
+     * every screen recreate — an on-device attacker could brute-force the
+     * 6-digit PIN indefinitely, bounded only by KDF cost.
+     */
     fun attemptPinRecovery(pin: CharArray) {
         viewModelScope.launch {
-            val walletIds = backupManager.listBackupWalletIds()
+            // Persistent lockout shared with the normal PIN gate.
+            if (pinManager.isLockedOut()) {
+                val secs = (pinManager.getLockoutRemainingMs() / 1000).coerceAtLeast(1)
+                _uiState.update {
+                    it.copy(error = "Too many attempts. Try again in ${secs}s.")
+                }
+                return@launch
+            }
+
+            // Verify against the stored PIN hash so failures escalate the SAME
+            // lockout the lock screen uses. The degenerate "no PIN hash but
+            // backups exist" case can't be brute-forced here (nothing to verify
+            // against), so we fall through to a decrypt attempt in that case.
+            if (pinManager.hasPin() && !pinManager.verifyPinFromChars(pin)) {
+                // verifyPinFromChars already recorded the failed attempt and
+                // advanced the persistent lockout/escalation counters.
+                val newAttempts = _uiState.value.failedAttempts + 1
+                val permanent = pinManager.isPermanentlyLocked()
+                _uiState.update {
+                    it.copy(
+                        failedAttempts = newAttempts,
+                        stage = if (permanent) RecoveryStage.MNEMONIC_ENTRY else RecoveryStage.PIN_ENTRY,
+                        error = if (permanent) {
+                            "Too many failed attempts. Please enter your recovery phrase."
+                        } else if (pinManager.isLockedOut()) {
+                            val secs = (pinManager.getLockoutRemainingMs() / 1000).coerceAtLeast(1)
+                            "Incorrect PIN. Locked for ${secs}s."
+                        } else {
+                            "Incorrect PIN. ${pinManager.getRemainingAttempts()} attempts remaining."
+                        }
+                    )
+                }
+                return@launch
+            }
+
+            // PIN verified (or no hash to verify against) — decrypt off the main
+            // thread (PBKDF2/Argon2 is CPU/memory-heavy).
             val recovered = mutableListOf<RecoveredWallet>()
             val failed = mutableListOf<String>()
-
-            for (id in walletIds) {
-                val material = backupManager.readBackup(id, pin)
-                if (material != null) {
-                    recovered.add(RecoveredWallet(id, material))
-                } else {
-                    failed.add(id)
+            withContext(ioDispatcher) {
+                for (id in backupManager.listBackupWalletIds()) {
+                    val material = backupManager.readBackup(id, pin)
+                    if (material != null) {
+                        recovered.add(RecoveredWallet(id, material))
+                    } else {
+                        failed.add(id)
+                    }
                 }
             }
 
@@ -69,13 +129,13 @@ class RecoveryViewModel @Inject constructor(
                     )
                 }
             } else {
-                val newAttempts = _uiState.value.failedAttempts + 1
+                // Verified PIN but nothing decrypted (corrupt blobs, or the
+                // degenerate no-hash case with a wrong PIN). Fall back to the
+                // mnemonic so the user isn't stuck.
                 _uiState.update {
                     it.copy(
-                        failedAttempts = newAttempts,
-                        stage = if (newAttempts >= MAX_PIN_ATTEMPTS) RecoveryStage.MNEMONIC_ENTRY else RecoveryStage.PIN_ENTRY,
-                        error = if (newAttempts >= MAX_PIN_ATTEMPTS) "Too many failed attempts. Please enter your recovery phrase."
-                        else "Incorrect PIN. ${MAX_PIN_ATTEMPTS - newAttempts} attempts remaining."
+                        stage = RecoveryStage.MNEMONIC_ENTRY,
+                        error = "Could not recover from PIN. Please enter your recovery phrase."
                     )
                 }
             }
@@ -84,9 +144,5 @@ class RecoveryViewModel @Inject constructor(
 
     fun clearError() {
         _uiState.update { it.copy(error = null) }
-    }
-
-    companion object {
-        const val MAX_PIN_ATTEMPTS = 3
     }
 }

--- a/android/app/src/main/res/xml/data_extraction_rules.xml
+++ b/android/app/src/main/res/xml/data_extraction_rules.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Excludes the wallet's sensitive at-rest data from Android Auto Backup
+  (cloud-backup) AND device-to-device transfer (device-transfer, API 31+).
+
+  android:allowBackup="false" already disables cloud backup and the pre-31
+  D2D path, but on Android 12+ device-transfer is governed independently by
+  this file. Without it, the PIN-encrypted seed backups in key_backups/ —
+  self-contained blobs whose only barrier is a 6-digit PIN — would be copied
+  to a new device during migration and become offline-brute-forceable (#319).
+
+  We exclude:
+   - key_backups/      : PIN-encrypted seed/key backup blobs
+   - ckb_pin_prefs.xml : EncryptedSharedPreferences holding the PIN hash/salt
+   - key_migration.xml : legacy ESP->Room migration bookkeeping
+-->
+<data-extraction-rules>
+    <cloud-backup>
+        <exclude domain="file" path="key_backups/" />
+        <exclude domain="sharedpref" path="ckb_pin_prefs.xml" />
+        <exclude domain="sharedpref" path="key_migration.xml" />
+    </cloud-backup>
+    <device-transfer>
+        <exclude domain="file" path="key_backups/" />
+        <exclude domain="sharedpref" path="ckb_pin_prefs.xml" />
+        <exclude domain="sharedpref" path="key_migration.xml" />
+    </device-transfer>
+</data-extraction-rules>

--- a/android/app/src/test/java/com/rjnr/pocketnode/data/wallet/KeyBackupManagerTest.kt
+++ b/android/app/src/test/java/com/rjnr/pocketnode/data/wallet/KeyBackupManagerTest.kt
@@ -41,8 +41,54 @@ class KeyBackupManagerTest {
     @Before
     fun setUp() {
         manager = KeyBackupManager(tempDir.root)
-        // Use low iteration count for fast tests (production uses 600_000)
+        // Use low cost factors for fast tests. Production uses PBKDF2 600_000
+        // (legacy reads) and Argon2id 64 MB / t=3 / p=4 (current writes).
         manager.kdfIterations = 1_000
+        manager.argon2Iterations = 1
+        manager.argon2MemoryKb = 8
+        manager.argon2Parallelism = 1
+    }
+
+    @Test
+    fun `new backups are written with Argon2id (format v2)`() {
+        manager.writeBackup("wallet1", mnemonicMaterial(), testPin)
+        val versionByte = File(tempDir.root, "wallet1.enc").readBytes()[4]
+        assertEquals(KeyBackupManager.FORMAT_VERSION_ARGON2, versionByte)
+    }
+
+    @Test
+    fun `legacy PBKDF2 (v1) backups remain readable`() {
+        // Hand-craft a v1 blob: PBKDF2-HMAC-SHA256 + AES-256-GCM, the exact
+        // format prior versions wrote. Proves the version byte dispatch keeps
+        // existing user backups recoverable after the Argon2id upgrade.
+        val material = mnemonicMaterial()
+        val salt = ByteArray(KeyBackupManager.SALT_SIZE) { it.toByte() }
+        val iv = ByteArray(KeyBackupManager.IV_SIZE) { (it + 1).toByte() }
+        val plaintext = kotlinx.serialization.json.Json
+            .encodeToString(KeyMaterial.serializer(), material)
+            .toByteArray(Charsets.UTF_8)
+        val spec = javax.crypto.spec.PBEKeySpec(testPin, salt, 1_000, KeyBackupManager.KEY_SIZE_BITS)
+        val secret = javax.crypto.SecretKeyFactory
+            .getInstance(KeyBackupManager.KDF_ALGORITHM).generateSecret(spec)
+        val key = javax.crypto.spec.SecretKeySpec(secret.encoded, "AES")
+        val cipher = javax.crypto.Cipher.getInstance(KeyBackupManager.CIPHER_TRANSFORM)
+        cipher.init(
+            javax.crypto.Cipher.ENCRYPT_MODE, key,
+            javax.crypto.spec.GCMParameterSpec(KeyBackupManager.GCM_TAG_BITS, iv)
+        )
+        val ciphertext = cipher.doFinal(plaintext)
+        File(tempDir.root, "legacy.enc").outputStream().use { out ->
+            out.write(KeyBackupManager.MAGIC)
+            out.write(byteArrayOf(KeyBackupManager.FORMAT_VERSION_PBKDF2))
+            out.write(salt)
+            out.write(iv)
+            out.write(ciphertext)
+        }
+
+        val result = manager.readBackup("legacy", testPin)
+        assertNotNull(result)
+        assertEquals(material.privateKey, result!!.privateKey)
+        assertEquals(material.mnemonic, result.mnemonic)
     }
 
     @Test

--- a/android/app/src/test/java/com/rjnr/pocketnode/ui/screens/recovery/RecoveryViewModelTest.kt
+++ b/android/app/src/test/java/com/rjnr/pocketnode/ui/screens/recovery/RecoveryViewModelTest.kt
@@ -1,5 +1,9 @@
 package com.rjnr.pocketnode.ui.screens.recovery
 
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import com.rjnr.pocketnode.data.auth.PinManager
+import com.rjnr.pocketnode.data.crypto.Blake2b
 import com.rjnr.pocketnode.data.wallet.KeyBackupManager
 import com.rjnr.pocketnode.data.wallet.KeyMaterial
 import kotlinx.coroutines.Dispatchers
@@ -31,6 +35,7 @@ class RecoveryViewModelTest {
     private val testDispatcher = StandardTestDispatcher()
     private val correctPin = "123456".toCharArray()
     private val wrongPin = "999999".toCharArray()
+    private var fakeTimeMs: Long = 1_000_000L
 
     private fun testMaterial(walletId: String = "wallet1") = KeyMaterial(
         privateKey = "a".repeat(64),
@@ -50,9 +55,25 @@ class RecoveryViewModelTest {
         Dispatchers.resetMain()
     }
 
-    private fun createBackupManager(): KeyBackupManager {
-        return KeyBackupManager(tempDir.root).also {
-            it.kdfIterations = 1_000
+    private fun createBackupManager(): KeyBackupManager =
+        KeyBackupManager(tempDir.root).also {
+            it.kdfIterations = 1_000          // fast PBKDF2 for legacy reads
+            it.argon2Iterations = 1           // fast Argon2id for v2 writes/reads
+            it.argon2MemoryKb = 8
+            it.argon2Parallelism = 1
+        }
+
+    /** A fast, in-memory PinManager with an optional stored PIN. */
+    private fun createPinManager(pin: CharArray? = null): PinManager {
+        val ctx = ApplicationProvider.getApplicationContext<Context>()
+        return PinManager(ctx, Blake2b()).apply {
+            testPrefs = ctx.getSharedPreferences("test_recovery_pin", Context.MODE_PRIVATE)
+            testPrefs!!.edit().clear().commit()
+            timeProvider = { fakeTimeMs }
+            argon2Iterations = 1
+            argon2MemoryKb = 8
+            argon2Parallelism = 1
+            if (pin != null) setPinFromChars(pin.copyOf())
         }
     }
 
@@ -61,7 +82,7 @@ class RecoveryViewModelTest {
         val manager = createBackupManager()
         manager.writeBackup("wallet1", testMaterial(), correctPin)
 
-        val vm = RecoveryViewModel(manager)
+        val vm = RecoveryViewModel(manager, createPinManager(correctPin), testDispatcher)
 
         assertEquals(RecoveryStage.PIN_ENTRY, vm.uiState.value.stage)
         assertEquals(0, vm.uiState.value.failedAttempts)
@@ -72,7 +93,7 @@ class RecoveryViewModelTest {
     fun `initial state is MnemonicEntry when no backups exist`() {
         val manager = createBackupManager()
 
-        val vm = RecoveryViewModel(manager)
+        val vm = RecoveryViewModel(manager, createPinManager(correctPin), testDispatcher)
 
         assertEquals(RecoveryStage.MNEMONIC_ENTRY, vm.uiState.value.stage)
     }
@@ -82,7 +103,7 @@ class RecoveryViewModelTest {
         val manager = createBackupManager()
         manager.writeBackup("wallet1", testMaterial(), correctPin)
 
-        val vm = RecoveryViewModel(manager)
+        val vm = RecoveryViewModel(manager, createPinManager(correctPin), testDispatcher)
         vm.attemptPinRecovery(correctPin)
         advanceUntilIdle()
 
@@ -94,41 +115,69 @@ class RecoveryViewModelTest {
     }
 
     @Test
-    fun `attemptPinRecovery fails with wrong PIN and tracks attempts`() = runTest {
+    fun `wrong PIN is rejected via PinManager and never reaches decrypt`() = runTest {
         val manager = createBackupManager()
         manager.writeBackup("wallet1", testMaterial(), correctPin)
+        val pinManager = createPinManager(correctPin)
 
-        val vm = RecoveryViewModel(manager)
+        val vm = RecoveryViewModel(manager, pinManager, testDispatcher)
         vm.attemptPinRecovery(wrongPin)
         advanceUntilIdle()
 
         assertEquals(RecoveryStage.PIN_ENTRY, vm.uiState.value.stage)
         assertEquals(1, vm.uiState.value.failedAttempts)
-        assertEquals("Incorrect PIN. 2 attempts remaining.", vm.uiState.value.error)
+        // PinManager (MAX_ATTEMPTS = 5) drives the counter, not a per-screen 3.
+        assertEquals("Incorrect PIN. 4 attempts remaining.", vm.uiState.value.error)
+        // The failed recovery attempt was recorded in the SHARED persistent
+        // lockout state — the bypass is closed.
+        assertEquals(4, pinManager.getRemainingAttempts())
     }
 
     @Test
-    fun `3 failed PIN attempts transitions to MnemonicEntry`() = runTest {
+    fun `recovery PIN attempts hit the persistent lockout (no bypass)`() = runTest {
         val manager = createBackupManager()
         manager.writeBackup("wallet1", testMaterial(), correctPin)
+        val pinManager = createPinManager(correctPin)
 
-        val vm = RecoveryViewModel(manager)
+        val vm = RecoveryViewModel(manager, pinManager, testDispatcher)
+        // 5 wrong attempts → PinManager locks out for 30s.
+        repeat(5) {
+            vm.attemptPinRecovery(wrongPin)
+            advanceUntilIdle()
+        }
+        assertTrue("PinManager must be locked out after 5 failures", pinManager.isLockedOut())
 
-        vm.attemptPinRecovery(wrongPin)
+        // A further attempt is refused before any decrypt, even with the
+        // CORRECT pin, because the lockout is active.
+        vm.attemptPinRecovery(correctPin)
         advanceUntilIdle()
-        assertEquals(1, vm.uiState.value.failedAttempts)
         assertEquals(RecoveryStage.PIN_ENTRY, vm.uiState.value.stage)
+        assertTrue(vm.uiState.value.error!!.contains("Try again"))
 
-        vm.attemptPinRecovery(wrongPin)
+        // Once the lockout expires, the correct PIN recovers.
+        fakeTimeMs += 31_000L
+        vm.attemptPinRecovery(correctPin)
         advanceUntilIdle()
-        assertEquals(2, vm.uiState.value.failedAttempts)
-        assertEquals(RecoveryStage.PIN_ENTRY, vm.uiState.value.stage)
+        assertEquals(RecoveryStage.SUCCESS, vm.uiState.value.stage)
+    }
 
-        vm.attemptPinRecovery(wrongPin)
-        advanceUntilIdle()
-        assertEquals(3, vm.uiState.value.failedAttempts)
+    @Test
+    fun `permanent lockout routes to MnemonicEntry`() = runTest {
+        val manager = createBackupManager()
+        manager.writeBackup("wallet1", testMaterial(), correctPin)
+        val pinManager = createPinManager(correctPin)
+
+        val vm = RecoveryViewModel(manager, pinManager, testDispatcher)
+        // Grind to the permanent-lockout threshold (10 failures), advancing time
+        // past each escalating lockout window so the next attempt isn't pre-blocked.
+        val windows = longArrayOf(0, 0, 0, 0, 31_000, 61_000, 301_000, 1_801_000, 3_601_000, 3_601_000)
+        for (w in windows) {
+            fakeTimeMs += w
+            vm.attemptPinRecovery(wrongPin)
+            advanceUntilIdle()
+        }
+        assertTrue(pinManager.isPermanentlyLocked())
         assertEquals(RecoveryStage.MNEMONIC_ENTRY, vm.uiState.value.stage)
-        assertEquals("Too many failed attempts. Please enter your recovery phrase.", vm.uiState.value.error)
     }
 
     @Test
@@ -136,11 +185,10 @@ class RecoveryViewModelTest {
         val manager = createBackupManager()
         manager.writeBackup("wallet1", testMaterial(), correctPin)
 
-        val vm = RecoveryViewModel(manager)
+        val vm = RecoveryViewModel(manager, createPinManager(correctPin), testDispatcher)
         vm.attemptPinRecovery(wrongPin)
         advanceUntilIdle()
 
-        // Error should be set
         assertTrue(vm.uiState.value.error != null)
 
         vm.clearError()
@@ -152,12 +200,13 @@ class RecoveryViewModelTest {
         val manager = createBackupManager()
         val pin1 = "111111".toCharArray()
         val pin2 = "222222".toCharArray()
-        // wallet1 encrypted with pin1, wallet2 encrypted with pin2
+        // wallet1 encrypted with pin1, wallet2 encrypted with pin2.
         manager.writeBackup("wallet1", testMaterial("wallet1"), pin1)
         manager.writeBackup("wallet2", testMaterial("wallet2"), pin2)
 
-        val vm = RecoveryViewModel(manager)
-        // Try with pin1 — wallet1 succeeds, wallet2 fails
+        // The device PIN is pin1, so the verify gate passes and the decrypt
+        // loop recovers wallet1 while wallet2 (encrypted under pin2) fails.
+        val vm = RecoveryViewModel(manager, createPinManager(pin1), testDispatcher)
         vm.attemptPinRecovery(pin1)
         advanceUntilIdle()
 


### PR DESCRIPTION
## Summary
Three backup-hardening fixes from the security sweep (#319):

### 1. dataExtractionRules — block D2D exfiltration of seed backups
`allowBackup="false"` disables cloud Auto Backup but **not** Android 12+ device-to-device transfer, which `android:dataExtractionRules` governs independently. The PIN-encrypted blobs in `key_backups/*.enc` are self-contained — only a 6-digit PIN protects the seed — so a migration could copy them to a new device for offline brute force. New [data_extraction_rules.xml](android/app/src/main/res/xml/data_extraction_rules.xml) excludes `key_backups/`, `ckb_pin_prefs`, and `key_migration` from both `<cloud-backup>` and `<device-transfer>`.

### 2. Recovery PIN bypassed the lockout
`RecoveryViewModel` called `readBackup(id, pin)` directly, throttled only by an in-memory counter that reset on every screen recreate — an on-device attacker got unlimited 6-digit guesses, bounded only by KDF cost. It now verifies through `PinManager.verifyPinFromChars`, sharing the **same persistent, cross-session escalating lockout** as the lock screen (30s → … → permanent at 10 failures), and refuses while locked. Decrypt moved off the main thread via an injected dispatcher.

### 3. Backup KDF upgraded to Argon2id
`KeyBackupManager` derived the backup AES key with PBKDF2-SHA256/600k — weak against offline brute force of a 10⁶ keyspace, and weaker than the Argon2id the PIN hash already uses. New backups now use **Argon2id (64 MB / t=3 / p=4)**. The format version byte goes to 2; **v1 (PBKDF2) blobs stay readable** and upgrade to v2 on the next re-encrypt (PIN change / opportunistic rewrite).

## Testing
- `KeyBackupManagerTest`: new backups are Argon2id v2; legacy hand-crafted v1 PBKDF2 blobs still decrypt.
- `RecoveryViewModelTest`: rewritten for PinManager gating — wrong-PIN counts against the shared lockout, 5 failures lock out (even a correct PIN is refused), lockout expiry recovers, 10 failures route to mnemonic.
- Full `testDebugUnitTest` green.

Closes #319

🤖 Generated with [Claude Code](https://claude.com/claude-code)