### PR TITLE
feat(sync): background sync at point of choice, honest staleness pill, foreground re-arm (#286)

### DIFF
--- a/android/app/src/androidTest/java/com/rjnr/pocketnode/UpgradeSmokeTest.kt
+++ b/android/app/src/androidTest/java/com/rjnr/pocketnode/UpgradeSmokeTest.kt
@@ -174,6 +174,13 @@ class UpgradeSmokeTest {
             tapDigit1UntilTitleChanges(from = "Confirm PIN", maxTaps = 12)
         )
 
+        // #286 added a background-sync opt-in screen right after PIN setup.
+        // Click through with the foreground-only option. Best-effort, same
+        // pattern as the #303 no-lock dialog: prev APKs that predate #286
+        // never show it, and a hard assert here would fail every smoke run
+        // until a post-#286 build becomes the prev artifact.
+        clickButton("bg-sync-optin-skip", "Only when app is open", 5_000L)
+
         val balanceRow = device.wait(
             Until.findObject(By.res("home-balance-row")),
             ONBOARDING_TIMEOUT_MS

--- a/android/app/src/main/java/com/rjnr/pocketnode/MainActivity.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/MainActivity.kt
@@ -119,6 +119,19 @@ class MainActivity : FragmentActivity() {
         }
     }
 
+    override fun onStart() {
+        super.onStart()
+        // Re-arm background sync on every foreground (#286). The FGS dies
+        // silently in three ways the preference can't see — Android 15's 6h
+        // dataSync budget (onTimeout → stopSelf, nothing reschedules), OEM
+        // battery managers, and post-grant notification revocation — leaving
+        // an ON toggle with a dead service. startBackgroundSync() no-ops when
+        // the preference is off and is idempotent when the service is already
+        // running; starting from the foreground also grants a fresh FGS time
+        // budget per the platform rules.
+        repository.startBackgroundSync()
+    }
+
     override fun onStop() {
         super.onStop()
         // Use cached value — avoids blocking main thread on every onStop

--- a/android/app/src/main/java/com/rjnr/pocketnode/data/gateway/GatewayRepository.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/gateway/GatewayRepository.kt
@@ -1964,6 +1964,10 @@ class GatewayRepository @Inject constructor(
      * Start centralized sync polling. Idempotent — does nothing if already running.
      * Polls getAccountStatus(), records samples, calculates progress, and emits to syncProgress flow.
      */
+    // Throttle for the lastSyncedAt pref write in the sync poll (#286).
+    @Volatile
+    private var lastSyncedAtWrittenMs = 0L
+
     fun startSyncPolling() {
         if (syncPollingJob?.isActive == true) return
 
@@ -2031,6 +2035,15 @@ class GatewayRepository @Inject constructor(
 
                         syncProgressTracker.recordSample(syncedBlock, System.currentTimeMillis())
                         val info = syncProgressTracker.calculate(tipBlock)
+
+                        // Staleness pill input (#286): persist "last time we
+                        // observed sync progress", throttled to ~1 write/min
+                        // (the poll runs every 5-30s; pref churn is pointless).
+                        val nowMs = System.currentTimeMillis()
+                        if (syncedBlock > 0 && nowMs - lastSyncedAtWrittenMs > 60_000L) {
+                            lastSyncedAtWrittenMs = nowMs
+                            walletPreferences.setLastSyncedAt(nowMs)
+                        }
 
                         val justReachedTip = wasSyncing && info.isSynced
                         wasSyncing = !info.isSynced

--- a/android/app/src/main/java/com/rjnr/pocketnode/data/wallet/WalletPreferences.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/wallet/WalletPreferences.kt
@@ -209,6 +209,26 @@ class WalletPreferences @Inject constructor(
         prefs.edit().putBoolean(KEY_BACKGROUND_SYNC, enabled).commit()
     }
 
+    /**
+     * Wall-clock of the last observed sync progress (#286). Written by the
+     * sync poll (throttled there to ~1/min); read by the Home staleness
+     * pill. 0 = never synced.
+     */
+    fun getLastSyncedAt(): Long = prefs.getLong(KEY_LAST_SYNCED_AT, 0L)
+
+    fun setLastSyncedAt(timestampMs: Long) {
+        // apply(), not commit(): hot path (sync poll), durability loss of one
+        // sample is harmless.
+        prefs.edit().putLong(KEY_LAST_SYNCED_AT, timestampMs).apply()
+    }
+
+    /** Home staleness pill dismissal (#286) — dismiss is permanent, not a nag. */
+    fun isBgSyncPillDismissed(): Boolean = prefs.getBoolean(KEY_BG_SYNC_PILL_DISMISSED, false)
+
+    fun setBgSyncPillDismissed() {
+        prefs.edit().putBoolean(KEY_BG_SYNC_PILL_DISMISSED, true).apply()
+    }
+
     // --- Database maintenance ---
 
     fun getLastVacuumAt(): Long = prefs.getLong(KEY_LAST_VACUUM_AT, 0L)
@@ -321,6 +341,8 @@ class WalletPreferences @Inject constructor(
         private const val KEY_SYNC_STRATEGY = "sync_strategy"
         private const val KEY_THEME_MODE = "theme_mode"
         private const val KEY_BACKGROUND_SYNC = "background_sync_enabled"
+        private const val KEY_LAST_SYNCED_AT = "last_synced_at_ms"
+        private const val KEY_BG_SYNC_PILL_DISMISSED = "bg_sync_pill_dismissed"
         private const val KEY_LAST_VACUUM_AT = "last_vacuum_at"
         private const val KEY_SYNC_PROGRESS_MIGRATED = "sync_progress_migrated_to_room_v7"
         private const val KEY_SYNC_COACHMARK_SEEN = "sync_coachmark_seen"

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/components/BgSyncStaleBanner.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/components/BgSyncStaleBanner.kt
@@ -1,0 +1,120 @@
+package com.rjnr.pocketnode.ui.components
+
+import android.Manifest
+import android.content.pm.PackageManager
+import android.os.Build
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.FilledTonalButton
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.core.content.ContextCompat
+import com.composables.icons.lucide.Lucide
+import com.composables.icons.lucide.RefreshCw
+import com.rjnr.pocketnode.R
+
+/**
+ * Home staleness banner (#286): shown when the wallet went stale (>1h with
+ * no observed sync) while the app was closed. Two variants:
+ *
+ *  - [bgSyncEnabled] = false → "background sync is off", with an Enable CTA
+ *    that runs the POST_NOTIFICATIONS grant before flipping the preference
+ *    (the FGS silently dies without it, #116).
+ *  - [bgSyncEnabled] = true → the service was killed behind the user's back
+ *    (OEM battery manager, 6h dataSync budget, revoked notifications) —
+ *    informational; MainActivity.onStart has already re-armed the service.
+ */
+@Composable
+fun BgSyncStaleBanner(
+    bgSyncEnabled: Boolean,
+    onEnable: () -> Unit,
+    onDismiss: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val context = LocalContext.current
+    val permissionLauncher = rememberLauncherForActivityResult(
+        ActivityResultContracts.RequestPermission()
+    ) { granted ->
+        // Deny → leave sync off rather than show a lying ON state (#116).
+        if (granted) onEnable()
+    }
+
+    Card(
+        modifier = modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.secondaryContainer,
+        ),
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(12.dp),
+            ) {
+                Icon(
+                    imageVector = Lucide.RefreshCw,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.onSecondaryContainer,
+                )
+                Text(
+                    text = stringResource(
+                        if (bgSyncEnabled) R.string.bg_sync_pill_title_dead
+                        else R.string.bg_sync_pill_title_off
+                    ),
+                    style = MaterialTheme.typography.titleSmall,
+                    color = MaterialTheme.colorScheme.onSecondaryContainer,
+                )
+            }
+            Text(
+                text = stringResource(
+                    if (bgSyncEnabled) R.string.bg_sync_pill_body_dead
+                    else R.string.bg_sync_pill_body_off
+                ),
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSecondaryContainer,
+            )
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.End,
+            ) {
+                TextButton(onClick = onDismiss) {
+                    Text(stringResource(R.string.bg_sync_pill_action_dismiss))
+                }
+                if (!bgSyncEnabled) {
+                    FilledTonalButton(onClick = {
+                        val needsPermission = Build.VERSION.SDK_INT >= 33 &&
+                            ContextCompat.checkSelfPermission(
+                                context, Manifest.permission.POST_NOTIFICATIONS
+                            ) != PackageManager.PERMISSION_GRANTED
+                        if (needsPermission) {
+                            permissionLauncher.launch(Manifest.permission.POST_NOTIFICATIONS)
+                        } else {
+                            onEnable()
+                        }
+                    }) {
+                        Text(stringResource(R.string.bg_sync_pill_action_enable))
+                    }
+                }
+            }
+        }
+    }
+}

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/navigation/NavGraph.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/navigation/NavGraph.kt
@@ -89,6 +89,7 @@ sealed class Screen(val route: String) {
             if (parentId.isNullOrBlank()) BASE else "$BASE?parentId=$parentId"
     }
     object InitialPinSetup : Screen("initial_pin_setup")
+    object BackgroundSyncOptIn : Screen("bg_sync_opt_in")
     object ForgotPin : Screen("forgot_pin")
     object Faq : Screen("faq?anchor={anchor}") {
         fun routeWithAnchor(anchor: String?): String =
@@ -578,6 +579,20 @@ fun CkbNavGraph(
         composable(Screen.InitialPinSetup.route) {
             InitialPinSetupScreen(
                 onPinCreated = {
+                    // #286: surface background sync at the point of choice,
+                    // right after the mandatory PIN step. The opt-in screen
+                    // self-skips when the preference is already set.
+                    navController.navigate(Screen.BackgroundSyncOptIn.route) {
+                        popUpTo(navController.graph.id) { inclusive = true }
+                        launchSingleTop = true
+                    }
+                }
+            )
+        }
+
+        composable(Screen.BackgroundSyncOptIn.route) {
+            com.rjnr.pocketnode.ui.screens.onboarding.BackgroundSyncOptInScreen(
+                onContinue = {
                     navController.navigate(destinationAfterWalletReady()) {
                         popUpTo(navController.graph.id) { inclusive = true }
                         launchSingleTop = true

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/home/BgSyncStaleness.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/home/BgSyncStaleness.kt
@@ -1,0 +1,19 @@
+package com.rjnr.pocketnode.ui.screens.home
+
+/** Default staleness window for the background-sync pill (#286): 1 hour. */
+const val BG_SYNC_STALE_THRESHOLD_MS = 3_600_000L
+
+/**
+ * True when the wallet hasn't observed sync progress for longer than
+ * [thresholdMs]. Deliberately ignores whether background sync is enabled:
+ * the 2026-06 research showed "enabled but silently dead" (OEM kill, 6h
+ * dataSync budget, notification-permission revocation) is the most common
+ * failure, so the pill must fire there too — the caller varies only the
+ * copy. `null` timestamp = wallet has never synced; don't nag during
+ * first-run.
+ */
+fun isBgSyncStale(
+    lastSyncedAtMs: Long?,
+    nowMs: Long,
+    thresholdMs: Long = BG_SYNC_STALE_THRESHOLD_MS,
+): Boolean = lastSyncedAtMs != null && (nowMs - lastSyncedAtMs) > thresholdMs

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/home/HomeScreen.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/home/HomeScreen.kt
@@ -91,6 +91,7 @@ import com.composables.icons.lucide.ChevronDown
 import androidx.compose.ui.res.stringResource
 import com.rjnr.pocketnode.ui.components.SecurityBanner
 import com.rjnr.pocketnode.ui.components.SecurityBannerState
+import com.rjnr.pocketnode.ui.components.BgSyncStaleBanner
 import com.rjnr.pocketnode.ui.components.SyncStallBanner
 import com.rjnr.pocketnode.ui.components.SyncOptionsSheet
 import com.rjnr.pocketnode.ui.components.UpdateDialog
@@ -472,6 +473,8 @@ fun HomeScreen(
                     onTopicHelp = { topic -> educationTopic = topic },
                     onSyncStallSwitchToRecent = { viewModel.switchToRecentSyncFromStall() },
                     onSyncStallDismiss = { viewModel.dismissSyncStallBanner() },
+                    onBgSyncStaleEnable = { viewModel.enableBackgroundSyncFromPill() },
+                    onBgSyncStaleDismiss = { viewModel.dismissBgSyncStalePill() },
                 )
                 if (uiState.isSwitchingWallet) {
                     LinearProgressIndicator(
@@ -541,6 +544,8 @@ fun HomeScreenUI(
     onTopicHelp: (EducationTopic) -> Unit = {},
     onSyncStallSwitchToRecent: () -> Unit = {},
     onSyncStallDismiss: () -> Unit = {},
+    onBgSyncStaleEnable: () -> Unit = {},
+    onBgSyncStaleDismiss: () -> Unit = {},
 ) {
     PullToRefreshBox(
         isRefreshing = uiState.isRefreshing,
@@ -611,6 +616,18 @@ fun HomeScreenUI(
                         minutesStalled = uiState.syncStallMinutes,
                         onSwitchToRecent = onSyncStallSwitchToRecent,
                         onDismiss = onSyncStallDismiss,
+                    )
+                }
+            }
+
+            // #286 staleness banner: wallet went >1h without observed sync
+            // while the app was closed. Latched at app open in HomeViewModel.
+            if (uiState.showBgSyncStalePill) {
+                item {
+                    BgSyncStaleBanner(
+                        bgSyncEnabled = uiState.bgSyncEnabledAtOpen,
+                        onEnable = onBgSyncStaleEnable,
+                        onDismiss = onBgSyncStaleDismiss,
                     )
                 }
             }

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/home/HomeViewModel.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/home/HomeViewModel.kt
@@ -199,6 +199,26 @@ class HomeViewModel @Inject constructor(
             }
         }
 
+        // #286 staleness pill, latched at VM creation (= app open). Fires for
+        // BOTH directions of the failure: bg sync off and the wallet went
+        // stale, AND bg sync ON but the service silently died (OEM kill, 6h
+        // dataSync budget, notification revocation) — the copy differs, the
+        // staleness test doesn't.
+        run {
+            val staleAtOpen = isBgSyncStale(
+                lastSyncedAtMs = walletPreferences.getLastSyncedAt().takeIf { it > 0 },
+                nowMs = System.currentTimeMillis(),
+            )
+            if (staleAtOpen && !walletPreferences.isBgSyncPillDismissed()) {
+                _uiState.update {
+                    it.copy(
+                        showBgSyncStalePill = true,
+                        bgSyncEnabledAtOpen = walletPreferences.isBackgroundSyncEnabled(),
+                    )
+                }
+            }
+        }
+
         // Sync coachmark visibility (#90): show first-run education when sync has
         // been catching up for at least the grace period. Combines the prefs flag,
         // the repository SyncProgress, and a 1-second clock tick so the UI updates
@@ -809,6 +829,24 @@ class HomeViewModel @Inject constructor(
         _uiState.update { it.copy(showSyncStallBanner = false) }
     }
 
+    /** #286 pill: permanent dismissal — informational, not a nag surface. */
+    fun dismissBgSyncStalePill() {
+        walletPreferences.setBgSyncPillDismissed()
+        _uiState.update { it.copy(showBgSyncStalePill = false) }
+    }
+
+    /**
+     * #286 pill enable action (caller has already handled the
+     * POST_NOTIFICATIONS grant). Session-hide only: if the service dies
+     * again later, the enabled-but-stale variant should still be able to
+     * show on a future open.
+     */
+    fun enableBackgroundSyncFromPill() {
+        walletPreferences.setBackgroundSyncEnabled(true)
+        repository.startBackgroundSync()
+        _uiState.update { it.copy(showBgSyncStalePill = false) }
+    }
+
     /**
      * One-tap recovery from a stall on a 2021-era wallet (#150): switch to
      * RECENT sync mode. Delegates to [changeSyncMode] so the polling teardown,
@@ -895,4 +933,8 @@ data class HomeUiState(
     val showSyncCoachmark: Boolean = false,
     val showSyncStallBanner: Boolean = false,
     val syncStallMinutes: Long = 0L,
+    // #286 staleness pill: latched at app open (foreground sync freshens
+    // lastSyncedAt within a minute, so a live check would self-hide).
+    val showBgSyncStalePill: Boolean = false,
+    val bgSyncEnabledAtOpen: Boolean = false,
 )

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/onboarding/BackgroundSyncOptInScreen.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/onboarding/BackgroundSyncOptInScreen.kt
@@ -1,0 +1,179 @@
+package com.rjnr.pocketnode.ui.screens.onboarding
+
+import android.Manifest
+import android.content.pm.PackageManager
+import android.os.Build
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.Button
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.core.content.ContextCompat
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.ViewModel
+import com.composables.icons.lucide.Lucide
+import com.composables.icons.lucide.RefreshCw
+import com.rjnr.pocketnode.data.gateway.GatewayRepository
+import com.rjnr.pocketnode.data.wallet.WalletPreferences
+import com.rjnr.pocketnode.ui.util.uaTestTag
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+/**
+ * One-time point-of-choice for background sync, shown right after PIN setup
+ * (#286). Background sync defaults OFF; this screen is the surface that
+ * tells users it exists instead of leaving it buried in Settings → Sync —
+ * Matt's review flagged "the app stops updating when I close it" as the
+ * symptom of nobody finding the toggle.
+ *
+ * Both choices land in the same place ([onContinue] → the normal
+ * post-wallet-ready destination); only the preference and the foreground
+ * service differ. "Keep syncing" requires POST_NOTIFICATIONS on 13+ — the
+ * FGS silently dies without it (#116), so denial leaves sync off and the
+ * user on this screen to pick the other option.
+ */
+@HiltViewModel
+class BackgroundSyncOptInViewModel @Inject constructor(
+    private val walletPreferences: WalletPreferences,
+    private val repository: GatewayRepository,
+) : ViewModel() {
+
+    fun isAlreadyEnabled(): Boolean = walletPreferences.isBackgroundSyncEnabled()
+
+    fun enableBackgroundSync() {
+        walletPreferences.setBackgroundSyncEnabled(true)
+        repository.startBackgroundSync()
+    }
+
+    fun declineBackgroundSync() {
+        // Already the default, but persist explicitly so the choice is a
+        // recorded decision, not an absence of one.
+        walletPreferences.setBackgroundSyncEnabled(false)
+    }
+}
+
+@Composable
+fun BackgroundSyncOptInScreen(
+    onContinue: () -> Unit,
+    viewModel: BackgroundSyncOptInViewModel = hiltViewModel(),
+) {
+    val context = LocalContext.current
+    val snackbarHostState = remember { SnackbarHostState() }
+    val scope = rememberCoroutineScope()
+
+    // Existing users who already enabled background sync in Settings should
+    // not be re-asked when they pass through PIN adoption.
+    androidx.compose.runtime.LaunchedEffect(Unit) {
+        if (viewModel.isAlreadyEnabled()) onContinue()
+    }
+
+    fun enableAndContinue() {
+        viewModel.enableBackgroundSync()
+        onContinue()
+    }
+
+    val notificationPermissionLauncher = rememberLauncherForActivityResult(
+        ActivityResultContracts.RequestPermission()
+    ) { granted ->
+        if (granted) {
+            enableAndContinue()
+        } else {
+            // FGS can't run without the notification on 13+ (#116) — leave
+            // sync off rather than show a lying ON state. User can still
+            // continue with the foreground-only option.
+            scope.launch {
+                snackbarHostState.showSnackbar(
+                    "Background sync needs notification permission to keep running"
+                )
+            }
+        }
+    }
+
+    Scaffold(snackbarHost = { SnackbarHost(snackbarHostState) }) { padding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(padding)
+                .padding(horizontal = 24.dp, vertical = 32.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.Center,
+        ) {
+            Icon(
+                imageVector = Lucide.RefreshCw,
+                contentDescription = null,
+                modifier = Modifier.size(56.dp),
+                tint = MaterialTheme.colorScheme.primary,
+            )
+            Spacer(Modifier.height(24.dp))
+            Text(
+                text = "Keep your wallet up to date?",
+                style = MaterialTheme.typography.headlineSmall,
+                textAlign = TextAlign.Center,
+            )
+            Spacer(Modifier.height(16.dp))
+            Text(
+                text = "Pocket Node can keep syncing while the app is closed, so your " +
+                    "balance and history are fresher when you come back. This shows a " +
+                    "small ongoing notification and uses some extra battery.\n\n" +
+                    "Android limits background work, so syncing may still pause until " +
+                    "you next open the app. You can change this anytime in Settings → Sync.",
+                style = MaterialTheme.typography.bodyMedium,
+                textAlign = TextAlign.Center,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            Spacer(Modifier.height(40.dp))
+            Button(
+                onClick = {
+                    val needsPermission = Build.VERSION.SDK_INT >= 33 &&
+                        ContextCompat.checkSelfPermission(
+                            context, Manifest.permission.POST_NOTIFICATIONS
+                        ) != PackageManager.PERMISSION_GRANTED
+                    if (needsPermission) {
+                        notificationPermissionLauncher.launch(Manifest.permission.POST_NOTIFICATIONS)
+                    } else {
+                        enableAndContinue()
+                    }
+                },
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .uaTestTag("bg-sync-optin-keep"),
+            ) {
+                Text("Keep syncing in background")
+            }
+            Spacer(Modifier.height(12.dp))
+            OutlinedButton(
+                onClick = {
+                    viewModel.declineBackgroundSync()
+                    onContinue()
+                },
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .uaTestTag("bg-sync-optin-skip"),
+            ) {
+                Text("Only when app is open")
+            }
+        }
+    }
+}

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/settings/SettingsScreen.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/settings/SettingsScreen.kt
@@ -481,6 +481,20 @@ private fun SettingsScreenUI(
                 )
             }
 
+            // #286: one-line tradeoff blurb at the point of choice.
+            item {
+                Text(
+                    text = "Keeps your balance fresh while the app is closed, with a small " +
+                        "ongoing notification and some extra battery use. Android may still " +
+                        "pause it after extended background time.",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier
+                        .padding(horizontal = 16.dp)
+                        .padding(top = 4.dp, bottom = 8.dp)
+                )
+            }
+
             item {
                 SettingsValueRow(
                     icon = Lucide.RefreshCw,

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -474,6 +474,12 @@
     <!-- endregion -->
 
     <!-- region: sync stall banner (#150) -->
+    <string name="bg_sync_pill_title_off">Balance may be out of date</string>
+    <string name="bg_sync_pill_body_off">Background sync is off, so this wallet only updates while the app is open. Turn it on to stay current.</string>
+    <string name="bg_sync_pill_title_dead">Background sync was interrupted</string>
+    <string name="bg_sync_pill_body_dead">Android or your device\'s battery manager stopped background sync while the app was closed. It has been restarted. If this keeps happening, allow Pocket Node to run unrestricted in battery settings.</string>
+    <string name="bg_sync_pill_action_enable">Enable</string>
+    <string name="bg_sync_pill_action_dismiss">Dismiss</string>
     <string name="sync_stall_banner_title">Sync hasn\'t progressed in %1$d min</string>
     <string name="sync_stall_banner_body">If this wallet has years of history, scanning from that far back is slow. Switch to Recent activity to catch up faster.</string>
     <string name="sync_stall_banner_action_switch_recent">Use Recent</string>

--- a/android/app/src/test/java/com/rjnr/pocketnode/ui/screens/home/BgSyncStalenessTest.kt
+++ b/android/app/src/test/java/com/rjnr/pocketnode/ui/screens/home/BgSyncStalenessTest.kt
@@ -1,0 +1,45 @@
+package com.rjnr.pocketnode.ui.screens.home
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * #286 staleness predicate. Key design point from the 2026-06 research:
+ * the pill must fire on BOTH "background sync off and stale" AND
+ * "enabled but the service silently died" (OEM kill, 6h budget, permission
+ * revocation) — so the predicate is pure staleness; the caller picks copy
+ * by the enabled flag.
+ */
+class BgSyncStalenessTest {
+
+    private val hour = 3_600_000L
+
+    @Test
+    fun `never-synced wallet is not stale`() {
+        // Fresh wallet pre-first-sync: no timestamp, no nagging.
+        assertFalse(isBgSyncStale(lastSyncedAtMs = null, nowMs = 10 * hour))
+    }
+
+    @Test
+    fun `recent sync is not stale`() {
+        assertFalse(isBgSyncStale(lastSyncedAtMs = 10 * hour - 5 * 60_000L, nowMs = 10 * hour))
+    }
+
+    @Test
+    fun `sync older than threshold is stale`() {
+        assertTrue(isBgSyncStale(lastSyncedAtMs = 8 * hour, nowMs = 10 * hour))
+    }
+
+    @Test
+    fun `exactly at threshold is not yet stale`() {
+        assertFalse(isBgSyncStale(lastSyncedAtMs = 9 * hour, nowMs = 10 * hour))
+    }
+
+    @Test
+    fun `custom threshold respected`() {
+        assertTrue(
+            isBgSyncStale(lastSyncedAtMs = 0L, nowMs = 16 * 60_000L, thresholdMs = 15 * 60_000L)
+        )
+    }
+}


### PR DESCRIPTION
## Summary

Implements #286 with the design amended per the 2026-06-11 background-sync research (three failure paths confirmed: Android 15's 6h dataSync budget with no reschedule, OEM kills, post-grant notification revocation — all leaving an ON toggle with a dead service).

### Onboarding point-of-choice
- New `BackgroundSyncOptInScreen` after PIN setup: "Keep syncing in background" (runs the POST_NOTIFICATIONS flow, #116-honest — deny leaves sync off) vs "Only when app is open". Copy is deliberately honest: "Android limits background work, so syncing may still pause until you next open the app." Self-skips for users who already enabled it in Settings.
- Nav: `InitialPinSetup.onPinCreated` → opt-in screen → `destinationAfterWalletReady()`.

### Honest staleness pill (amended from the issue spec)
- The issue specced "show when bg sync is OFF and stale" — research showed the common failure is ON-but-dead, so the pill fires on pure staleness with copy split by the enabled flag: off → educate + Enable CTA (with permission flow); on → "Android stopped it; restarted now; consider battery settings".
- New persisted `lastSyncedAt` (written by the sync poll, throttled to 1/min) + `isBgSyncStale` predicate (TDD, 5 cases). Staleness latched at app open — foreground sync freshens the timestamp within a minute, so a live check would self-hide before the user ever saw it.
- Dismiss is permanent (pref), per the issue's anti-nag stance.

### Foreground re-arm (one-line ON-but-dead recovery)
- `MainActivity.onStart` calls `startBackgroundSync()` — no-op when disabled, idempotent when running, and restarting from the foreground grants a fresh FGS budget per platform rules. Closes most of the silent-death window without waiting for #337.

### Secondary
- Settings: one-line tradeoff blurb under the Background Sync toggle.
- UpgradeSmokeTest: best-effort click-through of the new screen (same pattern as the #303 no-lock dialog) — prev APKs predate the screen, post-merge prev APKs will show it.

## Follow-ups filed from the research
- #337 — periodic WorkManager catch-up worker (#91 revival): makes the opt-in promise hold past the 6h budget and reboots.
- #338 — notification UX, metered-network option, OEM battery education, Play dataSync declaration prep.

## Tests
`BgSyncStalenessTest` (5 cases, RED verified first), full `testDebugUnitTest` green, `compileDebugAndroidTestKotlin` clean.

Closes #286

🤖 Generated with [Claude Code](https://claude.com/claude-code)