### PR TITLE
fix(update): internal-storage APK staging, URL allowlist, size cap (#318)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -134,6 +134,9 @@ target/
 
 # Debug
 debug/
+# ...but the Android debug *source set* is real source, not a build output.
+!android/app/src/debug/
+!android/app/src/debug/**
 
 # ===================
 # Environment Files

--- a/android/app/src/debug/res/xml/network_security_config.xml
+++ b/android/app/src/debug/res/xml/network_security_config.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  DEBUG-ONLY network security config. Permits cleartext to the emulator host
+  (10.0.2.2) and localhost for local development against a dev node. The
+  release build uses src/main's config, which permits no cleartext anywhere
+  (#318). Keep these exemptions out of production.
+-->
+<network-security-config>
+    <domain-config cleartextTrafficPermitted="true">
+        <domain includeSubdomains="true">10.0.2.2</domain>
+        <domain includeSubdomains="true">localhost</domain>
+    </domain-config>
+</network-security-config>

--- a/android/app/src/main/java/com/rjnr/pocketnode/data/update/UpdateDownloader.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/update/UpdateDownloader.kt
@@ -3,7 +3,7 @@ package com.rjnr.pocketnode.data.update
 import android.content.Context
 import android.content.Intent
 import android.net.Uri
-import android.os.Environment
+import android.os.StatFs
 import android.provider.Settings
 import android.util.Log
 import androidx.core.content.FileProvider
@@ -34,7 +34,22 @@ import javax.inject.Singleton
 
 private const val TAG = "UpdateDownloader"
 private const val APK_FILE_NAME = "pocket-node-update.apk"
+private const val APK_SUBDIR = "updates"
 private const val DOWNLOAD_BUFFER_BYTES = 16 * 1024
+
+// Hard ceiling on a downloaded APK regardless of the server-advertised size,
+// so a hostile/compromised endpoint can't fill the data partition and break
+// the light-client store / Room DB (#318). The real APK is ~40 MB.
+private const val MAX_APK_BYTES = 150L * 1024 * 1024
+
+// Hosts the GitHub release asset URL (and its redirect target) may resolve to.
+// browser_download_url lives on github.com; it 302s to the githubusercontent
+// CDN. Anything else is rejected before a single byte is streamed to disk.
+private val ALLOWED_APK_HOSTS = setOf(
+    "github.com",
+    "objects.githubusercontent.com",
+    "release-assets.githubusercontent.com",
+)
 
 /**
  * Visible states for the auto-update download flow. HomeScreen + the
@@ -142,6 +157,16 @@ class UpdateDownloader @Inject constructor(
      * trivial via Job.cancel.
      */
     fun downloadAndInstall(apkUrl: String, totalBytesHint: Long = -1L) {
+        // Reject anything that isn't an HTTPS GitHub release URL before we
+        // queue a download (#318). The signature gate at install is the last
+        // line of defense, but there's no reason to stream attacker-chosen
+        // bytes to disk first.
+        if (!isAllowedApkUrl(apkUrl)) {
+            Log.e(TAG, "Refusing update download from disallowed URL host")
+            _state.value = DownloadState.Failed("Update download blocked: untrusted source.")
+            return
+        }
+
         // Remember args for Retry. Set before the launch so a quick
         // Failed→Retry cycle finds the URL even if the job's catch block
         // has not run yet.
@@ -158,11 +183,28 @@ class UpdateDownloader @Inject constructor(
             cleanupStaleApk()
             _state.value = DownloadState.Downloading(0L, totalBytesHint.coerceAtLeast(0L))
 
-            val apkFile = File(
-                context.getExternalFilesDir(Environment.DIRECTORY_DOWNLOADS),
-                APK_FILE_NAME
-            )
+            val apkFile = apkFile()
             apkFile.parentFile?.mkdirs()
+
+            // Effective byte ceiling: trust the advertised size (+20% slack)
+            // when it's plausible, else the hard cap. Either way never exceed
+            // MAX_APK_BYTES so a lying Content-Length can't fill the disk.
+            val sizeCap = if (totalBytesHint in 1 until MAX_APK_BYTES) {
+                (totalBytesHint + totalBytesHint / 5).coerceAtMost(MAX_APK_BYTES)
+            } else {
+                MAX_APK_BYTES
+            }
+
+            // Free-space guard: refuse if we don't have room for the APK plus
+            // headroom, rather than half-writing and corrupting storage.
+            val free = runCatching {
+                val stat = StatFs(apkFile.parentFile?.absolutePath ?: context.filesDir.absolutePath)
+                stat.availableBytes
+            }.getOrDefault(Long.MAX_VALUE)
+            if (free < sizeCap + 32L * 1024 * 1024) {
+                _state.value = DownloadState.Failed("Not enough free space to download the update.")
+                return@launch
+            }
 
             try {
                 httpClient.prepareGet(apkUrl) {
@@ -190,9 +232,16 @@ class UpdateDownloader @Inject constructor(
                     val channel: ByteReadChannel = response.bodyAsChannel()
                     apkFile.outputStream().use { out ->
                         val buf = ByteArray(DOWNLOAD_BUFFER_BYTES)
+                        var written = 0L
                         while (!channel.isClosedForRead) {
                             val read = channel.readAvailable(buf, 0, buf.size)
                             if (read <= 0) break
+                            written += read
+                            // Abort the moment the stream exceeds the ceiling —
+                            // don't let an endless/oversized body fill the disk.
+                            if (written > sizeCap) {
+                                throw IOException("Update exceeds maximum size ($sizeCap bytes)")
+                            }
                             out.write(buf, 0, read)
                         }
                         out.flush()
@@ -238,10 +287,7 @@ class UpdateDownloader @Inject constructor(
      */
     fun installNow() {
         if (_state.value !is DownloadState.ReadyToInstall) return
-        val apkFile = File(
-            context.getExternalFilesDir(Environment.DIRECTORY_DOWNLOADS),
-            APK_FILE_NAME
-        )
+        val apkFile = apkFile()
         val verification = verifyApkSignature(apkFile)
         if (verification != SignatureCheck.Ok) {
             Log.e(TAG, "APK signature verification failed: $verification")
@@ -323,19 +369,13 @@ class UpdateDownloader @Inject constructor(
         downloadJob = null
         lastApkUrl = null
         lastTotalBytesHint = -1L
-        val apkFile = File(
-            context.getExternalFilesDir(Environment.DIRECTORY_DOWNLOADS),
-            APK_FILE_NAME
-        )
+        val apkFile = apkFile()
         if (apkFile.exists()) apkFile.delete()
         _state.value = DownloadState.Idle
     }
 
     private fun launchSystemInstaller() {
-        val apkFile = File(
-            context.getExternalFilesDir(Environment.DIRECTORY_DOWNLOADS),
-            APK_FILE_NAME
-        )
+        val apkFile = apkFile()
         if (!apkFile.exists()) {
             Log.e(TAG, "APK file not found at ${apkFile.absolutePath}")
             _state.value = DownloadState.Failed("APK file not found after download")
@@ -380,13 +420,29 @@ class UpdateDownloader @Inject constructor(
     }
 
     private fun cleanupStaleApk() {
-        val apkFile = File(
-            context.getExternalFilesDir(Environment.DIRECTORY_DOWNLOADS),
-            APK_FILE_NAME
-        )
+        val apkFile = apkFile()
         if (apkFile.exists()) {
             val deleted = apkFile.delete()
             Log.d(TAG, "cleanupStaleApk: deleted=$deleted size=${apkFile.length()}")
         }
+    }
+
+    /**
+     * The staged-update APK path. Internal storage ([Context.filesDir]) — NOT
+     * external app storage — so no other app can write or swap the file
+     * between our signature check and the system installer's read (#318 TOCTOU,
+     * exploitable on API 26-28 where any WRITE_EXTERNAL_STORAGE holder can
+     * write inside Android/data/<pkg>/). Served to the installer via the
+     * `<files-path>` FileProvider entry.
+     */
+    private fun apkFile(): File = File(File(context.filesDir, APK_SUBDIR), APK_FILE_NAME)
+
+    /** True iff [url] is an HTTPS URL on the GitHub release-asset host allowlist (#318). */
+    @androidx.annotation.VisibleForTesting
+    internal fun isAllowedApkUrl(url: String): Boolean {
+        val parsed = runCatching { Uri.parse(url) }.getOrNull() ?: return false
+        val scheme = parsed.scheme?.lowercase()
+        val host = parsed.host?.lowercase()
+        return scheme == "https" && host != null && host in ALLOWED_APK_HOSTS
     }
 }

--- a/android/app/src/main/res/xml/file_provider_paths.xml
+++ b/android/app/src/main/res/xml/file_provider_paths.xml
@@ -1,4 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <paths>
-    <external-files-path name="apk_downloads" path="Download" />
+    <!--
+      Update APKs are staged in internal storage (filesDir/updates/) so no
+      other app can swap the file between the signature check and the system
+      installer's read (#318). Served read-only to the installer via a
+      per-URI grant.
+    -->
+    <files-path name="apk_downloads" path="updates/" />
 </paths>

--- a/android/app/src/main/res/xml/network_security_config.xml
+++ b/android/app/src/main/res/xml/network_security_config.xml
@@ -1,7 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!--
+  Release config: no cleartext anywhere. All production traffic (GitHub
+  update API + APK download, CoinGecko/Binance price, explorer) is HTTPS,
+  and the embedded light-client RPC is never started, so nothing needs
+  cleartext. Dev cleartext exemptions (10.0.2.2 / localhost) live in
+  src/debug/res/xml/network_security_config.xml only (#318).
+-->
 <network-security-config>
-    <domain-config cleartextTrafficPermitted="true">
-        <domain includeSubdomains="true">10.0.2.2</domain>
-        <domain includeSubdomains="true">localhost</domain>
-    </domain-config>
+    <base-config cleartextTrafficPermitted="false" />
 </network-security-config>

--- a/android/app/src/test/java/com/rjnr/pocketnode/data/update/UpdateDownloaderUrlTest.kt
+++ b/android/app/src/test/java/com/rjnr/pocketnode/data/update/UpdateDownloaderUrlTest.kt
@@ -1,0 +1,57 @@
+package com.rjnr.pocketnode.data.update
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * #318: the update downloader must only fetch from HTTPS GitHub release-asset
+ * hosts. Anything else is rejected before a byte is streamed to disk; the
+ * signature gate is the backstop, not the first line of defense.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [28], manifest = Config.NONE)
+class UpdateDownloaderUrlTest {
+
+    private lateinit var downloader: UpdateDownloader
+
+    @Before
+    fun setUp() {
+        val ctx = ApplicationProvider.getApplicationContext<Context>()
+        downloader = UpdateDownloader(ctx)
+    }
+
+    @Test
+    fun `accepts github release asset URLs over https`() {
+        assertTrue(downloader.isAllowedApkUrl("https://github.com/RaheemJnr/pocket-node/releases/download/v1.7.4/app.apk"))
+        assertTrue(downloader.isAllowedApkUrl("https://objects.githubusercontent.com/github-production-release-asset/x/y.apk"))
+        assertTrue(downloader.isAllowedApkUrl("https://release-assets.githubusercontent.com/foo/app.apk"))
+    }
+
+    @Test
+    fun `rejects non-https schemes`() {
+        assertFalse(downloader.isAllowedApkUrl("http://github.com/RaheemJnr/pocket-node/releases/download/v1/app.apk"))
+        assertFalse(downloader.isAllowedApkUrl("file:///data/local/tmp/evil.apk"))
+    }
+
+    @Test
+    fun `rejects disallowed hosts`() {
+        assertFalse(downloader.isAllowedApkUrl("https://evil.com/app.apk"))
+        assertFalse(downloader.isAllowedApkUrl("https://github.com.evil.com/app.apk"))
+        // Subdomain of an allowed host is NOT auto-allowed (exact host match).
+        assertFalse(downloader.isAllowedApkUrl("https://gist.github.com/app.apk"))
+    }
+
+    @Test
+    fun `rejects malformed input`() {
+        assertFalse(downloader.isAllowedApkUrl(""))
+        assertFalse(downloader.isAllowedApkUrl("not a url"))
+        assertFalse(downloader.isAllowedApkUrl("https:///app.apk"))
+    }
+}


### PR DESCRIPTION
## Summary
Updater hardening from the security sweep (#318):

### 1. Stage the APK in internal storage (TOCTOU)
The downloaded APK moved from `getExternalFilesDir(DIRECTORY_DOWNLOADS)` to `filesDir/updates/`, and the FileProvider entry from `<external-files-path>` to `<files-path>`. On API 26-28 (minSdk 26, pre-scoped-storage) any app holding `WRITE_EXTERNAL_STORAGE` can write inside another app's `Android/data/`, so a malicious app could swap `pocket-node-update.apk` between `installNow()`'s signature check and the installer's re-read. Internal storage is inaccessible to other apps on **all** API levels, removing the window.

### 2. Download URL allowlist
`downloadAndInstall` rejects any URL that isn't HTTPS on a GitHub release-asset host (`github.com`, `objects.githubusercontent.com`, `release-assets.githubusercontent.com`) **before** streaming. A compromised release JSON / MITM can no longer point the downloader at an arbitrary endpoint to spray bytes to disk; the signature gate remains the backstop.

### 3. Size cap + free-space guard
The write loop aborts once bytes exceed the advertised size +20% (hard ceiling **150 MB**), and the download refuses up front if free space is insufficient — a hostile/oversized body can't fill the data partition and break the light-client store / Room DB.

### Related (sweep low)
Moved the cleartext network-security exemptions (`10.0.2.2`, `localhost`) into a **debug-only** `network_security_config.xml`; the release config now permits no cleartext (all prod traffic is HTTPS, RPC server never starts). Un-ignored `android/app/src/debug/` — the broad `debug/` gitignore rule was meant for build outputs, not the source set.

## Testing
- New `UpdateDownloaderUrlTest`: accepts github asset URLs; rejects non-HTTPS, look-alike hosts (`github.com.evil.com`), subdomains, and malformed input.
- `processDebugResources` validates the debug/main network-config merge.
- Full `testDebugUnitTest` green; signature test (#293) unaffected (path-independent).

Closes #318

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved app update reliability with pre-download storage space verification.

* **Security**
  * App update downloads now enforce strict source verification and download size limits.
  * Production network security configuration now requires encrypted connections for all communications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->