### PR TITLE
fix(send): integer-math Max + toLongOrNull capacity-parse sweep (#321 round 2)

### DIFF
--- a/android/app/src/main/java/com/rjnr/pocketnode/data/gateway/DaoDepositReader.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/gateway/DaoDepositReader.kt
@@ -116,7 +116,17 @@ class DaoDepositReader @Inject constructor(
 
         val deposits = mutableListOf<DaoDeposit>()
         for (jniCell in liveDaoCells) {
-            deposits += resolveOneDeposit(jniCell, currentEpoch, network)
+            // One malformed cell (bad capacity/epoch/timestamp hex from the
+            // node) drops that row instead of failing the whole DAO list (#321).
+            runCatching { resolveOneDeposit(jniCell, currentEpoch, network) }
+                .onSuccess { deposits += it }
+                .onFailure {
+                    Log.w(
+                        TAG,
+                        "Skipping unparseable DAO cell " +
+                            "${jniCell.outPoint.txHash.take(20)}...:${jniCell.outPoint.index} — ${it.message}"
+                    )
+                }
         }
         return deposits
     }

--- a/android/app/src/main/java/com/rjnr/pocketnode/data/gateway/GatewayRepository.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/gateway/GatewayRepository.kt
@@ -700,7 +700,7 @@ class GatewayRepository @Inject constructor(
         val tipStr = LightClientNative.nativeGetTipHeader()
         val tipHeight = if (tipStr != null) {
             val tip = json.decodeFromString<JniHeaderView>(tipStr)
-            tip.number.removePrefix("0x").toLong(16)
+            tip.number.removePrefix("0x").toLongOrNull(16) ?: 0L
         } else 0L
 
         // Check for existing sync progress to resume from (per-wallet)
@@ -812,7 +812,7 @@ class GatewayRepository @Inject constructor(
         val cap = json.decodeFromString<JniCellsCapacity>(responseJson)
 
         // Convert to balance response
-        var capacityVal = cap.capacity.removePrefix("0x").toLong(16)
+        var capacityVal = cap.capacity.removePrefix("0x").toLongOrNull(16) ?: 0L
 
         // The light client's nativeGetCellsCapacity may include spent cells
         // We need to calculate the true balance by getting live cells only
@@ -885,9 +885,9 @@ class GatewayRepository @Inject constructor(
                     val txPag = json.decodeFromString<JniPagination<JniTxWithCell>>(txJson)
                     if (txPag.objects.isNotEmpty()) {
                         Log.w(TAG, "🔄 Have ${txPag.objects.size} transactions but 0 live cells - triggering rescan")
-                        val earliestBlock = txPag.objects.minOfOrNull {
-                            it.blockNumber.removePrefix("0x").toLong(16)
-                        } ?: 0L
+                        val earliestBlock = txPag.objects
+                            .mapNotNull { it.blockNumber.removePrefix("0x").toLongOrNull(16) }
+                            .minOrNull() ?: 0L
                         val rescanFrom = (earliestBlock - 100).coerceAtLeast(0L)
                         Log.d(TAG, "🔄 Rescan from block $rescanFrom (earliest tx at $earliestBlock)")
 
@@ -936,7 +936,7 @@ class GatewayRepository @Inject constructor(
         val tipJson = LightClientNative.nativeGetTipHeader()
         val tipNumber = if (tipJson != null) {
             val tip = json.decodeFromString<JniHeaderView>(tipJson)
-            tip.number.removePrefix("0x").toLong(16)
+            tip.number.removePrefix("0x").toLongOrNull(16) ?: 0L
         } else {
             0L
         }
@@ -957,7 +957,7 @@ class GatewayRepository @Inject constructor(
         var anyUpdated = false
         scripts.forEach { script ->
             val walletId = syncCoordinator.getWalletIdForScript(script.script.args) ?: return@forEach
-            val block = script.blockNumber.removePrefix("0x").toLong(16)
+            val block = script.blockNumber.removePrefix("0x").toLongOrNull(16) ?: return@forEach
             if (block > getWalletSyncBlock(walletId)) {
                 setWalletSyncBlock(walletId, block)
                 anyUpdated = true
@@ -976,9 +976,9 @@ class GatewayRepository @Inject constructor(
         val activeArgs = _walletInfo.value?.script?.args
         val scriptBlockNumber = if (activeArgs != null) {
             scripts.find { it.script.args == activeArgs }
-                ?.blockNumber?.removePrefix("0x")?.toLong(16) ?: 0L
+                ?.blockNumber?.removePrefix("0x")?.toLongOrNull(16) ?: 0L
         } else {
-            scripts.firstOrNull()?.blockNumber?.removePrefix("0x")?.toLong(16) ?: 0L
+            scripts.firstOrNull()?.blockNumber?.removePrefix("0x")?.toLongOrNull(16) ?: 0L
         }
 
         // Log sync progress for debugging
@@ -1174,7 +1174,7 @@ class GatewayRepository @Inject constructor(
             // for the UI. (Prior code used "-0x..." which broke capacityAsLong's
             // hex parser and rendered as 0.)
             val outgoingAmount = signed.cellOutputs
-                .minOfOrNull { it.capacity.removePrefix("0x").toLong(16) }
+                .mapNotNull { it.capacity.removePrefix("0x").toLongOrNull(16) }.minOrNull()
                 ?: 0L
             val balanceChangeHex = "0x${outgoingAmount.toString(16)}"
 
@@ -1272,7 +1272,9 @@ class GatewayRepository @Inject constructor(
         require(transaction.cellInputs.isNotEmpty()) { "Transaction has no inputs" }
         require(transaction.cellOutputs.isNotEmpty()) { "Transaction has no outputs" }
         for (output in transaction.cellOutputs) {
-            val capacity = output.capacity.removePrefix("0x").toLong(16)
+            val capacity = requireNotNull(output.capacity.removePrefix("0x").toLongOrNull(16)) {
+                "Malformed output capacity '${output.capacity}' in transaction"
+            }
             require(capacity >= TransactionBuilder.MIN_CELL_CAPACITY) {
                 "Output capacity ${capacity / 100_000_000.0} CKB is below minimum 61 CKB"
             }
@@ -1293,7 +1295,7 @@ class GatewayRepository @Inject constructor(
         // For a normal transfer the smallest output is the recipient; for a
         // "send all" there's only one output. Either way: smallest by capacity.
         val outgoingAmount = transaction.cellOutputs
-            .minOfOrNull { it.capacity.removePrefix("0x").toLong(16) }
+            .mapNotNull { it.capacity.removePrefix("0x").toLongOrNull(16) }.minOrNull()
             ?: 0L
         // Positive hex per existing convention; `direction = "out"` carries sign.
         val balanceChangeHex = "0x${outgoingAmount.toString(16)}"
@@ -1407,7 +1409,7 @@ class GatewayRepository @Inject constructor(
                 val tipStr = LightClientNative.nativeGetTipHeader()
                 if (tipStr != null && senderInfo != null) {
                     val tip = json.decodeFromString<JniHeaderView>(tipStr)
-                    val tipNumber = tip.number.removePrefix("0x").toLong(16)
+                    val tipNumber = tip.number.removePrefix("0x").toLongOrNull(16) ?: 0L
                     val rescanFrom = (tipNumber - 10).coerceAtLeast(0L)
                     Log.d(TAG, "🔄 Partial re-register from block $rescanFrom to catch change output")
 
@@ -1463,7 +1465,7 @@ class GatewayRepository @Inject constructor(
             // Net balance change = Sum(Outputs to us) - Sum(Inputs from us)
             var netChangeShannons = 0L
             cellInteractions.forEach { interaction ->
-                val cap = interaction.ioCapacity.removePrefix("0x").toLong(16)
+                val cap = interaction.ioCapacity.removePrefix("0x").toLongOrNull(16) ?: 0L
                 if (interaction.ioType == "output") {
                     netChangeShannons += cap
                 } else {
@@ -1542,7 +1544,7 @@ class GatewayRepository @Inject constructor(
             val (finalDirection, finalAmount) = if (hasDaoOutput) {
                 val daoOutputCapacity = tx.outputs
                     .first { it.type?.codeHash == DaoConstants.DAO_CODE_HASH }
-                    .capacity.removePrefix("0x").toLong(16)
+                    .capacity.removePrefix("0x").toLongOrNull(16) ?: 0L
                 if (tx.headerDeps.isEmpty()) {
                     "dao_deposit" to daoOutputCapacity
                 } else {
@@ -1552,7 +1554,7 @@ class GatewayRepository @Inject constructor(
                 // Unlock: show total CKB returned (deposit + compensation)
                 val totalOutput = cellInteractions
                     .filter { it.ioType == "output" }
-                    .sumOf { it.ioCapacity.removePrefix("0x").toLong(16) }
+                    .sumOf { it.ioCapacity.removePrefix("0x").toLongOrNull(16) ?: 0L }
                 "dao_unlock" to totalOutput
             } else {
                 direction to amount
@@ -1609,14 +1611,18 @@ class GatewayRepository @Inject constructor(
             val tipJson = LightClientNative.nativeGetTipHeader()
             if (tipJson != null) {
                 val tip = json.decodeFromString<JniHeaderView>(tipJson)
-                val tipNumber = tip.number.removePrefix("0x").toLong(16)
+                val tipNumber = tip.number.removePrefix("0x").toLongOrNull(16) ?: 0L
 
                 // Get tx's block header to compute real confirmation depth
                 val txBlockJson = LightClientNative.nativeGetHeader(txWithStatus.txStatus.blockHash!!)
                 if (txBlockJson != null) {
                     val txBlock = json.decodeFromString<JniHeaderView>(txBlockJson)
-                    val txBlockNumber = txBlock.number.removePrefix("0x").toLong(16)
-                    val realConfirmations = (tipNumber - txBlockNumber + 1).coerceAtLeast(1).toInt()
+                    val txBlockNumber = txBlock.number.removePrefix("0x").toLongOrNull(16)
+                    val realConfirmations = if (txBlockNumber != null) {
+                        (tipNumber - txBlockNumber + 1).coerceAtLeast(1).toInt()
+                    } else {
+                        1 // malformed tx-block number; committed means at least 1
+                    }
                     Log.d(TAG, "📈 Tip: $tipNumber, txBlock: $txBlockNumber, confirmations: $realConfirmations")
                     realConfirmations
                 } else {
@@ -1677,7 +1683,7 @@ class GatewayRepository @Inject constructor(
             } else {
                 scripts.firstOrNull()
             }
-            match?.blockNumber?.removePrefix("0x")?.toLong(16) ?: 0L
+            match?.blockNumber?.removePrefix("0x")?.toLongOrNull(16) ?: 0L
         } catch (e: Exception) {
             Log.w(TAG, "Failed to get existing script block: ${e.message}")
             0L

--- a/android/app/src/main/java/com/rjnr/pocketnode/data/gateway/SyncCoordinator.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/gateway/SyncCoordinator.kt
@@ -176,7 +176,9 @@ class SyncCoordinator @Inject constructor(
         statuses.zip(walletIds).forEach { (status, walletId) ->
             if (walletId.isEmpty()) return@forEach
             newMapping[status.script.args] = walletId
-            val startBlock = status.blockNumber.removePrefix("0x").toLong(16)
+            // Malformed block number from the node: skip this script's row
+            // rather than abort registration for every wallet (#321).
+            val startBlock = status.blockNumber.removePrefix("0x").toLongOrNull(16) ?: return@forEach
             // Atomic UPDATE preserves localSavedBlockNumber under concurrent writes
             // from the sync poll's setWalletSyncBlock. Falls through to upsert only
             // when no row exists yet (no race possible — nothing to overwrite).

--- a/android/app/src/main/java/com/rjnr/pocketnode/data/gateway/models/ApiModels.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/gateway/models/ApiModels.kt
@@ -82,7 +82,9 @@ data class BalanceResponse(
     @SerialName("capacity_ckb") val capacityCkb: String,
     @SerialName("as_of_block") val asOfBlock: String
 ) {
-    fun capacityAsLong(): Long = capacity.removePrefix("0x").toLong(16)
+    // Malformed node data degrades to 0 instead of crashing balance
+    // flow collectors with NumberFormatException (#321).
+    fun capacityAsLong(): Long = capacity.removePrefix("0x").toLongOrNull(16) ?: 0L
     fun capacityAsCkb(): Double = capacityCkb.toDoubleOrNull() ?: 0.0
 }
 

--- a/android/app/src/main/java/com/rjnr/pocketnode/data/gateway/models/CkbModels.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/gateway/models/CkbModels.kt
@@ -80,7 +80,9 @@ data class Cell(
     val type: Script? = null,
     val data: String = "0x"
 ) {
-    fun capacityAsLong(): Long = capacity.removePrefix("0x").toLong(16)
+    // Malformed node data degrades to 0 instead of crashing balance
+    // flow collectors with NumberFormatException (#321).
+    fun capacityAsLong(): Long = capacity.removePrefix("0x").toLongOrNull(16) ?: 0L
 }
 
 @Serializable

--- a/android/app/src/main/java/com/rjnr/pocketnode/data/transaction/TransactionBuilder.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/transaction/TransactionBuilder.kt
@@ -478,22 +478,26 @@ class TransactionBuilder @Inject constructor(
     private fun selectCells(cells: List<Cell>, requiredCapacity: Long): Pair<List<Cell>, Long> {
         val sortedCells = cells
             .filter { it.type == null }
-            .sortedByDescending { parseCapacity(it.capacity) }
+            // Malformed capacity hex from the node: skip the cell rather than
+            // abort the whole selection — same treatment as
+            // calculateMaxSendable (#321).
+            .mapNotNull { cell -> parseCapacity(cell.capacity)?.let { cell to it } }
+            .sortedByDescending { (_, capacity) -> capacity }
 
         val selected = mutableListOf<Cell>()
         var total = 0L
 
-        for (cell in sortedCells) {
+        for ((cell, capacity) in sortedCells) {
             if (total >= requiredCapacity) break
             selected.add(cell)
-            total += parseCapacity(cell.capacity)
+            total += capacity
         }
 
         return Pair(selected, total)
     }
 
-    private fun parseCapacity(hex: String): Long {
-        return hex.removePrefix("0x").toLong(16)
+    private fun parseCapacity(hex: String): Long? {
+        return hex.removePrefix("0x").toLongOrNull(16)
     }
 
     /**
@@ -682,7 +686,10 @@ class TransactionBuilder @Inject constructor(
     }
 
     private fun serializeCellInput(input: CellInput): ByteArray {
-        val since = serializeUint64(input.since.removePrefix("0x").toLong(16))
+        val since = serializeUint64(
+            input.since.removePrefix("0x").toLongOrNull(16)
+                ?: throw IllegalArgumentException("Malformed input since '${input.since}' in transaction")
+        )
         val previousOutput = serializeOutPoint(input.previousOutput)
         return since + previousOutput
     }
@@ -714,7 +721,10 @@ class TransactionBuilder @Inject constructor(
     }
 
     private fun serializeCellOutput(output: CellOutput): ByteArray {
-        val capacity = serializeUint64(output.capacity.removePrefix("0x").toLong(16))
+        val capacity = serializeUint64(
+            output.capacity.removePrefix("0x").toLongOrNull(16)
+                ?: throw IllegalArgumentException("Malformed output capacity '${output.capacity}' in transaction")
+        )
         val lock = serializeScript(output.lock)
         val type = serializeScriptOpt(output.type)
         return serializeTable(listOf(capacity, lock, type))

--- a/android/app/src/main/java/com/rjnr/pocketnode/data/transaction/TransactionBuilder.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/transaction/TransactionBuilder.kt
@@ -63,6 +63,25 @@ class TransactionBuilder @Inject constructor(
     }
 
     /**
+     * Max sendable amount for a "send everything" transfer: the sum of all
+     * spendable cell capacities minus the fee for a transaction consuming
+     * EVERY cell as an input with a single output and no change. Pure integer
+     * math throughout — Double loses shannon precision above ~90M CKB (#321),
+     * and a 1-input fee assumption underestimates the fee on fragmented
+     * wallets, making the subsequent Max send fail with insufficient funds.
+     *
+     * Cells with malformed capacity hex are skipped from both the sum and the
+     * input count: buildTransfer could not spend them either.
+     */
+    fun calculateMaxSendable(cells: List<Cell>): Long {
+        val capacities = cells.mapNotNull { it.capacity.removePrefix("0x").toLongOrNull(16) }
+        if (capacities.isEmpty()) return 0L
+        val total = capacities.sum()
+        val fee = estimateTransferFee(inputCount = capacities.size, outputCount = 1)
+        return (total - fee).coerceAtLeast(0L)
+    }
+
+    /**
      * Calculate fee from serialized transaction size using the standard fee rate.
      * fee = ceil(size_bytes * fee_rate / 1000), with a minimum floor.
      */

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/send/SendViewModel.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/send/SendViewModel.kt
@@ -282,17 +282,32 @@ class SendViewModel @Inject constructor(
     }
 
     fun setMaxAmount() {
-        val balanceShannons = _uiState.value.availableBalance
-        // Max send: 1 input, 1 output (no change — sending everything)
-        val feeShannons = transactionBuilder.estimateTransferFee(inputCount = 1, outputCount = 1)
-        val maxShannons = (balanceShannons - feeShannons).coerceAtLeast(0L)
-        val maxCkb = maxShannons / 100_000_000.0
-        // Locale.US — sanitizeAmount rejects comma decimals; on de/fr/es devices
-        // `"%.8f".format(...)` would emit "0,12345678" and silently drop the prefill.
-        val formatted = String.format(java.util.Locale.US, "%.8f", maxCkb)
-            .trimEnd('0')
-            .trimEnd('.')
-        updateAmount(formatted.ifEmpty { "0" })
+        viewModelScope.launch {
+            // Sending max consumes EVERY spendable cell, so the fee must be
+            // estimated for all of them as inputs — the old 1-input estimate
+            // undershot on fragmented wallets and the Max send then failed
+            // with insufficient funds (#321). getCells is the same source the
+            // send path uses (spent + typed/DAO cells already filtered), so
+            // Max also can't overshoot a balance that includes unspendable
+            // cells.
+            val maxShannons = repository.getCells()
+                .map { transactionBuilder.calculateMaxSendable(it.items) }
+                .getOrElse {
+                    // Cell fetch failed — fall back to displayed balance with
+                    // the 1-input estimate (previous behavior), integer math.
+                    val balance = _uiState.value.availableBalance
+                    val fee = transactionBuilder.estimateTransferFee(inputCount = 1, outputCount = 1)
+                    (balance - fee).coerceAtLeast(0L)
+                }
+            // BigDecimal, not Double: shannon precision is lost above ~90M CKB.
+            // toPlainString always uses '.' regardless of device locale, which
+            // sanitizeAmount requires.
+            val formatted = BigDecimal(maxShannons)
+                .movePointLeft(8)
+                .stripTrailingZeros()
+                .toPlainString()
+            updateAmount(formatted)
+        }
     }
 
     /**

--- a/android/app/src/test/java/com/rjnr/pocketnode/data/gateway/models/CapacityParseTest.kt
+++ b/android/app/src/test/java/com/rjnr/pocketnode/data/gateway/models/CapacityParseTest.kt
@@ -1,0 +1,61 @@
+package com.rjnr.pocketnode.data.gateway.models
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * Malformed hex from the node must degrade to 0, not crash the balance
+ * flow collectors with an uncaught NumberFormatException (#321).
+ */
+class CapacityParseTest {
+
+    private val lock = Script(
+        codeHash = Script.SECP256K1_CODE_HASH,
+        hashType = "type",
+        args = "0x0011223344556677889900112233445566778899"
+    )
+
+    @Test
+    fun `Cell capacityAsLong parses valid hex`() {
+        val cell = Cell(
+            outPoint = OutPoint("0x" + "ab".repeat(32), "0x0"),
+            capacity = "0x174876e800", // 1000 CKB
+            blockNumber = "0x1",
+            lock = lock
+        )
+        assertEquals(100_000_000_000L, cell.capacityAsLong())
+    }
+
+    @Test
+    fun `Cell capacityAsLong returns 0 on malformed hex`() {
+        val cell = Cell(
+            outPoint = OutPoint("0x" + "ab".repeat(32), "0x0"),
+            capacity = "0xZZNOTHEX",
+            blockNumber = "0x1",
+            lock = lock
+        )
+        assertEquals(0L, cell.capacityAsLong())
+    }
+
+    @Test
+    fun `BalanceResponse capacityAsLong parses valid hex`() {
+        val balance = BalanceResponse(
+            address = "ckt1...",
+            capacity = "0x174876e800",
+            capacityCkb = "1000",
+            asOfBlock = "0x1"
+        )
+        assertEquals(100_000_000_000L, balance.capacityAsLong())
+    }
+
+    @Test
+    fun `BalanceResponse capacityAsLong returns 0 on malformed hex`() {
+        val balance = BalanceResponse(
+            address = "ckt1...",
+            capacity = "garbage",
+            capacityCkb = "",
+            asOfBlock = "0x1"
+        )
+        assertEquals(0L, balance.capacityAsLong())
+    }
+}

--- a/android/app/src/test/java/com/rjnr/pocketnode/data/transaction/TransactionBuilderMaxSendTest.kt
+++ b/android/app/src/test/java/com/rjnr/pocketnode/data/transaction/TransactionBuilderMaxSendTest.kt
@@ -1,0 +1,83 @@
+package com.rjnr.pocketnode.data.transaction
+
+import com.rjnr.pocketnode.data.gateway.models.Cell
+import com.rjnr.pocketnode.data.gateway.models.OutPoint
+import com.rjnr.pocketnode.data.gateway.models.Script
+import com.rjnr.pocketnode.data.validation.NetworkValidator
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+/**
+ * calculateMaxSendable must use pure integer math (no Double precision loss)
+ * and must charge fee for ALL spendable cells as inputs — sending max consumes
+ * every cell, so the 1-input assumption underestimated the fee on fragmented
+ * wallets and the resulting send failed with insufficient funds (#321).
+ */
+@RunWith(RobolectricTestRunner::class)
+class TransactionBuilderMaxSendTest {
+
+    private val builder = TransactionBuilder(NetworkValidator())
+
+    private val lock = Script(
+        codeHash = Script.SECP256K1_CODE_HASH,
+        hashType = "type",
+        args = "0x0011223344556677889900112233445566778899"
+    )
+
+    private fun cell(capacityShannons: Long, index: Int = 0) = Cell(
+        outPoint = OutPoint(txHash = "0x" + "ab".repeat(32), index = "0x${index.toString(16)}"),
+        capacity = "0x" + capacityShannons.toString(16),
+        blockNumber = "0x1",
+        lock = lock
+    )
+
+    @Test
+    fun `single cell max is capacity minus 1-input fee`() {
+        val cells = listOf(cell(100_00000000L))
+        val expected = 100_00000000L - builder.estimateTransferFee(inputCount = 1, outputCount = 1)
+        assertEquals(expected, builder.calculateMaxSendable(cells))
+    }
+
+    @Test
+    fun `fragmented wallet charges fee for every input`() {
+        // 30 cells pushes estimated tx size past the MIN_FEE clamp so the
+        // per-input fee actually differentiates from the 1-input estimate.
+        val cells = (0 until 30).map { cell(70_00000000L, index = it) }
+        val sum = 30 * 70_00000000L
+        val expected = sum - builder.estimateTransferFee(inputCount = 30, outputCount = 1)
+        assertEquals(expected, builder.calculateMaxSendable(cells))
+    }
+
+    @Test
+    fun `no cells means zero max`() {
+        assertEquals(0L, builder.calculateMaxSendable(emptyList()))
+    }
+
+    @Test
+    fun `fee exceeding total clamps to zero`() {
+        val cells = listOf(cell(500L))
+        assertEquals(0L, builder.calculateMaxSendable(cells))
+    }
+
+    @Test
+    fun `no precision loss above the Double 53-bit mantissa`() {
+        // 100M CKB in one cell — above ~90M CKB a Double round-trip corrupts
+        // the shannon amount; integer math must be exact.
+        val big = 100_000_000_00000000L
+        val cells = listOf(cell(big))
+        val expected = big - builder.estimateTransferFee(inputCount = 1, outputCount = 1)
+        assertEquals(expected, builder.calculateMaxSendable(cells))
+    }
+
+    @Test
+    fun `malformed capacity cell is skipped entirely`() {
+        // Malformed node data: cell drops out of both the sum and the input
+        // count — it could not be spent by buildTransfer anyway.
+        val good = cell(100_00000000L)
+        val bad = good.copy(capacity = "0xZZ")
+        val expected = 100_00000000L - builder.estimateTransferFee(inputCount = 1, outputCount = 1)
+        assertEquals(expected, builder.calculateMaxSendable(listOf(good, bad)))
+    }
+}


### PR DESCRIPTION
## Summary

Round 2 of the #321 deferred checklist — the two money-path items.

### Send-max integer-math rewrite
- New `TransactionBuilder.calculateMaxSendable(cells)`: sum of spendable capacities minus `estimateTransferFee(inputCount = cells.size, outputCount = 1)`, pure `Long` math. The old `setMaxAmount` assumed 1 input — on fragmented wallets the fee was underestimated and the Max send failed with insufficient funds. It also divided through `Double`, which corrupts shannon amounts above ~90M CKB.
- `setMaxAmount` now fetches the actual spendable set via `repository.getCells()` (same source the send path uses, spent + typed/DAO cells already filtered), so Max can no longer overshoot a displayed balance that includes unspendable cells. Falls back to the previous balance-based estimate if the cell fetch fails. Formatting via `BigDecimal.movePointLeft(8).toPlainString()` — locale-safe, no Double.

### toLongOrNull capacity-parse sweep
All remaining raw `toLong(16)` hex parses on node-provided data (~30 sites), with per-category fallbacks — same pattern as #329's balance-builder fix:
- **Aggregation/display loops** (GatewayRepository history/DAO/tip sites, SyncCoordinator registration): malformed entry is skipped or contributes 0, never crashes the operation.
- **Money paths** (TransactionBuilder cell selection, molecule serialization, pre-flight output validation): malformed values throw a clear `IllegalArgumentException` instead of a bare `NumberFormatException` — never silently default where funds are computed. Cell selection skips malformed cells, consistent with `calculateMaxSendable`.
- **DaoDepositReader**: per-cell `runCatching` in the deposit loop — one unparseable DAO cell drops that row instead of failing the whole deposits list (covers its 8 internal parse sites plus `EpochInfo.fromHex`).
- **Model helpers** (`Cell.capacityAsLong`, `BalanceResponse.capacityAsLong`): degrade to 0 instead of throwing inside flow collectors.
- ActivityScreen, TimeUtils, LightClientReadOnly and SyncCoordinator's tip-poll were verified already guarded by `runCatching`/`try` and left as-is.

## Tests
TDD throughout: `TransactionBuilderMaxSendTest` (6 cases: single cell, 30-cell fragmented wallet, empty, fee > total, >2^53 precision, malformed-cell skip) and `CapacityParseTest` (4 cases) were written and verified failing before implementation. Full `testDebugUnitTest` suite green.

End-to-end dust/selection coverage via `buildTransfer` remains blocked by the placeholder-address fixtures (pre-existing, noted in TransactionBuilderTest).

## Checklist state after this PR
- [x] send-max integer-math rewrite
- [x] toLongOrNull at remaining capacity-parse sites
- [x] LightClientNative UnsatisfiedLinkError gating — verified already implemented (loadLibrary try/catch with JVM-test note)
- [x] DAO withdraw flat-fee + dust refusal UX — verified already implemented (#287 refusal wording at all three build paths + SendViewModel error mapping)
- [ ] debug-build log scrubbing (next PR)
- [ ] String→ByteArray memory hygiene (own PR, riskiest)

Refs #321

🤖 Generated with [Claude Code](https://claude.com/claude-code)