### PR TITLE
ci(smoke): harden upgrade-smoke against both #330 flake modes

### DIFF
--- a/.github/workflows/upgrade-smoke-rerun.yml
+++ b/.github/workflows/upgrade-smoke-rerun.yml
@@ -1,0 +1,35 @@
+# Auto-rerun the upgrade-smoke check exactly once when its first attempt
+# fails (#330). Both known flake modes (PIN-intro transition race, emulator
+# boot timeout) resolve on rerun; a second failure stays red — twice-failing
+# is signal, not flake.
+#
+# Notes:
+# - workflow_run only triggers from the default branch, so this is inert
+#   until merged to main.
+# - Skip-path smoke runs conclude 'success' and cancelled runs 'cancelled',
+#   so the 'failure' guard ignores both.
+# - GITHUB_TOKEN-initiated reruns don't retrigger workflow_run in a loop;
+#   the run_attempt == 1 guard is belt-and-braces on top of that.
+name: Upgrade Smoke Auto-Rerun
+
+on:
+  workflow_run:
+    workflows: ["Upgrade Smoke"]
+    types: [completed]
+
+permissions:
+  actions: write
+
+jobs:
+  rerun:
+    if: >-
+      github.event.workflow_run.conclusion == 'failure' &&
+      github.event.workflow_run.run_attempt == 1
+    runs-on: ubuntu-latest
+    steps:
+      - name: Rerun failed smoke jobs once
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh api -X POST \
+            "repos/${{ github.repository }}/actions/runs/${{ github.event.workflow_run.id }}/rerun-failed-jobs"

--- a/.github/workflows/upgrade-smoke.yml
+++ b/.github/workflows/upgrade-smoke.yml
@@ -134,6 +134,9 @@ jobs:
           api-level: 34
           arch: x86_64
           target: default
+          # Default 600 s flakes on slow shared runners — see #330 mode 2
+          # (run 27303458847: "Timeout waiting for emulator to boot").
+          emulator-boot-timeout: 900
           force-avd-creation: false
           emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           disable-animations: true
@@ -146,7 +149,10 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: upgrade-smoke-artifacts
+          # Suffix with attempt so a rerun can't clobber/409 the previous
+          # attempt's fail-*.png/xml evidence (upload-artifact@v4 artifacts
+          # are immutable per run).
+          name: upgrade-smoke-artifacts-attempt-${{ github.run_attempt }}
           path: |
             seed.log
             post.log

--- a/android/app/src/androidTest/java/com/rjnr/pocketnode/UpgradeSmokeTest.kt
+++ b/android/app/src/androidTest/java/com/rjnr/pocketnode/UpgradeSmokeTest.kt
@@ -26,6 +26,12 @@ private const val LAUNCH_TIMEOUT_MS = 10_000L
 private const val ONBOARDING_TIMEOUT_MS = 15_000L
 private const val POST_UPGRADE_HOME_TIMEOUT_MS = 30_000L
 
+// Import → PIN-intro transition does real key-derivation work; on a loaded
+// CI x86_64 emulator (no hardware crypto) it can blow well past the ~27 s
+// combined budget of a single clickButton call. Same 90 s ceiling as the
+// Argon2id allowance in tapDigit1UntilTitleChanges, for the same reason.
+private const val PIN_INTRO_DEADLINE_MS = 90_000L
+
 // Standard BIP39 dev mnemonic. 11×"abandon" + "about" is a valid checksum.
 // Hardcoded so the seed is deterministic across runs.
 private const val TEST_MNEMONIC =
@@ -125,10 +131,14 @@ class UpgradeSmokeTest {
         // it doesn't appear; clickButton returns false and we fall through.
         clickButton("sync-sheet-apply", "Apply", ONBOARDING_TIMEOUT_MS)
 
-        // After import + sync-selection the app shows the PIN intro.
+        // After import + sync-selection the app shows the PIN intro. Deadline-
+        // poll instead of a single fixed-timeout lookup: import does real
+        // key-derivation work and the transition can be slow on CI (#330).
+        // Other call sites stay on fixed timeouts deliberately — real
+        // onboarding breaks (#324) should fail loud and fast.
         assertTrue(
             "PIN intro continue button not found",
-            clickButton("pin-intro-continue", "Create PIN", ONBOARDING_TIMEOUT_MS)
+            clickButtonWithin("pin-intro-continue", "Create PIN", PIN_INTRO_DEADLINE_MS)
         )
 
         // SETUP phase: tap digit 1 until the SETUP title disappears. This
@@ -203,6 +213,23 @@ class UpgradeSmokeTest {
             "Home balance row not visible within ${POST_UPGRADE_HOME_TIMEOUT_MS}ms after upgrade",
             balanceRow
         )
+    }
+
+    /**
+     * Deadline-poll wrapper around clickButton for screens that can take a long
+     * time to APPEAR (vs. nodes that exist but go briefly stale). Each cycle
+     * re-runs the full clickButton strategy (resource-id fast path, scroll, text
+     * fallback) with a short per-cycle timeout so a slow transition is absorbed
+     * by repetition rather than one long blind wait. A full miss cycle is ~20 s,
+     * so the deadline is a floor on patience, not a precise budget — the loop
+     * may overshoot by one cycle.
+     */
+    private fun clickButtonWithin(res: String, text: String, deadlineMs: Long): Boolean {
+        val deadline = System.currentTimeMillis() + deadlineMs
+        while (System.currentTimeMillis() < deadline) {
+            if (clickButton(res, text, timeoutMs = 5_000L)) return true
+        }
+        return false
     }
 
     /**


### PR DESCRIPTION
## Summary
- **Mode 1 (PIN-intro race):** `clickButtonWithin` deadline-polls the `pin-intro-continue` lookup for up to 90 s, re-running the full res+text+scroll strategy each ~5 s cycle. Import does real key-derivation work; the old single `clickButton` call gave up after ~27 s. Other call sites keep fixed timeouts so real onboarding breaks (#324) stay loud.
- **Mode 2 (boot timeout):** `emulator-boot-timeout: 900` (default 600 flaked on run 27303458847), plus a new `workflow_run` workflow that reruns failed smoke jobs exactly once (`run_attempt == 1` guard — no loop; second failure stays red).
- **Evidence preservation:** artifact name now suffixed with `github.run_attempt` so a rerun can't clobber the previous attempt's `fail-*.png`/`fail-*.xml` dumps — losing those is what blocked the #320/#321 post-mortem.

## Notes
- `workflow_run` triggers only from the default branch — the auto-rerun workflow goes live after merge; first exercise is the next post-merge attempt-1 failure.
- Accepted edge: an auto-rerun shares the smoke concurrency group and could cancel a newer in-flight run on the same ref; rare, self-heals on next push.

## Validation
- `:app:compileDebugAndroidTestKotlin` clean
- `testDebugUnitTest` green (no production code touched)
- Acceptance per #330: ~10 consecutive first-try-green PR smoke runs after merge

Refs #330 — issue stays open until the acceptance window is observed post-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced CI workflow with automatic rerun capability for failed upgrade smoke tests
  * Improved timeout handling for Android emulator tests to accommodate slower CI environments
  * Updated artifact naming to prevent conflicts between workflow rerun attempts

<!-- end of auto-generated comment: release notes by coderabbit.ai -->