### PR TITLE
fix(auth): tell users the keystore prompt wants their phone's screen lock

### DIFF
--- a/android/app/src/main/java/com/rjnr/pocketnode/data/migration/KeystoreV2MigrationRunner.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/migration/KeystoreV2MigrationRunner.kt
@@ -79,7 +79,7 @@ class KeystoreV2MigrationRunner @Inject constructor(
     suspend fun runMigration(
         activity: FragmentActivity,
         promptTitle: String = "Upgrade wallet security",
-        promptSubtitle: String = "Unlock to re-encrypt your wallet keys.",
+        promptSubtitle: String = "Use your phone's screen lock — fingerprint, face, or device PIN — to re-encrypt your wallet keys.",
     ): Outcome {
         // Note: the `helper.isMigrationComplete()` short-circuit was removed in v1.7.2
         // (#289). It caused new V1 rows inserted after the prefs flag was set (e.g.

--- a/android/app/src/main/java/com/rjnr/pocketnode/data/wallet/WalletKeyWriter.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/wallet/WalletKeyWriter.kt
@@ -99,8 +99,12 @@ class WalletKeyWriter @Inject constructor(
         bundle: WalletKeyBundle,
         walletType: String,
         mnemonicBackedUp: Boolean,
+        // Copy must name the credential: users who reached this prompt after a
+        // seed restore did not know WHICH password Android was asking for
+        // (knmo, Nervos Talk, 2026-06). On devices without biometrics the
+        // system sheet goes straight to the screen-lock PIN/pattern/password.
         promptTitle: String = "Secure wallet",
-        promptSubtitle: String = "Unlock to encrypt your wallet keys.",
+        promptSubtitle: String = "Use your phone's screen lock — fingerprint, face, or device PIN — to encrypt this wallet's keys.",
     ): Result {
         val cipher = try {
             encryptionManager.newEncryptCipherV2()

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/onboarding/MnemonicImportScreen.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/onboarding/MnemonicImportScreen.kt
@@ -424,6 +424,17 @@ fun MnemonicImportScreen(
                 Text(stringResource(R.string.mnemonic_import_have_private_key))
             }
 
+            // Heads-up that a SYSTEM credential sheet is about to appear —
+            // users restoring a seed didn't know which password the
+            // "Secure wallet" prompt wanted (knmo, Nervos Talk, 2026-06).
+            Text(
+                text = stringResource(R.string.mnemonic_import_screen_lock_notice),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.align(Alignment.CenterHorizontally)
+            )
+            Spacer(Modifier.height(4.dp))
+
             // Import button
             Button(
                 onClick = { viewModel.importMnemonic(activity) },

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/wallet/AddWalletViewModel.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/wallet/AddWalletViewModel.kt
@@ -168,7 +168,7 @@ class AddWalletViewModel @Inject constructor(
                     walletType = KeyManager.WALLET_TYPE_MNEMONIC,
                     mnemonicBackedUp = false,
                     promptTitle = "Secure new sub-account",
-                    promptSubtitle = "Encrypt the new account's keys.",
+                    promptSubtitle = "Use your phone's screen lock to encrypt the new account's keys.",
                 )
             }
             result.onSuccess { wallet ->

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -474,6 +474,7 @@
     <!-- endregion -->
 
     <!-- region: sync stall banner (#150) -->
+    <string name="mnemonic_import_screen_lock_notice">Next, Android will ask for your screen lock (fingerprint, face, or device PIN) to encrypt your keys on this device.</string>
     <string name="bg_sync_pill_title_off">Balance may be out of date</string>
     <string name="bg_sync_pill_body_off">Background sync is off, so this wallet only updates while the app is open. Turn it on to stay current.</string>
     <string name="bg_sync_pill_title_dead">Background sync was interrupted</string>


### PR DESCRIPTION
## Summary

Nervos Talk feedback (knmo): after updating, the "Secure wallet — Unlock to encrypt your wallet keys" prompt appeared and it took several attempts to realize Android was asking for the device's screen-lock credential — nothing in the copy said which password. On devices without enrolled biometrics, the system sheet goes straight to PIN/pattern/password entry with our subtitle as the only explanation.

- `WalletKeyWriter.persistNewWallet` (create + seed restore), `KeystoreV2MigrationRunner` (the post-update migration prompt), and the sub-account encrypt prompt now all say: "Use your phone's screen lock — fingerprint, face, or device PIN — to …".
- Seed-restore screen gets a one-line heads-up above the Import button — "Next, Android will ask for your screen lock…" — the exact pre-prompt warning the user asked for ("even after restoring a seed phrase").

## Tests
Copy + one new Text composable; full `testDebugUnitTest` green. The import screen sits on the smoke walk — the new Text is above the existing `import-submit` button, which the walk locates by testTag/scroll, so the walk is unaffected (CI smoke will confirm).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated biometric authentication prompts to specify that fingerprint, face recognition, or device PIN will be used to encrypt wallet keys
  * Added lock notice on mnemonic import screen informing users about device encryption requirements

<!-- end of auto-generated comment: release notes by coderabbit.ai -->