### PR TITLE
fix(sync): monotonic clamp for PARTIAL setScripts + post-send guard + honest CUSTOM copy (#332)

### DIFF
--- a/android/app/src/main/java/com/rjnr/pocketnode/data/gateway/GatewayRepository.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/gateway/GatewayRepository.kt
@@ -916,7 +916,12 @@ class GatewayRepository @Inject constructor(
                                 blockNumber = blockNumberHex
                             )
                         )
-                        setScriptsAndRecord(scriptStatuses, listOf(activeWalletId), LightClientNative.CMD_SET_SCRIPTS_PARTIAL)
+                        setScriptsAndRecord(
+                            scriptStatuses,
+                            listOf(activeWalletId),
+                            LightClientNative.CMD_SET_SCRIPTS_PARTIAL,
+                            allowRewind = true, // rescue rescan IS the intentional rewind
+                        )
                         // Deliberately NOT persisted via setWalletSyncBlock: the
                         // light client's own storage carries the rewind for this
                         // session, and the sync poll's monotonic write records
@@ -1428,6 +1433,14 @@ class GatewayRepository @Inject constructor(
         scope.launch {
             try {
                 delay(5000) // Wait a bit for tx to propagate
+                // #332: on a still-catching-up wallet, re-registering at
+                // tip-10 JUMPS the script forward over unscanned history —
+                // silent balance/history loss. The ongoing scan will find the
+                // change output anyway; only fast-path when already synced.
+                if (_syncProgress.value.isSyncing) {
+                    Log.d(TAG, "Skipping post-send partial re-register: wallet still catching up")
+                    return@launch
+                }
                 val tipStr = LightClientNative.nativeGetTipHeader()
                 if (tipStr != null && senderInfo != null) {
                     val tip = json.decodeFromString<JniHeaderView>(tipStr)
@@ -1960,7 +1973,8 @@ class GatewayRepository @Inject constructor(
         statuses: List<JniScriptStatus>,
         walletIds: List<String>,
         cmd: Int,
-    ): Boolean = syncCoordinator.setScriptsAndRecord(statuses, walletIds, cmd, currentNetwork)
+        allowRewind: Boolean = false,
+    ): Boolean = syncCoordinator.setScriptsAndRecord(statuses, walletIds, cmd, currentNetwork, allowRewind)
 
     private suspend fun maybeReregisterBalanced() {
         syncCoordinator.maybeReregisterBalanced(makeSyncContext())

--- a/android/app/src/main/java/com/rjnr/pocketnode/data/gateway/SyncCoordinator.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/gateway/SyncCoordinator.kt
@@ -80,6 +80,34 @@ internal fun balancedFilterAlgorithm(
  * is idempotent and benign.
  */
 /**
+ * Clamp PARTIAL setScripts rewinds (#332). For each requested script status,
+ * if the same script (by lock args) is already registered at a HIGHER block,
+ * replace the requested block with the current one. A rewind makes the Rust
+ * light client restart its filter scan from the older block (no monotonic
+ * guard in `update_filter_scripts`, and it clears the matched-block download
+ * queue) — a multi-hour re-scan on long-history wallets. Returns the clamped
+ * list and how many entries were clamped.
+ */
+internal fun clampPartialRewinds(
+    requested: List<JniScriptStatus>,
+    currentBlockByArgs: Map<String, Long>,
+): Pair<List<JniScriptStatus>, Int> {
+    var clampedCount = 0
+    val out = requested.map { status ->
+        val req = status.blockNumber.removePrefix("0x").toLongOrNull(16)
+            ?: return@map status
+        val cur = currentBlockByArgs[status.script.args] ?: return@map status
+        if (req < cur) {
+            clampedCount++
+            status.copy(blockNumber = "0x${cur.toString(16)}")
+        } else {
+            status
+        }
+    }
+    return out to clampedCount
+}
+
+/**
  * Thin indirection over the two static JNI methods [SyncCoordinator]
  * touches. Exists so unit tests can fake the JNI surface without
  * forcing `System.loadLibrary` on the JVM — `external` methods can't
@@ -88,6 +116,7 @@ internal fun balancedFilterAlgorithm(
 interface LightClientBridge {
     suspend fun setScripts(scriptsJson: String, command: Int): Boolean
     suspend fun getTipHeaderRaw(): String?
+    suspend fun getScriptsRaw(): String?
 }
 
 /** Production bridge — delegates straight to the JNI `external fun`s. */
@@ -97,6 +126,8 @@ class LightClientNativeBridge @Inject constructor() : LightClientBridge {
         com.nervosnetwork.ckblightclient.LightClientNative.nativeSetScripts(scriptsJson, command)
     override suspend fun getTipHeaderRaw(): String? =
         com.nervosnetwork.ckblightclient.LightClientNative.nativeGetTipHeader()
+    override suspend fun getScriptsRaw(): String? =
+        com.nervosnetwork.ckblightclient.LightClientNative.nativeGetScripts()
 }
 
 @Singleton
@@ -147,11 +178,33 @@ class SyncCoordinator @Inject constructor(
         walletIds: List<String>,
         cmd: Int,
         network: NetworkType,
+        allowRewind: Boolean = false,
     ): Boolean {
         require(statuses.size == walletIds.size) {
             "setScriptsAndRecord: statuses (${statuses.size}) and walletIds (${walletIds.size}) must be parallel"
         }
-        val jsonStr = json.encodeToString(statuses)
+        // #332: PARTIAL with an older block rewinds the rust filter scan for
+        // hours. Clamp to the currently-registered block per script unless the
+        // caller is an intentional rewind (rescue rescan, find-older-deposits).
+        val effectiveStatuses = if (
+            cmd == LightClientNative.CMD_SET_SCRIPTS_PARTIAL && !allowRewind
+        ) {
+            val currentByArgs = runCatching {
+                lightClient.getScriptsRaw()?.let { raw ->
+                    json.decodeFromString<List<JniScriptStatus>>(raw).associate { st ->
+                        st.script.args to (st.blockNumber.removePrefix("0x").toLongOrNull(16) ?: 0L)
+                    }
+                }
+            }.getOrNull() ?: emptyMap()
+            val (clamped, clampedCount) = clampPartialRewinds(statuses, currentByArgs)
+            if (clampedCount > 0) {
+                Log.w(TAG, "setScripts PARTIAL: clamped $clampedCount rewind(s) to current block (#332)")
+            }
+            clamped
+        } else {
+            statuses
+        }
+        val jsonStr = json.encodeToString(effectiveStatuses)
         // Diagnostic for the production sync-stall reports (#150). Logs every
         // (walletId, startBlock) pair just before the JNI handoff. If a user
         // reports "stayed at 0", this line tells us deterministically what
@@ -159,7 +212,7 @@ class SyncCoordinator @Inject constructor(
         // ALL android.util.Log calls via proguard -assumenosideeffects, so
         // this diagnostic only exists in debug builds — use a debug APK when
         // chasing #150-class sync stalls.
-        statuses.zip(walletIds).forEach { (status, walletId) ->
+        effectiveStatuses.zip(walletIds).forEach { (status, walletId) ->
             val startBlock = status.blockNumber.removePrefix("0x").toLongOrNull(16) ?: -1L
             Log.i(
                 TAG,
@@ -175,7 +228,7 @@ class SyncCoordinator @Inject constructor(
 
         val now = System.currentTimeMillis()
         val newMapping = mutableMapOf<String, String>()
-        statuses.zip(walletIds).forEach { (status, walletId) ->
+        effectiveStatuses.zip(walletIds).forEach { (status, walletId) ->
             if (walletId.isEmpty()) return@forEach
             newMapping[status.script.args] = walletId
             // Malformed block number from the node: skip this script's row

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -109,7 +109,7 @@
     <string name="sync_mode_custom_pick_if">Pick this if you know roughly when your first CKB transaction was. You will enter a block number — we will help you find it.</string>
     <string name="sync_mode_full_title">All history</string>
     <string name="sync_mode_full_pick_if">Pick this only if you need every transaction since CKB launched. Slow — can take hours on mainnet.</string>
-    <string name="sync_custom_warning">Transactions before this block won\'t appear in history, but your balance will still be correct.</string>
+    <string name="sync_custom_warning">Anything before this block is invisible to the wallet — including Nervos DAO deposits, which won\'t show or count toward your balance. Choose a height from before your first transaction or DAO deposit.</string>
     <string name="sync_custom_block_label">Block Height</string>
     <string name="sync_custom_block_placeholder">e.g., 12000000</string>
     <string name="sync_custom_invalid">Invalid block height</string>

--- a/android/app/src/test/java/com/rjnr/pocketnode/data/gateway/PartialClampTest.kt
+++ b/android/app/src/test/java/com/rjnr/pocketnode/data/gateway/PartialClampTest.kt
@@ -1,0 +1,71 @@
+package com.rjnr.pocketnode.data.gateway
+
+import com.rjnr.pocketnode.data.gateway.models.JniScriptStatus
+import com.rjnr.pocketnode.data.gateway.models.Script
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * #332 follow-up: PARTIAL setScripts with a block number BEHIND the script's
+ * current position rewinds the light client's filter scan (Rust
+ * `update_filter_scripts` has no monotonic guard and clears the matched-block
+ * queue) — a multi-hour re-scan on long-history wallets. The seam now clamps
+ * rewinds unless the caller explicitly opts in (rescue rescan,
+ * find-older-deposits).
+ */
+class PartialClampTest {
+
+    private fun script(args: String) = Script(
+        codeHash = Script.SECP256K1_CODE_HASH,
+        hashType = "type",
+        args = args,
+    )
+
+    private fun status(args: String, block: Long) = JniScriptStatus(
+        script = script(args),
+        scriptType = "lock",
+        blockNumber = "0x${block.toString(16)}",
+    )
+
+    @Test
+    fun `rewind below current position is clamped to current`() {
+        val (clamped, count) = clampPartialRewinds(
+            requested = listOf(status("0xaa", 5_000_000L)),
+            currentBlockByArgs = mapOf("0xaa" to 18_000_000L),
+        )
+        assertEquals("0x${18_000_000L.toString(16)}", clamped.single().blockNumber)
+        assertEquals(1, count)
+    }
+
+    @Test
+    fun `forward or equal block passes through untouched`() {
+        val (clamped, count) = clampPartialRewinds(
+            requested = listOf(status("0xaa", 18_000_000L), status("0xbb", 19_000_000L)),
+            currentBlockByArgs = mapOf("0xaa" to 18_000_000L, "0xbb" to 18_000_000L),
+        )
+        assertEquals("0x${18_000_000L.toString(16)}", clamped[0].blockNumber)
+        assertEquals("0x${19_000_000L.toString(16)}", clamped[1].blockNumber)
+        assertEquals(0, count)
+    }
+
+    @Test
+    fun `unknown script args pass through - nothing to clamp against`() {
+        val (clamped, count) = clampPartialRewinds(
+            requested = listOf(status("0xnew", 1_000L)),
+            currentBlockByArgs = mapOf("0xaa" to 18_000_000L),
+        )
+        assertEquals("0x${1_000L.toString(16)}", clamped.single().blockNumber)
+        assertEquals(0, count)
+    }
+
+    @Test
+    fun `malformed requested block passes through unchanged`() {
+        val bad = JniScriptStatus(script = script("0xaa"), scriptType = "lock", blockNumber = "0xZZ")
+        val (clamped, count) = clampPartialRewinds(
+            requested = listOf(bad),
+            currentBlockByArgs = mapOf("0xaa" to 18_000_000L),
+        )
+        assertEquals("0xZZ", clamped.single().blockNumber)
+        assertEquals(0, count)
+    }
+}

--- a/android/app/src/test/java/com/rjnr/pocketnode/data/gateway/SyncCoordinatorCustomBlockTest.kt
+++ b/android/app/src/test/java/com/rjnr/pocketnode/data/gateway/SyncCoordinatorCustomBlockTest.kt
@@ -72,6 +72,9 @@ class SyncCoordinatorCustomBlockTest {
         }
 
         override suspend fun getTipHeaderRaw(): String? = tipHeaderJson
+        // No scripts registered in the fake — clamp finds nothing to clamp
+        // against, preserving the original pass-through behavior under test.
+        override suspend fun getScriptsRaw(): String? = null
     }
 
     // Real testnet script (from AddressUtilsTest) — encodes to a real CKB


### PR DESCRIPTION
## Summary

Second #332 PR — protects the script-registration seam against the accidental-rewind class of bug that #340 fixed one instance of.

- **Monotonic clamp at the seam**: `SyncCoordinator.setScriptsAndRecord` now clamps PARTIAL block numbers to the script's currently-registered block (read via `nativeGetScripts`) unless the caller passes `allowRewind = true`. A rewind makes the Rust light client restart its filter scan and drop its download queue — multi-hour cost on long-history wallets. The rescue rescan opts in explicitly (it IS the intentional rewind); every other current and future PARTIAL call site is protected by default. Pure `clampPartialRewinds` function, TDD (4 cases: rewind clamped, forward/equal pass, unknown script passes, malformed passes).
- **Post-send forward-skip guard**: the post-send tip-10 re-register on a still-catching-up wallet JUMPED the script forward over unscanned history — silent balance/history loss (the mirror image of the rewind bug). Now skipped while syncing; the ongoing scan finds the change output anyway.
- **CUSTOM picker copy fix**: the warning claimed "your balance will still be correct" — false for wallets with DAO deposits older than the chosen height (they vanish from both the deposit list and the balance, per the #332 windowing analysis). Copy now says so and tells the user to pick a height before their first transaction or DAO deposit.

## Tests
`PartialClampTest` written and verified failing first; `SyncCoordinatorCustomBlockTest` fake extended with `getScriptsRaw`; full `testDebugUnitTest` green.

Refs #332 — remaining after this: DAO windowing recovery (write-through persistence + find-older-deposits), tracked for the next PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced wallet balance recovery mechanism to fix wallets showing zero balance
  * Improved custom sync block height selection with updated guidance on transaction visibility and DAO deposits

* **Bug Fixes**
  * Prevents potential balance and transaction history gaps during active wallet synchronization by deferring updates until sync completes

* **Tests**
  * Added comprehensive test coverage for the balance recovery and rewind logic

<!-- end of auto-generated comment: release notes by coderabbit.ai -->