### PR TITLE
feat(dao): windowing recovery — persisted deposits, pre-window merge, deep rescan (#332)

### DIFF
--- a/android/app/src/main/java/com/rjnr/pocketnode/data/gateway/DaoCellMapping.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/gateway/DaoCellMapping.kt
@@ -1,0 +1,65 @@
+package com.rjnr.pocketnode.data.gateway
+
+import com.rjnr.pocketnode.data.database.entity.DaoCellEntity
+import com.rjnr.pocketnode.data.gateway.models.DaoCellStatus
+import com.rjnr.pocketnode.data.gateway.models.DaoDeposit
+import com.rjnr.pocketnode.data.gateway.models.EpochInfo
+import com.rjnr.pocketnode.data.gateway.models.OutPoint
+
+/**
+ * dao_cells ↔ DaoDeposit mapping (#332 windowing recovery).
+ *
+ * Every live scan writes its deposits through to Room so they survive a
+ * later narrowing of the sync window (CUSTOM resync with a higher start
+ * block, RECENT switch). A cached deposit older than the current window is
+ * merged back into the UI list flagged [DaoDeposit.outsideSyncWindow] —
+ * visible, but marked as needing a deeper rescan for fresh compensation
+ * and spend state.
+ */
+
+private fun EpochInfo.toHexString(): String {
+    val packed = (length shl 40) or (index shl 24) or number
+    return "0x${packed.toString(16)}"
+}
+
+internal fun DaoDeposit.toDaoCellEntity(
+    network: String,
+    walletId: String,
+    nowMs: Long,
+): DaoCellEntity = DaoCellEntity(
+    txHash = outPoint.txHash,
+    index = outPoint.index,
+    capacity = capacity,
+    status = status.name,
+    depositBlockNumber = depositBlockNumber,
+    depositBlockHash = depositBlockHash,
+    depositEpochHex = depositEpoch?.toHexString(),
+    withdrawBlockNumber = withdrawBlockNumber,
+    withdrawBlockHash = withdrawBlockHash,
+    withdrawEpochHex = withdrawEpoch?.toHexString(),
+    compensation = compensation,
+    unlockEpochHex = unlockEpoch?.toHexString(),
+    depositTimestamp = depositTimestamp,
+    network = network,
+    lastUpdatedAt = nowMs,
+    walletId = walletId,
+)
+
+internal fun DaoCellEntity.toOutsideWindowDeposit(): DaoDeposit = DaoDeposit(
+    outPoint = OutPoint(txHash = txHash, index = index),
+    capacity = capacity,
+    status = runCatching { DaoCellStatus.valueOf(status) }.getOrDefault(DaoCellStatus.DEPOSITED),
+    depositBlockNumber = depositBlockNumber,
+    depositBlockHash = depositBlockHash,
+    depositEpoch = depositEpochHex?.let { parseEpochOrNull(it) },
+    withdrawBlockNumber = withdrawBlockNumber,
+    withdrawBlockHash = withdrawBlockHash,
+    withdrawEpoch = withdrawEpochHex?.let { parseEpochOrNull(it) },
+    compensation = compensation,
+    unlockEpoch = unlockEpochHex?.let { parseEpochOrNull(it) },
+    depositTimestamp = depositTimestamp,
+    outsideSyncWindow = true,
+)
+
+private fun parseEpochOrNull(hex: String): EpochInfo? =
+    runCatching { EpochInfo.fromHex(hex) }.getOrNull()

--- a/android/app/src/main/java/com/rjnr/pocketnode/data/gateway/GatewayRepository.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/gateway/GatewayRepository.kt
@@ -1751,7 +1751,93 @@ class GatewayRepository @Inject constructor(
     suspend fun getDaoDeposits(): Result<List<DaoDeposit>> = runCatching {
         val info = _walletInfo.value ?: throw Exception("No wallet")
         val currentEpoch = getCurrentEpoch().getOrNull()
-        daoDepositReader.list(info.script, currentEpoch, currentNetwork)
+        val live = daoDepositReader.list(info.script, currentEpoch, currentNetwork)
+        mergeWithCachedDaoDeposits(live)
+    }
+
+    /**
+     * #332 windowing recovery. The light client only indexes cells created
+     * AFTER the script's registered start block, so a DAO deposit older than
+     * the chosen sync window silently vanishes from both the deposit list and
+     * the balance. Mitigation:
+     *  1. write-through: every live scan persists its deposits to dao_cells;
+     *  2. reconcile: cached active deposits INSIDE the window that the live
+     *     scan no longer returns were spent/unlocked — mark COMPLETED;
+     *  3. merge: cached active deposits from BEFORE the window are appended,
+     *     flagged [DaoDeposit.outsideSyncWindow] so the UI can offer the
+     *     deeper-rescan recovery instead of pretending they don't exist.
+     */
+    private suspend fun mergeWithCachedDaoDeposits(live: List<DaoDeposit>): List<DaoDeposit> {
+        val walletId = activeWalletId
+        if (walletId.isEmpty()) return live
+        val network = currentNetwork.name
+        val nowMs = System.currentTimeMillis()
+
+        runCatching {
+            daoSyncManager.upsertDaoCells(live.map { it.toDaoCellEntity(network, walletId, nowMs) })
+        }.onFailure { Log.w(TAG, "DAO write-through failed: ${it.message}") }
+
+        val windowStart = getExistingScriptBlock()
+        val liveKeys = live.map { "${it.outPoint.txHash}:${it.outPoint.index}" }.toSet()
+        val cached = runCatching { daoSyncManager.getActiveDeposits(network, walletId) }
+            .getOrDefault(emptyList())
+
+        val outsideWindow = mutableListOf<DaoDeposit>()
+        for (entity in cached) {
+            val key = "${entity.txHash}:${entity.index}"
+            if (key in liveKeys) continue
+            // DEPOSITING rows are optimistic pre-confirmation inserts with
+            // blockNumber 0 — not windowing victims; leave them alone.
+            if (entity.status == DaoCellStatus.DEPOSITING.name) continue
+            if (windowStart > 0 && entity.depositBlockNumber in 1 until windowStart) {
+                outsideWindow += entity.toOutsideWindowDeposit()
+            } else {
+                // Inside the window yet absent from the live scan: the cell
+                // was spent (withdrawn/unlocked) — retire the cached row so it
+                // doesn't resurrect.
+                runCatching {
+                    daoSyncManager.updateStatus(entity.txHash, entity.index, DaoCellStatus.COMPLETED.name)
+                }
+            }
+        }
+        if (outsideWindow.isNotEmpty()) {
+            Log.i(TAG, "DAO merge: ${outsideWindow.size} cached deposit(s) predate sync window (start=$windowStart)")
+        }
+        return live + outsideWindow
+    }
+
+    /**
+     * User-confirmed deeper rescan to re-index DAO deposits that predate the
+     * current sync window (#332). Rewinds the wallet's lock script to just
+     * before the oldest cached out-of-window deposit. Multi-hour cost on
+     * mainnet — callers must gate behind an explicit confirmation dialog.
+     * Returns the rewind target block.
+     */
+    suspend fun rescanForOlderDaoDeposits(): Result<Long> = runCatching {
+        val info = _walletInfo.value ?: throw Exception("No wallet")
+        val walletId = activeWalletId.takeIf { it.isNotEmpty() } ?: throw Exception("No active wallet")
+        val windowStart = getExistingScriptBlock()
+        val oldest = daoSyncManager.getActiveDeposits(currentNetwork.name, walletId)
+            .filter { it.status != DaoCellStatus.DEPOSITING.name }
+            .filter { windowStart > 0 && it.depositBlockNumber in 1 until windowStart }
+            .minOfOrNull { it.depositBlockNumber }
+            ?: throw Exception("No deposits older than the current sync window")
+        val target = (oldest - 100).coerceAtLeast(0L)
+        val ok = setScriptsAndRecord(
+            listOf(
+                JniScriptStatus(
+                    script = info.script,
+                    scriptType = "lock",
+                    blockNumber = "0x${target.toString(16)}"
+                )
+            ),
+            listOf(walletId),
+            LightClientNative.CMD_SET_SCRIPTS_PARTIAL,
+            allowRewind = true, // explicitly user-initiated rewind
+        )
+        if (!ok) throw Exception("Light client refused script registration")
+        Log.i(TAG, "DAO deep rescan: rewound script to block $target (oldest cached deposit at $oldest)")
+        target
     }
 
 

--- a/android/app/src/main/java/com/rjnr/pocketnode/data/gateway/models/DaoModels.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/gateway/models/DaoModels.kt
@@ -68,7 +68,11 @@ data class DaoDeposit(
     val compensationCycleProgress: Float = 0f,
     val cyclePhase: CyclePhase = CyclePhase.NORMAL,
     val depositTimestamp: Long = 0L,  // Unix millis from block header
-    val apc: Double = 0.0             // annualized per-deposit APC %
+    val apc: Double = 0.0,            // annualized per-deposit APC %
+    // #332: deposit known from the Room cache but created BEFORE the script's
+    // current sync window — the light client cannot see it, so compensation/
+    // status may be stale until the user runs a deeper rescan.
+    val outsideSyncWindow: Boolean = false
 )
 
 // -- Aggregate overview --

--- a/android/app/src/main/java/com/rjnr/pocketnode/data/gateway/models/DaoModels.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/gateway/models/DaoModels.kt
@@ -109,7 +109,11 @@ data class DaoUiState(
     val error: com.rjnr.pocketnode.ui.util.UiMessage? = null,
     val pendingAction: DaoAction? = null,
     val requiresAuth: Boolean = false,
-    val authMethod: AuthMethod? = null
+    val authMethod: AuthMethod? = null,
+    // #332: cached deposits that predate the sync window — drives the
+    // deeper-rescan banner on DaoScreen.
+    val outsideWindowCount: Int = 0,
+    val isDeepRescanning: Boolean = false
 )
 
 // -- DAO header field extraction result --

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/dao/DaoScreen.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/dao/DaoScreen.kt
@@ -47,6 +47,7 @@ fun DaoScreen(
     val networkType by viewModel.networkType.collectAsState()
     val snackbarHostState = remember { SnackbarHostState() }
     var showDepositSheet by remember { mutableStateOf(false) }
+    var showDeepRescanConfirm by remember { mutableStateOf(false) }
     var withdrawTarget by remember { mutableStateOf<DaoDeposit?>(null) }
     var unlockTarget by remember { mutableStateOf<DaoDeposit?>(null) }
     val context = LocalContext.current
@@ -112,6 +113,50 @@ fun DaoScreen(
                         completedCount = uiState.overview.completedCount,
                         onTabSelected = viewModel::selectTab
                     )
+                }
+
+                // #332: cached deposits that predate the sync window. The
+                // light client can't see them, so status/compensation are
+                // stale and they don't count toward live balance — offer the
+                // deeper rescan instead of silently hiding them.
+                if (uiState.outsideWindowCount > 0) {
+                    item("outside-window-banner") {
+                        Card(
+                            modifier = Modifier.fillMaxWidth(),
+                            colors = CardDefaults.cardColors(
+                                containerColor = MaterialTheme.colorScheme.secondaryContainer
+                            )
+                        ) {
+                            Column(
+                                modifier = Modifier.padding(12.dp),
+                                verticalArrangement = Arrangement.spacedBy(8.dp)
+                            ) {
+                                Text(
+                                    text = "${uiState.outsideWindowCount} deposit(s) were made before this wallet's sync window",
+                                    style = MaterialTheme.typography.titleSmall,
+                                    color = MaterialTheme.colorScheme.onSecondaryContainer
+                                )
+                                Text(
+                                    text = "Shown from this device's records. Status and compensation may be " +
+                                        "outdated, and they aren't counted in your live balance. Run a deep " +
+                                        "rescan to re-index them on-chain.",
+                                    style = MaterialTheme.typography.bodySmall,
+                                    color = MaterialTheme.colorScheme.onSecondaryContainer
+                                )
+                                Row(
+                                    modifier = Modifier.fillMaxWidth(),
+                                    horizontalArrangement = Arrangement.End
+                                ) {
+                                    Button(
+                                        onClick = { showDeepRescanConfirm = true },
+                                        enabled = !uiState.isDeepRescanning,
+                                    ) {
+                                        Text(if (uiState.isDeepRescanning) "Starting…" else "Deep rescan")
+                                    }
+                                }
+                            }
+                        }
+                    }
                 }
 
                 // Pending action banner — only when an action is in flight.
@@ -192,6 +237,32 @@ fun DaoScreen(
                 }
             }
         }
+    }
+
+    // #332 deep-rescan confirmation: rewinding the script means re-scanning
+    // millions of block filters — hours on mainnet. Never trigger silently.
+    if (showDeepRescanConfirm) {
+        AlertDialog(
+            onDismissRequest = { showDeepRescanConfirm = false },
+            title = { Text("Deep rescan for older deposits?") },
+            text = {
+                Text(
+                    "Your wallet will re-scan the chain from just before your oldest " +
+                        "recorded deposit. On mainnet this can take several hours; the " +
+                        "app stays usable while it runs. Balance and history keep " +
+                        "updating as the scan progresses."
+                )
+            },
+            confirmButton = {
+                Button(onClick = {
+                    showDeepRescanConfirm = false
+                    viewModel.deepRescanForOlderDeposits()
+                }) { Text("Start rescan") }
+            },
+            dismissButton = {
+                TextButton(onClick = { showDeepRescanConfirm = false }) { Text("Cancel") }
+            }
+        )
     }
 
     // Snackbar for errors

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/dao/DaoViewModel.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/dao/DaoViewModel.kt
@@ -63,6 +63,39 @@ class DaoViewModel @Inject constructor(
         }
     }
 
+    /**
+     * #332: user-confirmed deeper rescan to re-index DAO deposits that
+     * predate the sync window. Multi-hour cost — DaoScreen gates this
+     * behind an explicit confirmation dialog.
+     */
+    fun deepRescanForOlderDeposits() {
+        viewModelScope.launch {
+            _uiState.update { it.copy(isDeepRescanning = true) }
+            repository.rescanForOlderDaoDeposits()
+                .onSuccess { target ->
+                    _uiState.update {
+                        it.copy(
+                            isDeepRescanning = false,
+                            error = com.rjnr.pocketnode.ui.util.UiMessage.Raw(
+                                "Deep rescan started from block $target. " +
+                                    "This can take a while — leave the app open or enable background sync."
+                            )
+                        )
+                    }
+                }
+                .onFailure { e ->
+                    _uiState.update {
+                        it.copy(
+                            isDeepRescanning = false,
+                            error = com.rjnr.pocketnode.ui.util.UiMessage.Raw(
+                                e.message ?: "Deep rescan failed"
+                            )
+                        )
+                    }
+                }
+        }
+    }
+
     private suspend fun refreshDaoData() {
         repository.getDaoDeposits()
             .onSuccess { deposits ->
@@ -93,7 +126,8 @@ class DaoViewModel @Inject constructor(
                         activeDeposits = active,
                         completedDeposits = completed,
                         isLoading = false,
-                        error = null
+                        error = null,
+                        outsideWindowCount = deposits.count { d -> d.outsideSyncWindow }
                     )
                 }
 

--- a/android/app/src/test/java/com/rjnr/pocketnode/data/gateway/DaoCellMappingTest.kt
+++ b/android/app/src/test/java/com/rjnr/pocketnode/data/gateway/DaoCellMappingTest.kt
@@ -1,0 +1,66 @@
+package com.rjnr.pocketnode.data.gateway
+
+import com.rjnr.pocketnode.data.gateway.models.DaoCellStatus
+import com.rjnr.pocketnode.data.gateway.models.DaoDeposit
+import com.rjnr.pocketnode.data.gateway.models.EpochInfo
+import com.rjnr.pocketnode.data.gateway.models.OutPoint
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * #332 DAO windowing recovery: deposits discovered by a live scan are
+ * persisted to `dao_cells`, and cached deposits older than the script's
+ * sync window are merged back into the list (flagged) instead of silently
+ * vanishing when the user narrows the window.
+ */
+class DaoCellMappingTest {
+
+    private fun deposit(
+        block: Long = 8_000_000L,
+        status: DaoCellStatus = DaoCellStatus.DEPOSITED,
+    ) = DaoDeposit(
+        outPoint = OutPoint(txHash = "0x" + "ab".repeat(32), index = "0x0"),
+        capacity = 500_00000000L,
+        status = status,
+        depositBlockNumber = block,
+        depositBlockHash = "0x" + "cd".repeat(32),
+        depositEpoch = EpochInfo(number = 7000, index = 1, length = 1800),
+        compensation = 12_00000000L,
+        depositTimestamp = 1_700_000_000_000L,
+    )
+
+    @Test
+    fun `round-trips through the entity`() {
+        val original = deposit()
+        val entity = original.toDaoCellEntity(network = "MAINNET", walletId = "w1", nowMs = 42L)
+        assertEquals("MAINNET", entity.network)
+        assertEquals("w1", entity.walletId)
+        assertEquals("DEPOSITED", entity.status)
+        assertEquals(original.capacity, entity.capacity)
+        assertEquals(original.depositBlockNumber, entity.depositBlockNumber)
+
+        val back = entity.toOutsideWindowDeposit()
+        assertEquals(original.outPoint, back.outPoint)
+        assertEquals(original.capacity, back.capacity)
+        assertEquals(original.status, back.status)
+        assertEquals(original.depositBlockNumber, back.depositBlockNumber)
+        assertEquals(original.depositEpoch, back.depositEpoch)
+        assertTrue("merged-from-cache deposit must be flagged", back.outsideSyncWindow)
+    }
+
+    @Test
+    fun `unknown status string degrades to DEPOSITED not crash`() {
+        val entity = deposit().toDaoCellEntity("MAINNET", "w1", 0L)
+            .copy(status = "SOMETHING_FUTURE")
+        assertEquals(DaoCellStatus.DEPOSITED, entity.toOutsideWindowDeposit().status)
+    }
+
+    @Test
+    fun `malformed epoch hex degrades to null`() {
+        val entity = deposit().toDaoCellEntity("MAINNET", "w1", 0L)
+            .copy(depositEpochHex = "0xZZ")
+        assertNull(entity.toOutsideWindowDeposit().depositEpoch)
+    }
+}


### PR DESCRIPTION
## Summary

Final #332 PR — fixes the reporter's actual symptom: one of several DAO deposits invisible because it predates the script's sync window (the light client never indexes cells created before the registered start block).

- **Write-through persistence**: every successful `getDaoDeposits` scan upserts its deposits into the existing `dao_cells` Room table (`DaoCellMapping`, TDD round-trip + degradation cases). No schema change — the table and `DaoSyncManager` were already there, unused for this purpose.
- **Pre-window merge**: cached active deposits whose `depositBlockNumber` is provably before the current window start (read via `nativeGetScripts`) are appended to the result flagged `outsideSyncWindow` — visible instead of silently vanishing. Cached deposits INSIDE the window that the live scan no longer returns were spent — retired to COMPLETED so they can't resurrect stale.
- **Deep-rescan recovery**: DaoScreen banner when flagged deposits exist ("N deposits were made before this wallet's sync window…") with an explicit confirmation dialog (hours-long cost stated) → `rescanForOlderDaoDeposits()` rewinds the lock script to oldest-cached-deposit − 100 via the #341 seam with `allowRewind = true` — the one legitimate user-initiated rewind.

## Known limits (stated, not hidden)
- A deposit the wallet has NEVER seen (created outside every window this device ever synced) is not in the cache and can't be merged — for that case the recovery is the now-working CUSTOM resync with an earlier height (#340 keyboard fix + #341 honest picker copy). Tx-hash-based import was considered and deferred.
- Cached compensation/status are stale until the deep rescan completes; the banner says so.

## Tests
`DaoCellMappingTest` (round-trip, unknown-status degrade, malformed-epoch degrade) RED-verified first; full `testDebugUnitTest` green. Banner is conditional UI (`outsideWindowCount > 0`) — composes only when flagged deposits exist; DaoScreen is not on the smoke-critical onboarding path. Live validation of the full loop needs a DAO wallet on an 8114-open network (this network blocks it) — flagged for the next devnet/testnet session.

Depends on #341 (merged). Refs #332.

🤖 Generated with [Claude Code](https://claude.com/claude-code)