### PR TITLE
fix(dao): stack deposit-card action below the date (Withdraw button no longer wraps)

### DIFF
--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/dao/components/DaoDepositCard.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/dao/components/DaoDepositCard.kt
@@ -113,65 +113,70 @@ fun DaoDepositCard(
 
             Spacer(modifier = Modifier.height(10.dp))
 
-            // Bottom row: date + action button
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.SpaceBetween,
-                verticalAlignment = Alignment.CenterVertically
-            ) {
-                // Deposit date with clock icon
-                Row(verticalAlignment = Alignment.CenterVertically) {
-                    Icon(
-                        imageVector = Icons.Outlined.Schedule,
-                        contentDescription = null,
-                        modifier = Modifier.size(14.dp),
-                        tint = MaterialTheme.colorScheme.onSurfaceVariant
-                    )
-                    Spacer(modifier = Modifier.width(4.dp))
-                    Text(
-                        text = formatStatusWithDate(deposit.status, deposit.depositTimestamp),
-                        style = MaterialTheme.typography.bodySmall,
-                        fontSize = 11.sp,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant
-                    )
-                }
+            // Deposit date with clock icon. On its own row — the timestamp is
+            // long ("Deposited 2026-05-23 18:49:27") and previously shared a
+            // SpaceBetween row with the action button, which squeezed
+            // "Withdraw" onto two lines on narrower screens (#304 follow-up).
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Icon(
+                    imageVector = Icons.Outlined.Schedule,
+                    contentDescription = null,
+                    modifier = Modifier.size(14.dp),
+                    tint = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+                Spacer(modifier = Modifier.width(4.dp))
+                Text(
+                    text = formatStatusWithDate(deposit.status, deposit.depositTimestamp),
+                    style = MaterialTheme.typography.bodySmall,
+                    fontSize = 11.sp,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
 
-                // Action button
-                when (deposit.status) {
-                    DaoCellStatus.DEPOSITED -> {
-                        Button(
-                            onClick = onWithdraw,
-                            shape = RoundedCornerShape(8.dp),
-                            colors = ButtonDefaults.buttonColors(
-                                containerColor = DaoGreen,
-                                contentColor = Color.Black
-                            ),
-                            contentPadding = PaddingValues(horizontal = 16.dp, vertical = 6.dp)
-                        ) {
-                            Text(stringResource(R.string.dao_card_withdraw), fontWeight = FontWeight.Medium)
-                        }
+            // Action button (or progress) below the date — full width so the
+            // label can never wrap and the tap target is generous.
+            when (deposit.status) {
+                DaoCellStatus.DEPOSITED -> {
+                    Spacer(modifier = Modifier.height(12.dp))
+                    Button(
+                        onClick = onWithdraw,
+                        modifier = Modifier.fillMaxWidth(),
+                        shape = RoundedCornerShape(8.dp),
+                        colors = ButtonDefaults.buttonColors(
+                            containerColor = DaoGreen,
+                            contentColor = Color.Black
+                        )
+                    ) {
+                        Text(stringResource(R.string.dao_card_withdraw), fontWeight = FontWeight.Medium)
                     }
-                    DaoCellStatus.UNLOCKABLE -> {
-                        Button(
-                            onClick = onUnlock,
-                            shape = RoundedCornerShape(8.dp),
-                            colors = ButtonDefaults.buttonColors(
-                                containerColor = DaoGreen,
-                                contentColor = Color.Black
-                            ),
-                            contentPadding = PaddingValues(horizontal = 16.dp, vertical = 6.dp)
-                        ) {
-                            Text(stringResource(R.string.dao_card_unlock), fontWeight = FontWeight.Medium)
-                        }
+                }
+                DaoCellStatus.UNLOCKABLE -> {
+                    Spacer(modifier = Modifier.height(12.dp))
+                    Button(
+                        onClick = onUnlock,
+                        modifier = Modifier.fillMaxWidth(),
+                        shape = RoundedCornerShape(8.dp),
+                        colors = ButtonDefaults.buttonColors(
+                            containerColor = DaoGreen,
+                            contentColor = Color.Black
+                        )
+                    ) {
+                        Text(stringResource(R.string.dao_card_unlock), fontWeight = FontWeight.Medium)
                     }
-                    DaoCellStatus.DEPOSITING, DaoCellStatus.WITHDRAWING, DaoCellStatus.UNLOCKING -> {
+                }
+                DaoCellStatus.DEPOSITING, DaoCellStatus.WITHDRAWING, DaoCellStatus.UNLOCKING -> {
+                    Spacer(modifier = Modifier.height(12.dp))
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.Center
+                    ) {
                         CircularProgressIndicator(
                             modifier = Modifier.size(24.dp),
                             strokeWidth = 2.dp
                         )
                     }
-                    else -> { /* no action button */ }
                 }
+                else -> { /* no action button */ }
             }
         }
     }


### PR DESCRIPTION
## Summary
User-reported (screenshot): on the active DAO deposit card the "Withdraw" button shared a `SpaceBetween` row with the deposit date. The timestamp ("Deposited 2026-05-23 18:49:27") is wide enough that the button got squeezed and wrapped onto two lines ("With / draw").

- Bottom section is now a Column: date row on its own line, action below it.
- Withdraw / Unlock are full-width buttons (matches the "Deposit" CTA on the overview card) so the label can never wrap and the tap target is larger.
- In-progress states (Depositing/Withdrawing/Unlocking) center their spinner below the date.

Pure layout change, no behavior touched. Compiles clean.

> Note: the withdraw-hangs-then-clears-on-restart complaint in the same report is a **separate** pending-state bug (the "Withdrawing from DAO…" banner is in-memory only and the withdraw confirmation never reconciles `dao_cells`), not addressed here — tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized deposit card layout with dedicated timestamp section and full-width action buttons for withdrawals, unlocking, and loading states, improving visual clarity and accessibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->