### PR TITLE
fix(keys): scoped memory hygiene — zero transient key buffers (#321)

### DIFF
--- a/android/app/src/main/java/com/rjnr/pocketnode/data/gateway/GatewayRepository.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/gateway/GatewayRepository.kt
@@ -1743,7 +1743,13 @@ class GatewayRepository @Inject constructor(
     }
 
     suspend fun depositToDao(amountShannons: Long): Result<String> =
-        depositToDao(amountShannons, privateKey = getPrivateKey())
+        getPrivateKey().let { key ->
+            try {
+                depositToDao(amountShannons, privateKey = key)
+            } finally {
+                key.fill(0) // transient signing key — zero after use (#321)
+            }
+        }
 
     /**
      * V2-aware overload: caller supplies the private key already
@@ -1782,7 +1788,13 @@ class GatewayRepository @Inject constructor(
     }
 
     suspend fun withdrawFromDao(depositOutPoint: OutPoint): Result<String> =
-        withdrawFromDao(depositOutPoint, privateKey = getPrivateKey())
+        getPrivateKey().let { key ->
+            try {
+                withdrawFromDao(depositOutPoint, privateKey = key)
+            } finally {
+                key.fill(0) // transient signing key — zero after use (#321)
+            }
+        }
 
     /** V2-aware overload — see [depositToDao]. */
     suspend fun withdrawFromDao(
@@ -1833,7 +1845,13 @@ class GatewayRepository @Inject constructor(
     }
 
     suspend fun unlockDao(withdrawingOutPoint: OutPoint): Result<String> =
-        unlockDao(withdrawingOutPoint, privateKey = getPrivateKey())
+        getPrivateKey().let { key ->
+            try {
+                unlockDao(withdrawingOutPoint, privateKey = key)
+            } finally {
+                key.fill(0) // transient signing key — zero after use (#321)
+            }
+        }
 
     /** V2-aware overload — see [depositToDao]. */
     suspend fun unlockDao(

--- a/android/app/src/main/java/com/rjnr/pocketnode/data/wallet/KeyBackupManager.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/wallet/KeyBackupManager.kt
@@ -2,9 +2,13 @@ package com.rjnr.pocketnode.data.wallet
 
 import android.util.Log
 import androidx.annotation.VisibleForTesting
+import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.decodeFromStream
+import kotlinx.serialization.json.encodeToStream
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
 import org.bouncycastle.crypto.generators.Argon2BytesGenerator
 import org.bouncycastle.crypto.params.Argon2Parameters
 import java.io.File
@@ -58,10 +62,22 @@ class KeyBackupManager @Inject constructor(
         // New backups are always written with the strongest KDF (Argon2id, v2).
         val key = deriveKey(pin, salt, FORMAT_VERSION_ARGON2)
 
-        val plaintext = json.encodeToString(material).toByteArray(Charsets.UTF_8)
-        val cipher = Cipher.getInstance(CIPHER_TRANSFORM)
-        cipher.init(Cipher.ENCRYPT_MODE, key, GCMParameterSpec(GCM_TAG_BITS, iv))
-        val ciphertext = cipher.doFinal(plaintext)
+        // Serialize straight to bytes — no String intermediate for the
+        // plaintext key material — and zero the buffer once encrypted (#321).
+        // Serializer-internal buffers and the Strings inside KeyMaterial
+        // itself are beyond reach on the JVM; see #335 for the full rewrite.
+        val plaintext = ByteArrayOutputStream().use { baos ->
+            @OptIn(ExperimentalSerializationApi::class)
+            json.encodeToStream(material, baos)
+            baos.toByteArray()
+        }
+        val ciphertext = try {
+            val cipher = Cipher.getInstance(CIPHER_TRANSFORM)
+            cipher.init(Cipher.ENCRYPT_MODE, key, GCMParameterSpec(GCM_TAG_BITS, iv))
+            cipher.doFinal(plaintext)
+        } finally {
+            plaintext.fill(0)
+        }
 
         val file = backupFile(walletId)
         val tmpFile = File(file.parent, "${file.name}.tmp")
@@ -98,7 +114,14 @@ class KeyBackupManager @Inject constructor(
             cipher.init(Cipher.DECRYPT_MODE, key, GCMParameterSpec(GCM_TAG_BITS, iv))
             val plaintext = cipher.doFinal(ciphertext)
 
-            json.decodeFromString<KeyMaterial>(String(plaintext, Charsets.UTF_8))
+            // Decode from the byte buffer directly (no plaintext String of the
+            // key material) and zero it after parsing (#321).
+            try {
+                @OptIn(ExperimentalSerializationApi::class)
+                json.decodeFromStream<KeyMaterial>(ByteArrayInputStream(plaintext))
+            } finally {
+                plaintext.fill(0)
+            }
         } catch (e: Exception) {
             Log.w(TAG, "Failed to read backup for $walletId", e)
             null

--- a/android/app/src/main/java/com/rjnr/pocketnode/data/wallet/KeyManager.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/wallet/KeyManager.kt
@@ -20,6 +20,25 @@ import java.math.BigInteger
 import javax.inject.Inject
 import javax.inject.Singleton
 
+/**
+ * ## Memory-hygiene boundary (#321 / #335)
+ *
+ * Transient `ByteArray` private keys returned by the read paths are zeroed
+ * by callers after signing (`fill(0)` in SendViewModel and the
+ * GatewayRepository DAO overloads), and KeyBackupManager zeroes its
+ * plaintext buffers around encrypt/decrypt. What canNOT be zeroed on the
+ * JVM, deliberately accepted:
+ *
+ *  - Hex `String`s handed out by EncryptedSharedPreferences / Room TEXT
+ *    columns — immutable, GC-managed.
+ *  - `BigInteger` / `ECKeyPair` internals — the CKB SDK signing API takes
+ *    immutable BigInteger copies of the key.
+ *
+ * The full String→ByteArray storage rewrite (prefs re-encode, Room BLOB
+ * migration, backup format v3) is tracked in #335 and intentionally NOT
+ * bundled into routine changes — a migration bug there is unrecoverable
+ * key loss.
+ */
 @Singleton
 class KeyManager @Inject constructor(
     @ApplicationContext private val context: Context,

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/send/SendViewModel.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/send/SendViewModel.kt
@@ -504,6 +504,8 @@ class SendViewModel @Inject constructor(
                     statusMessage = "Transaction failed"
                 )
             }
+        } finally {
+            privateKey.fill(0) // transient signing key — zero after use (#321)
         }
     }
 
@@ -593,6 +595,8 @@ class SendViewModel @Inject constructor(
                         statusMessage = "Transaction failed"
                     )
                 }
+            } finally {
+                capturedKey.fill(0) // transient signing key — zero after use (#321)
             }
         }
     }


### PR DESCRIPTION
## Summary

Final #321 checklist item, scoped per discussion — no storage-format changes, existing wallets untouched by construction. The full String→ByteArray storage rewrite (prefs re-encode, Room BLOB migration, backup format v3) is deliberately deferred to #335 with the risk analysis.

- **KeyBackupManager**: plaintext key-material JSON no longer round-trips through a `String` — serialized straight to bytes (`encodeToStream`) and parsed from bytes (`decodeFromStream`); the plaintext buffer is `fill(0)`-ed in a `finally` around both encrypt and decrypt. This was the largest single blob of key material held in app-controlled memory.
- **Send paths** (SendViewModel V2 + legacy): the transient signing `ByteArray` is zeroed in `finally` once `prepareAndSend` returns. Safe: every read path allocates a fresh array (`Numeric.hexStringToByteArray`), nothing retains it, and `ECKeyPair` copies into its own `BigInteger` before signing.
- **DAO paths** (GatewayRepository `depositToDao`/`withdrawFromDao`/`unlockDao` convenience overloads): same try/finally zeroing around the inner call.
- **KeyManager KDoc**: documents the JVM boundary — prefs/Room Strings and `BigInteger`/`ECKeyPair` internals cannot be zeroed; accepted explicitly and pointed at #335 so the limitation is a decision, not an accident.

## Tests
Behavior-preserving refactor: full `testDebugUnitTest` green, including `KeyBackupManagerTest` round-trips for both backup KDF formats (v1 PBKDF2 + v2 Argon2id) over the new byte-stream path.

## #321 checklist — complete
- [x] send-max integer-math rewrite (#333)
- [x] toLongOrNull capacity-parse sweep (#333)
- [x] debug-build log scrubbing (#334)
- [x] UnsatisfiedLinkError gating (verified already implemented)
- [x] DAO dust refusal UX (verified already implemented)
- [x] String→ByteArray memory hygiene — scoped here; full rewrite tracked in #335

Closes #321

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened memory security by implementing explicit zeroization of sensitive cryptographic key material following signing operations, transaction processing, and backup encryption/decryption workflows, ensuring sensitive data is cleared from memory even when errors occur.

* **Documentation**
  * Added comprehensive documentation detailing memory-hygiene practices and security boundaries for key management components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->