### PR TITLE
fix(sync): stop DAO-wallet rescan loop + unhide custom-height Apply button (#332)

### DIFF
--- a/android/app/src/main/java/com/rjnr/pocketnode/data/gateway/GatewayRepository.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/gateway/GatewayRepository.kt
@@ -854,6 +854,7 @@ class GatewayRepository @Inject constructor(
                 val cellsPag = json.decodeFromString<JniPagination<JniCell>>(cellsJson)
                 var liveCapacity = 0L
                 var liveCellCount = 0
+                var typedCellCount = 0
 
                 cellsPag.objects.forEach { cell ->
                     val outpointKey = "${cell.outPoint.txHash}:${cell.outPoint.index}"
@@ -867,6 +868,7 @@ class GatewayRepository @Inject constructor(
                         if (cellCapacity == null) {
                             Log.w(TAG, "Skipping cell $outpointKey with unparseable capacity ${cell.output.capacity}")
                         } else if (cell.output.type != null) {
+                            typedCellCount++
                             Log.d(TAG, "🔒 DAO/typed cell excluded from balance: $outpointKey = $cellCapacity shannons")
                         } else {
                             liveCapacity += cellCapacity
@@ -881,10 +883,24 @@ class GatewayRepository @Inject constructor(
                 Log.d(TAG, "💰 Live balance: $liveCellCount cells, $liveCapacity shannons")
                 capacityVal = liveCapacity
 
-                // If we have 0 live cells but transactions exist, trigger rescan
-                if (liveCapacity == 0L && txJson != null) {
+                // Rescue rescan (#332): only for a wallet that is GENUINELY
+                // empty (no spendable AND no typed/DAO cells) yet has history,
+                // at most once per wallet per process, and never while sync is
+                // still catching up. The old `liveCapacity == 0` trigger
+                // counted DAO deposits as nothing and re-fired after every
+                // refresh — rewinding the light client to the wallet's
+                // earliest transaction in an infinite loop.
+                if (txJson != null) {
                     val txPag = json.decodeFromString<JniPagination<JniTxWithCell>>(txJson)
-                    if (txPag.objects.isNotEmpty()) {
+                    if (shouldAttemptZeroCellRescan(
+                            spendableCapacity = liveCapacity,
+                            typedCellCount = typedCellCount,
+                            hasTransactions = txPag.objects.isNotEmpty(),
+                            alreadyAttempted = activeWalletId in balanceRescanAttempted,
+                            isSyncing = _syncProgress.value.isSyncing,
+                        )
+                    ) {
+                        balanceRescanAttempted.add(activeWalletId)
                         Log.w(TAG, "🔄 Have ${txPag.objects.size} transactions but 0 live cells - triggering rescan")
                         val earliestBlock = txPag.objects
                             .mapNotNull { it.blockNumber.removePrefix("0x").toLongOrNull(16) }
@@ -901,7 +917,12 @@ class GatewayRepository @Inject constructor(
                             )
                         )
                         setScriptsAndRecord(scriptStatuses, listOf(activeWalletId), LightClientNative.CMD_SET_SCRIPTS_PARTIAL)
-                        setWalletSyncBlock(activeWalletId, rescanFrom)
+                        // Deliberately NOT persisted via setWalletSyncBlock: the
+                        // light client's own storage carries the rewind for this
+                        // session, and the sync poll's monotonic write records
+                        // progress as it advances. Persisting the regression made
+                        // it survive restarts — re-registering from the rewound
+                        // block forever (#332).
                         Log.d(TAG, "✅ Rescan triggered (partial) - balance should update on next refresh")
                     }
                 }
@@ -1967,6 +1988,11 @@ class GatewayRepository @Inject constructor(
     // Throttle for the lastSyncedAt pref write in the sync poll (#286).
     @Volatile
     private var lastSyncedAtWrittenMs = 0L
+
+    // One rescue rescan per wallet per process (#332) — the rescan itself
+    // takes hours on a long-history wallet; re-firing restarts it.
+    private val balanceRescanAttempted =
+        java.util.Collections.synchronizedSet(mutableSetOf<String>())
 
     fun startSyncPolling() {
         if (syncPollingJob?.isActive == true) return

--- a/android/app/src/main/java/com/rjnr/pocketnode/data/gateway/RescanPolicy.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/gateway/RescanPolicy.kt
@@ -1,0 +1,26 @@
+package com.rjnr.pocketnode.data.gateway
+
+/**
+ * Decision for the 0-live-cells rescue rescan in
+ * [GatewayRepository.refreshBalance] (#332). Pure so it is unit-testable
+ * away from the JNI surface.
+ *
+ * History: the original trigger was `liveCapacity == 0 && transactions
+ * exist`. `liveCapacity` excludes typed cells, so a wallet whose entire
+ * balance sits in Nervos DAO satisfied it on EVERY refresh — each hit
+ * rewound the light-client scripts to the wallet's earliest transaction and
+ * restarted a multi-hour filter scan the moment the previous one finished.
+ * "Sync restarts indefinitely."
+ */
+internal fun shouldAttemptZeroCellRescan(
+    spendableCapacity: Long,
+    typedCellCount: Int,
+    hasTransactions: Boolean,
+    alreadyAttempted: Boolean,
+    isSyncing: Boolean,
+): Boolean =
+    spendableCapacity == 0L &&
+        typedCellCount == 0 &&
+        hasTransactions &&
+        !alreadyAttempted &&
+        !isSyncing

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/components/SyncOptionsSheet.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/components/SyncOptionsSheet.kt
@@ -14,7 +14,13 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.layout.imePadding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.ui.platform.LocalFocusManager
+import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
@@ -88,6 +94,13 @@ internal fun SyncOptionsSheet(
                 .fillMaxWidth()
                 .widthIn(max = centredContentMaxWidth())
                 .align(Alignment.CenterHorizontally)
+                // #332: the numeric keyboard covered the Cancel/Apply row at
+                // the bottom of the sheet — users reported "no confirm
+                // button". imePadding lifts the content above the keyboard;
+                // verticalScroll makes the lifted content reachable on small
+                // screens.
+                .verticalScroll(rememberScrollState())
+                .imePadding()
                 .padding(start = 24.dp, end = 24.dp, top = 8.dp, bottom = 24.dp),
             verticalArrangement = Arrangement.spacedBy(8.dp),
         ) {
@@ -320,6 +333,7 @@ private fun CustomBlockInput(
     val parsedHeight = value.toLongOrNull()
     val exceedsTip = parsedHeight != null && tipBlockNumber > 0 && parsedHeight > tipBlockNumber
     val invalidNumber = value.isNotBlank() && parsedHeight == null
+    val focusManager = LocalFocusManager.current
 
     Row(verticalAlignment = Alignment.CenterVertically) {
         OutlinedTextField(
@@ -327,7 +341,14 @@ private fun CustomBlockInput(
             onValueChange = onValueChange,
             label = { Text(stringResource(R.string.sync_custom_block_label)) },
             placeholder = { Text(stringResource(R.string.sync_custom_block_placeholder)) },
-            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+            // #332: without an explicit IME action the numeric keyboard's
+            // Enter key did nothing on this singleLine field. Done clears
+            // focus, dropping the keyboard so the Apply button is visible.
+            keyboardOptions = KeyboardOptions(
+                keyboardType = KeyboardType.Number,
+                imeAction = ImeAction.Done,
+            ),
+            keyboardActions = KeyboardActions(onDone = { focusManager.clearFocus() }),
             modifier = Modifier.weight(1f),
             singleLine = true,
             isError = invalidNumber || exceedsTip,

--- a/android/app/src/test/java/com/rjnr/pocketnode/data/gateway/RescanPolicyTest.kt
+++ b/android/app/src/test/java/com/rjnr/pocketnode/data/gateway/RescanPolicyTest.kt
@@ -1,0 +1,79 @@
+package com.rjnr.pocketnode.data.gateway
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * #332: the 0-live-cells rescue rescan looped indefinitely for DAO-heavy
+ * wallets because the trigger counted typed (DAO) cells as "no cells", and
+ * nothing stopped it from firing again after every refresh. The policy is
+ * now pure and explicit:
+ *  - a wallet whose balance sits in typed cells is NOT empty;
+ *  - one attempt per wallet per process (the rescan itself takes hours on a
+ *    long-history wallet — re-firing mid-recovery restarts it);
+ *  - never while sync is still catching up (the missing cells may simply
+ *    not have been scanned yet).
+ */
+class RescanPolicyTest {
+
+    @Test
+    fun `fires for genuinely empty wallet with history`() {
+        assertTrue(
+            shouldAttemptZeroCellRescan(
+                spendableCapacity = 0L, typedCellCount = 0, hasTransactions = true,
+                alreadyAttempted = false, isSyncing = false,
+            )
+        )
+    }
+
+    @Test
+    fun `DAO-only wallet is not empty - no rescan`() {
+        assertFalse(
+            shouldAttemptZeroCellRescan(
+                spendableCapacity = 0L, typedCellCount = 3, hasTransactions = true,
+                alreadyAttempted = false, isSyncing = false,
+            )
+        )
+    }
+
+    @Test
+    fun `does not re-fire after an attempt this session`() {
+        assertFalse(
+            shouldAttemptZeroCellRescan(
+                spendableCapacity = 0L, typedCellCount = 0, hasTransactions = true,
+                alreadyAttempted = true, isSyncing = false,
+            )
+        )
+    }
+
+    @Test
+    fun `never fires mid-sync`() {
+        assertFalse(
+            shouldAttemptZeroCellRescan(
+                spendableCapacity = 0L, typedCellCount = 0, hasTransactions = true,
+                alreadyAttempted = false, isSyncing = true,
+            )
+        )
+    }
+
+    @Test
+    fun `no transactions means nothing to rescue`() {
+        assertFalse(
+            shouldAttemptZeroCellRescan(
+                spendableCapacity = 0L, typedCellCount = 0, hasTransactions = false,
+                alreadyAttempted = false, isSyncing = false,
+            )
+        )
+    }
+
+    @Test
+    fun `funded wallet never rescans`() {
+        assertFalse(
+            shouldAttemptZeroCellRescan(
+                spendableCapacity = 61_00000000L, typedCellCount = 0, hasTransactions = true,
+                alreadyAttempted = false, isSyncing = false,
+            )
+        )
+    }
+}


### PR DESCRIPTION
## Summary

First fix PR from the #332 root-cause investigation (full analysis in the issue comments).

### Rescan loop — "sync restarts indefinitely"
The 0-live-cells rescue rescan in `refreshBalance` treated DAO deposits as nothing (`liveCapacity` excludes typed cells), so a wallet whose balance sits in Nervos DAO re-triggered it on every refresh — each hit rewound the light-client scripts to the wallet's earliest transaction, persisted the regression, and restarted a multi-hour filter scan the moment the previous one finished. Fixes:
- Trigger extracted into pure `shouldAttemptZeroCellRescan` (TDD, 6 cases): a wallet with typed/DAO cells is NOT empty; at most one attempt per wallet per process; never while sync is still catching up.
- The rescan no longer persists its rewound block via `setWalletSyncBlock` — the light client's own storage carries the rewind for the session, and the sync poll's monotonic write records progress as it advances. Previously the regression survived restarts and re-registered from the rewound block forever.

### Custom block height — "Enter doesn't work, no confirm button"
`SyncOptionsSheet`: the numeric keyboard covered the Cancel/Apply row (no `imePadding`/scroll on the sheet) and the height field had no IME action (Enter was a no-op on a singleLine field). Now: `ImeAction.Done` clears focus to drop the keyboard, and the sheet column gets `verticalScroll + imePadding` so Apply stays reachable while typing.

## Verification
- `RescanPolicyTest` (6 cases) written and verified failing first; full `testDebugUnitTest` green.
- Device-verified on a local emulator: full onboarding walk passes; reproduced the user's exact scenario — typed 12000000 into the custom field with the keyboard open, **Apply visible and enabled**, Done key drops the keyboard, Apply re-registers scripts at the chosen height (confirmed via `setScripts ... startBlock=12000000` in logcat).
- The rescan loop itself needs a long-history DAO wallet to reproduce live; covered by unit tests + the mechanism analysis on the issue.

## Remaining #332 follow-ups (not in this PR)
- Monotonic clamp for PARTIAL setScripts at the SyncCoordinator seam (with explicit user-initiated rewind flag).
- DAO windowing recovery: copy in the CUSTOM picker ("start height must predate your first DAO deposit"), "find older deposits" rewind, Room-persisted deposits.

Refs #332

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Improved wallet balance recovery: Wallets displaying zero balance will now automatically rescan if transaction history exists.

* **Bug Fixes**
  * Fixed on-screen keyboard covering action buttons in sync options.
  * Enhanced balance calculation accuracy for edge cases.

* **Tests**
  * Added comprehensive test coverage for wallet recovery scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->