### PR TITLE
fix(logs): debug-build log scrubbing — redact addresses, drop payment record (#321)

### DIFF
--- a/android/app/src/main/java/com/rjnr/pocketnode/data/contacts/ContactRepository.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/contacts/ContactRepository.kt
@@ -16,6 +16,7 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import java.util.UUID
 import javax.inject.Inject
 import javax.inject.Singleton
+import com.rjnr.pocketnode.util.redactAddress
 
 /**
  * Validation and lifecycle wrapper around [ContactDao] for the M4 Phase 2
@@ -215,7 +216,7 @@ class ContactRepository @Inject constructor(
             val match = contactDao.getByAddress(address) ?: return
             contactDao.markUsed(match.id, nowProvider())
         } catch (e: Exception) {
-            Log.w(TAG, "markUsed failed for address=$address", e)
+            Log.w(TAG, "markUsed failed for address=${address.redactAddress()}", e)
         }
     }
 

--- a/android/app/src/main/java/com/rjnr/pocketnode/data/gateway/GatewayRepository.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/gateway/GatewayRepository.kt
@@ -47,6 +47,7 @@ import kotlinx.serialization.json.decodeFromJsonElement
 import java.io.File
 import javax.inject.Inject
 import javax.inject.Singleton
+import com.rjnr.pocketnode.util.redactAddress
 
 data class SyncProgress(
     val isSyncing: Boolean = false,
@@ -802,7 +803,7 @@ class GatewayRepository @Inject constructor(
         }
 
         val searchKey = JniSearchKey(script = info.script)
-        Log.d(TAG, "🔍 Fetching balance for script: ${json.encodeToString(searchKey)}")
+        Log.d(TAG, "🔍 Fetching balance for script args ${searchKey.script.args.redactAddress()}")
 
         val responseJson = LightClientNative.nativeGetCellsCapacity(json.encodeToString(searchKey))
             ?: throw Exception("Failed to get capacity - null response")
@@ -1024,7 +1025,7 @@ class GatewayRepository @Inject constructor(
         }
         val searchKey = JniSearchKey(script = script)
 
-        Log.d(TAG, "🔍 getCells: Fetching cells for script: ${json.encodeToString(searchKey)}")
+        Log.d(TAG, "🔍 getCells: Fetching cells for script args ${searchKey.script.args.redactAddress()}")
 
         // First, get all transactions to find spent outpoints
         val txJson = LightClientNative.nativeGetTransactions(

--- a/android/app/src/main/java/com/rjnr/pocketnode/data/gateway/SyncCoordinator.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/gateway/SyncCoordinator.kt
@@ -155,8 +155,10 @@ class SyncCoordinator @Inject constructor(
         // Diagnostic for the production sync-stall reports (#150). Logs every
         // (walletId, startBlock) pair just before the JNI handoff. If a user
         // reports "stayed at 0", this line tells us deterministically what
-        // block they were actually scanning from. Logged at INFO so it
-        // survives release builds' default log level.
+        // block they were actually scanning from. NB: release builds strip
+        // ALL android.util.Log calls via proguard -assumenosideeffects, so
+        // this diagnostic only exists in debug builds — use a debug APK when
+        // chasing #150-class sync stalls.
         statuses.zip(walletIds).forEach { (status, walletId) ->
             val startBlock = status.blockNumber.removePrefix("0x").toLongOrNull(16) ?: -1L
             Log.i(

--- a/android/app/src/main/java/com/rjnr/pocketnode/data/transaction/TransactionBuilder.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/transaction/TransactionBuilder.kt
@@ -14,6 +14,7 @@ import java.io.ByteArrayOutputStream
 import java.math.BigInteger
 import javax.inject.Inject
 import javax.inject.Singleton
+import com.rjnr.pocketnode.util.redactAddress
 
 @Singleton
 class TransactionBuilder @Inject constructor(
@@ -99,9 +100,10 @@ class TransactionBuilder @Inject constructor(
         network: NetworkType
     ): Transaction {
         Log.d(TAG, "🔨 Building transfer transaction")
-        Log.d(TAG, "  From: $fromAddress")
-        Log.d(TAG, "  To: $toAddress")
-        Log.d(TAG, "  Amount: $amountShannons shannons")
+        // Sender + recipient + amount form a payment record — redact the
+        // addresses and drop the amount from debug logcat (#321).
+        Log.d(TAG, "  From: ${fromAddress.redactAddress()}")
+        Log.d(TAG, "  To: ${toAddress.redactAddress()}")
 
         // Validate recipient amount meets minimum cell capacity
         if (amountShannons < MIN_CELL_CAPACITY) {

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/home/HomeViewModel.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/home/HomeViewModel.kt
@@ -31,6 +31,7 @@ import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.jsonArray
 import java.util.Locale
 import javax.inject.Inject
+import com.rjnr.pocketnode.util.redactAddress
 
 private const val TAG = "HomeViewModel"
 
@@ -226,7 +227,7 @@ class HomeViewModel @Inject constructor(
 
         repository.initializeWallet()
             .onSuccess { info ->
-                Log.d(TAG, "Wallet initialized: ${info.testnetAddress}")
+                Log.d(TAG, "Wallet initialized: ${info.testnetAddress.redactAddress()}")
                 _uiState.update { it.copy(walletInfo = info, isLoading = false) }
                 fetchPrice()
                 registerAndRefresh()

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/scanner/QrScannerScreen.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/scanner/QrScannerScreen.kt
@@ -40,6 +40,7 @@ import com.google.zxing.PlanarYUVLuminanceSource
 import com.google.zxing.common.HybridBinarizer
 import com.rjnr.pocketnode.util.extractCkbAddress
 import java.util.concurrent.Executors
+import com.rjnr.pocketnode.util.redactAddress
 
 private const val TAG = "QrScannerScreen"
 
@@ -167,7 +168,7 @@ private fun CameraPreviewWithScanner(
                                     val address = extractCkbAddress(decoded)
                                     if (address != null && !hasScanned) {
                                         hasScanned = true
-                                        Log.d(TAG, "Scanned CKB address: $address")
+                                        Log.d(TAG, "Scanned CKB address: ${address.redactAddress()}")
                                         // Dispatch the result callback to Main —
                                         // the caller invokes navController.popBackStack()
                                         // which mutates LifecycleRegistry state, and

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/send/SendViewModel.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/send/SendViewModel.kt
@@ -27,6 +27,8 @@ import java.math.BigDecimal
 import java.math.RoundingMode
 import com.rjnr.pocketnode.data.auth.AuthMethod
 import javax.inject.Inject
+import com.rjnr.pocketnode.util.redactAddress
+import com.rjnr.pocketnode.util.redactHash
 
 enum class TransactionState {
     IDLE,           // No transaction in progress
@@ -541,9 +543,11 @@ class SendViewModel @Inject constructor(
 
             try {
                 Log.d(TAG, "Starting send transaction flow")
-                Log.d(TAG, "  Recipient: ${state.recipientAddress}")
-                Log.d(TAG, "  Amount: ${state.amountCkb} CKB ($amountShannons shannons)")
-                Log.d(TAG, "  From address: $capturedAddress")
+                // Recipient + amount + sender together are a full payment
+                // record; logcat is adb/bugreport-readable on debug builds.
+                // Redact the addresses, drop the amount (#321).
+                Log.d(TAG, "  Recipient: ${state.recipientAddress.redactAddress()}")
+                Log.d(TAG, "  From address: ${capturedAddress.redactAddress()}")
 
                 _uiState.update { it.copy(statusMessage = "Broadcasting transaction...") }
                 Log.d(TAG, "📡 prepareAndSend: fetching cells, filtering reserved, building, broadcasting...")
@@ -646,7 +650,7 @@ class SendViewModel @Inject constructor(
             var consecutiveUnknowns = 0
             val previousBalance = _uiState.value.availableBalance
 
-            Log.d(TAG, "🔄 Starting to poll for tx status: $txHash (previous balance: $previousBalance)")
+            Log.d(TAG, "🔄 Starting to poll for tx status: ${txHash.redactHash()} (previous balance: $previousBalance)")
 
             while (attempts < MAX_POLLING_ATTEMPTS) {
                 delay(POLLING_INTERVAL_MS)

--- a/android/app/src/main/java/com/rjnr/pocketnode/util/Redaction.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/util/Redaction.kt
@@ -1,0 +1,20 @@
+package com.rjnr.pocketnode.util
+
+/**
+ * Log scrubbing for sensitive identifiers (#321).
+ *
+ * Release builds strip ALL android.util.Log calls via the proguard
+ * `-assumenosideeffects` rule, so these helpers exist for DEBUG builds:
+ * logcat on a tester device is readable through adb and bugreports, and
+ * full addresses + amounts together form a payment record. Keeping a short
+ * prefix/suffix preserves enough to correlate log lines during debugging
+ * without exposing the full linkable value.
+ */
+
+/** Address-shaped values: keep an 8-char prefix and 5-char suffix. */
+fun String.redactAddress(): String =
+    if (length <= 16) this else "${take(8)}…${takeLast(5)}"
+
+/** Hash-shaped values (tx hashes, block hashes): keep a 10-char prefix. */
+fun String.redactHash(): String =
+    if (length <= 10) this else "${take(10)}…"

--- a/android/app/src/test/java/com/rjnr/pocketnode/util/RedactionTest.kt
+++ b/android/app/src/test/java/com/rjnr/pocketnode/util/RedactionTest.kt
@@ -1,0 +1,34 @@
+package com.rjnr.pocketnode.util
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * Debug-build log scrubbing (#321): addresses and tx hashes in logcat are
+ * readable via adb/bugreports on tester devices. Helpers keep enough prefix
+ * to correlate log lines without exposing the full linkable value.
+ */
+class RedactionTest {
+
+    @Test
+    fun `redactAddress keeps prefix and suffix only`() {
+        val addr = "ckt1qzda0cr08m85hc8jlnfp3zer7xulejywt49kt2rr0vthywaa50xwsq2qf8keemy2p5uu0g0gn8cd4ju23s5269qk8rg4r"
+        assertEquals("ckt1qzda…8rg4r", addr.redactAddress())
+    }
+
+    @Test
+    fun `redactAddress leaves short strings unchanged`() {
+        assertEquals("0xab12", "0xab12".redactAddress())
+    }
+
+    @Test
+    fun `redactHash keeps prefix only`() {
+        val hash = "0x" + "ab".repeat(32)
+        assertEquals("0xabababab…", hash.redactHash())
+    }
+
+    @Test
+    fun `redactHash leaves short strings unchanged`() {
+        assertEquals("0xab", "0xab".redactHash())
+    }
+}


### PR DESCRIPTION
## Summary

Third #321 PR — the debug-build log scrubbing checklist item.

Release builds already strip ALL `android.util.Log` calls via the proguard `-assumenosideeffects` rule, so the exposure is debug-build logcat: readable via adb and bugreports on tester devices.

- New `redactAddress()` / `redactHash()` helpers in `util/Redaction.kt` (TDD, 4 tests in `RedactionTest`): keep an 8+5-char prefix/suffix (addresses) or 10-char prefix (hashes) so log lines stay correlatable without exposing the full linkable value.
- **Send path** (SendViewModel, TransactionBuilder): recipient + sender redacted, the precise amount line dropped — together they formed a complete payment record in logcat.
- **Other address leaks**: scanned QR address, wallet-init address (HomeViewModel), contact `markUsed` warning, and the two `getBalance`/`getCells` logs that serialized the full search key (script args are address-equivalent) now log redacted args only.
- **Kept deliberately**: own-balance operational logs (balance polling, live-cell counts, DAO capacities). They reveal only the wallet's own state to whoever already has device/adb access, and they are the primary debugging signal for sync/balance issues — the #1 support class. No keys or mnemonics were logged anywhere (verified by sweep).
- Fixed a stale comment in SyncCoordinator claiming its #150 Log.i diagnostic "survives release builds" — proguard strips it; noted that #150-class debugging needs a debug APK.

## Tests
`RedactionTest` written and verified failing before implementation. Full `testDebugUnitTest` green.

## Checklist state after this PR
- [x] send-max integer-math rewrite (#333)
- [x] toLongOrNull capacity-parse sweep (#333)
- [x] UnsatisfiedLinkError gating (verified already implemented)
- [x] DAO dust refusal UX (verified already implemented)
- [x] debug-build log scrubbing (this PR)
- [ ] String→ByteArray memory hygiene (last item — own PR)

Refs #321

🤖 Generated with [Claude Code](https://claude.com/claude-code)