### PR TITLE
chore(hardening): low-severity sweep fixes — parsing, locale, JNI (#321)

### DIFF
--- a/android/app/src/main/assets/mainnet.toml
+++ b/android/app/src/main/assets/mainnet.toml
@@ -72,6 +72,10 @@ discovery_local_address = false
 # Ensure that itself can continue to serve as a bootnode node
 bootnode_mode = false
 
+# NOTE: the JNI build does NOT start an RPC server (see lifecycle.rs —
+# startup is intentionally skipped). This block is inert. Keep listen_address
+# bound to loopback: if the server is ever wired up, binding elsewhere would
+# expose an unauthenticated API to co-resident apps on the device (#321).
 [rpc]
 # Light client rpc is designed for self hosting, exposing to public network is not recommended and may cause security issues.
 # By default RPC only binds to localhost, thus it only allows accessing from the same machine.

--- a/android/app/src/main/assets/testnet.toml
+++ b/android/app/src/main/assets/testnet.toml
@@ -66,6 +66,10 @@ discovery_local_address = false
 # Ensure that itself can continue to serve as a bootnode node
 bootnode_mode = false
 
+# NOTE: the JNI build does NOT start an RPC server (see lifecycle.rs —
+# startup is intentionally skipped). This block is inert. Keep listen_address
+# bound to loopback: if the server is ever wired up, binding elsewhere would
+# expose an unauthenticated API to co-resident apps on the device (#321).
 [rpc]
 # Light client rpc is designed for self hosting, exposing to public network is not recommended and may cause security issues.
 # By default RPC only binds to localhost, thus it only allows accessing from the same machine.

--- a/android/app/src/main/java/com/rjnr/pocketnode/data/gateway/GatewayRepository.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/gateway/GatewayRepository.kt
@@ -859,11 +859,15 @@ class GatewayRepository @Inject constructor(
                     if (outpointKey !in spentOutpoints) {
                         // Exclude cells with type scripts (DAO cells, etc.) from available balance
                         // Like Neuron: typeHash IS NULL AND hasData = false
-                        if (cell.output.type != null) {
-                            val cellCapacity = cell.output.capacity.removePrefix("0x").toLong(16)
+                        // Skip a record with an unparseable capacity rather than
+                        // letting one bad value throw and poison the whole balance
+                        // page (#321). toLongOrNull also guards u64 > Long.MAX.
+                        val cellCapacity = cell.output.capacity.removePrefix("0x").toLongOrNull(16)
+                        if (cellCapacity == null) {
+                            Log.w(TAG, "Skipping cell $outpointKey with unparseable capacity ${cell.output.capacity}")
+                        } else if (cell.output.type != null) {
                             Log.d(TAG, "🔒 DAO/typed cell excluded from balance: $outpointKey = $cellCapacity shannons")
                         } else {
-                            val cellCapacity = cell.output.capacity.removePrefix("0x").toLong(16)
                             liveCapacity += cellCapacity
                             liveCellCount++
                             Log.d(TAG, "✅ Live cell: $outpointKey = $cellCapacity shannons")

--- a/android/app/src/main/java/com/rjnr/pocketnode/data/update/UpdateRepository.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/update/UpdateRepository.kt
@@ -80,8 +80,13 @@ class UpdateRepository @Inject constructor(
          * Compares dot-separated integer segments left to right.
          */
         internal fun isNewer(current: String, latest: String): Boolean {
-            val currentParts = current.split(".").mapNotNull { it.toIntOrNull() }
-            val latestParts = latest.split(".").mapNotNull { it.toIntOrNull() }
+            // Parse the leading digit-run of each dot segment so pre-release
+            // suffixes survive: "1.7.3-rc1" -> [1, 7, 3], not [1, 7] (#321).
+            fun parts(v: String) = v.split(".").mapNotNull { seg ->
+                seg.takeWhile { it.isDigit() }.takeIf { it.isNotEmpty() }?.toIntOrNull()
+            }
+            val currentParts = parts(current)
+            val latestParts = parts(latest)
 
             if (currentParts.isEmpty() || latestParts.isEmpty()) return false
 

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/dao/components/DepositBottomSheet.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/dao/components/DepositBottomSheet.kt
@@ -120,7 +120,11 @@ fun DepositBottomSheet(
                     shape = CircleShape,
                     onClick = {
                         val maxCkb = maxDepositable / 100_000_000.0
-                        amountText = "%.8f".format(maxCkb).trimEnd('0').trimEnd('.').ifEmpty { "0" }
+                        // Locale.US — sanitizeAmount rejects comma decimals; on
+                        // de/fr/es devices "%.8f".format(...) emits "0,12" and the
+                        // MAX tap would silently no-op (#321).
+                        amountText = String.format(java.util.Locale.US, "%.8f", maxCkb)
+                            .trimEnd('0').trimEnd('.').ifEmpty { "0" }
                     },
                     enabled = maxDepositable >= DaoConstants.MIN_DEPOSIT_SHANNONS,
                 ) {

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/send/SendViewModel.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/send/SendViewModel.kt
@@ -251,7 +251,7 @@ class SendViewModel @Inject constructor(
         val amountShannons = try {
             if (sanitized.isEmpty()) 0L
             else BigDecimal(sanitized).setScale(8, RoundingMode.DOWN)
-                .multiply(BigDecimal(100_000_000)).toLong()
+                .multiply(BigDecimal(100_000_000)).longValueExact()
         } catch (e: Exception) {
             0L
         }
@@ -272,7 +272,8 @@ class SendViewModel @Inject constructor(
                 .divide(java.math.BigDecimal(100_000_000))
                 .stripTrailingZeros()
                 .toPlainString()
-            "Warning: Your remaining $lostCkb CKB is below the 61 CKB minimum and will be lost as a fee."
+            "Heads up: this would leave $lostCkb CKB change, below the 61 CKB minimum cell size. " +
+                "The send will be refused — adjust the amount so the change is 0 or at least 61 CKB."
         } else {
             null
         }
@@ -353,7 +354,7 @@ class SendViewModel @Inject constructor(
         }
         val amountShannons = try {
             BigDecimal(state.amountCkb).setScale(8, RoundingMode.DOWN)
-                .multiply(BigDecimal(100_000_000)).toLong()
+                .multiply(BigDecimal(100_000_000)).longValueExact()
         } catch (e: Exception) {
             _uiState.update { it.copy(error = com.rjnr.pocketnode.ui.util.UiMessage.Resource(com.rjnr.pocketnode.R.string.vm_error_invalid_amount)) }
             return false
@@ -390,7 +391,7 @@ class SendViewModel @Inject constructor(
     private suspend fun executeSendV2(activity: FragmentActivity) {
         val state = _uiState.value
         val amountShannons = BigDecimal(state.amountCkb).setScale(8, RoundingMode.DOWN)
-            .multiply(BigDecimal(100_000_000)).toLong()
+            .multiply(BigDecimal(100_000_000)).longValueExact()
 
         val capturedAddress = repository.getCurrentAddress()
         if (capturedAddress == null) {
@@ -495,7 +496,7 @@ class SendViewModel @Inject constructor(
 
         val amountShannons = try {
             BigDecimal(state.amountCkb).setScale(8, RoundingMode.DOWN)
-                .multiply(BigDecimal(100_000_000)).toLong()
+                .multiply(BigDecimal(100_000_000)).longValueExact()
         } catch (e: Exception) {
             _uiState.update { it.copy(error = com.rjnr.pocketnode.ui.util.UiMessage.Resource(com.rjnr.pocketnode.R.string.vm_error_invalid_amount)) }
             return

--- a/android/app/src/test/java/com/rjnr/pocketnode/data/update/UpdateRepositoryTest.kt
+++ b/android/app/src/test/java/com/rjnr/pocketnode/data/update/UpdateRepositoryTest.kt
@@ -40,6 +40,15 @@ class UpdateRepositoryTest {
         assertFalse(UpdateRepository.isNewer("", ""))
     }
 
+    @Test
+    fun `isNewer parses pre-release suffixes by leading digits (#321)`() {
+        // "1.7.3-rc1" must read as [1,7,3], not [1,7] — so it is newer than
+        // 1.7.2 and equal to (not newer than) 1.7.3.
+        assertTrue(UpdateRepository.isNewer("1.7.2", "1.7.3-rc1"))
+        assertFalse(UpdateRepository.isNewer("1.7.3-rc1", "1.7.3"))
+        assertFalse(UpdateRepository.isNewer("1.7.3", "1.7.3-rc1"))
+    }
+
     // --- findApkAsset ---
 
     @Test

--- a/external/ckb-light-client/light-client-lib/src/jni_bridge/callbacks.rs
+++ b/external/ckb-light-client/light-client-lib/src/jni_bridge/callbacks.rs
@@ -17,7 +17,7 @@ pub fn invoke_status_callback(status: &str, data: &str) -> Result<(), Box<dyn st
     let data_str = env.new_string(data)?;
 
     // Call: void onStatusChange(String status, String data)
-    env.call_method(
+    let result = env.call_method(
         callback.as_obj(),
         "onStatusChange",
         "(Ljava/lang/String;Ljava/lang/String;)V",
@@ -25,7 +25,16 @@ pub fn invoke_status_callback(status: &str, data: &str) -> Result<(), Box<dyn st
             jni::objects::JValue::Object(&status_str),
             jni::objects::JValue::Object(&data_str),
         ],
-    )?;
+    );
+
+    // If the Kotlin callback threw, clear the pending Java exception so it
+    // doesn't linger on this attached thread until detach (#321). The current
+    // Kotlin impl only writes a StateFlow and can't throw, but this keeps the
+    // boundary safe if that ever changes.
+    if result.is_err() {
+        let _ = env.exception_clear();
+    }
+    result?;
 
     Ok(())
 }

--- a/external/ckb-light-client/light-client-lib/src/jni_bridge/query.rs
+++ b/external/ckb-light-client/light-client-lib/src/jni_bridge/query.rs
@@ -654,7 +654,7 @@ pub extern "C" fn Java_com_nervosnetwork_ckblightclient_LightClientNative_native
                 tx_index: tx_index.into(),
             })
         })
-        .take(limit as usize)
+        .take(limit.max(0) as usize)
         .collect();
 
     let result = Pagination {
@@ -817,7 +817,7 @@ pub extern "C" fn Java_com_nervosnetwork_ckblightclient_LightClientNative_native
                 io_capacity: io_capacity.into(),
             }))
         })
-        .take(limit as usize)
+        .take(limit.max(0) as usize)
         .collect();
 
     let result = Pagination {


### PR DESCRIPTION
## Summary
A focused pass over the low-severity sweep bundle (#321). High-confidence, low-risk fixes only:

- **Balance builder capacity parse** ([GatewayRepository]) — `toLongOrNull` + skip a bad record rather than letting one unparseable capacity throw and poison the whole balance page. (Also guards u64 > Long.MAX.)
- **Amount overflow** ([SendViewModel]) — `BigDecimal…longValueExact()` (throws → caught as "invalid amount") instead of `toLong()`'s silent narrowing wrap.
- **Stale burn warning** ([SendViewModel]) — reworded the pre-#287 "will be lost as a fee" copy; the builder now *refuses* dust-change sends, so the warning explains that and how to adjust.
- **Locale bug** ([DepositBottomSheet]) — MAX button uses `Locale.US` so de/fr/es (comma-decimal) devices no longer silently no-op. (SendViewModel's send-max was already fixed.)
- **Version compare** ([UpdateRepository.isNewer]) — parses the leading digit-run of each dot segment so `1.7.3-rc1` reads as `[1,7,3]`; fully non-numeric versions stay malformed (false). Regression test added.
- **Rust JNI** — `callbacks.rs` clears a pending Java exception if the Kotlin status callback throws; `query.rs` clamps a negative `jint` limit before `as usize`; `mainnet/testnet.toml` document that the `[rpc]` block is inert (server never started) and must stay loopback-bound.

## Deferred (left on #321)
send-max integer-math rewrite, `toLongOrNull` at the remaining capacity sites, `LightClientNative` link-error gating, debug-build log scrubbing, and the String→ByteArray memory-hygiene refactor — each low/no realistic impact and not worth the churn/risk here.

## Testing
- `testDebugUnitTest` green (new isNewer pre-release test).
- `cargo check` green for the JNI crate.

Refs #321 (partial — see deferred list)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved balance calculation to handle malformed cell data gracefully.
  * Fixed decimal separator issues for locale-specific number inputs.
  * Enhanced transaction amount precision to prevent rounding truncation.
  * Corrected query result pagination limits to prevent oversized batches.
  * Refined dust change warning messages for clarity.
  * Strengthened JNI error handling for robustness.

* **Tests**
  * Added version parsing validation tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->