### PR TITLE
fix(dao): persistent withdraw state — no more hung banner or double-withdraw (#347)

### DIFF
--- a/android/app/src/main/java/com/rjnr/pocketnode/data/database/AppDatabase.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/database/AppDatabase.kt
@@ -8,11 +8,13 @@ import com.rjnr.pocketnode.data.database.dao.DaoCellDao
 import com.rjnr.pocketnode.data.database.dao.HeaderCacheDao
 import com.rjnr.pocketnode.data.database.dao.KeyMaterialDao
 import com.rjnr.pocketnode.data.database.dao.PendingBroadcastDao
+import com.rjnr.pocketnode.data.database.dao.PendingDaoWithdrawDao
 import com.rjnr.pocketnode.data.database.dao.SyncProgressDao
 import com.rjnr.pocketnode.data.database.dao.TransactionDao
 import com.rjnr.pocketnode.data.database.dao.WalletDao
 import com.rjnr.pocketnode.data.database.entity.BalanceCacheEntity
 import com.rjnr.pocketnode.data.database.entity.ContactEntity
+import com.rjnr.pocketnode.data.database.entity.PendingDaoWithdrawEntity
 import com.rjnr.pocketnode.data.database.entity.DaoCellEntity
 import com.rjnr.pocketnode.data.database.entity.HeaderCacheEntity
 import com.rjnr.pocketnode.data.database.entity.KeyMaterialEntity
@@ -32,6 +34,7 @@ import com.rjnr.pocketnode.data.database.entity.WalletEntity
         SyncProgressEntity::class,
         PendingBroadcastEntity::class,
         ContactEntity::class,
+        PendingDaoWithdrawEntity::class,
     ],
     // Bumped from 8 to 9 in v1.5.2 because TransactionEntity / BalanceCacheEntity
     // / DaoCellEntity gained @Index(idx_tx_pending) + @ColumnInfo(defaultValue)
@@ -50,7 +53,11 @@ import com.rjnr.pocketnode.data.database.entity.WalletEntity
     // the `contacts` table with indices on address and walletId. No
     // existing column changed; MIGRATION_10_11 is a single CREATE TABLE
     // + 2 CREATE INDEX.
-    version = 11,
+    //
+    // Bumped from 11 to 12 for #347: adds the `pending_dao_withdraws` table —
+    // durable marker for an in-flight DAO phase-1 withdraw. MIGRATION_11_12 is
+    // a single CREATE TABLE + 1 CREATE INDEX.
+    version = 12,
     // Schema export deliberately OFF until the Room 2.8.4 / kotlinx-serialization
     // 1.8.0 binary incompatibility is resolved (tracked in #149). Enabling it
     // crashes KSP with AbstractMethodError in Room's bundled
@@ -71,4 +78,5 @@ abstract class AppDatabase : RoomDatabase() {
     abstract fun syncProgressDao(): SyncProgressDao
     abstract fun pendingBroadcastDao(): PendingBroadcastDao
     abstract fun contactDao(): ContactDao
+    abstract fun pendingDaoWithdrawDao(): PendingDaoWithdrawDao
 }

--- a/android/app/src/main/java/com/rjnr/pocketnode/data/database/Migrations.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/database/Migrations.kt
@@ -426,6 +426,25 @@ val MIGRATION_9_10 = object : Migration(9, 10) {
  * so smart-suggestion ranking has stable starting values. Existing
  * rows are unaffected — this is a pure additive migration.
  */
+val MIGRATION_11_12 = object : Migration(11, 12) {
+    override fun migrate(db: SupportSQLiteDatabase) {
+        db.execSQL(
+            """
+            CREATE TABLE IF NOT EXISTS `pending_dao_withdraws` (
+                `depositTxHash` TEXT NOT NULL,
+                `depositIndex` TEXT NOT NULL,
+                `withdrawTxHash` TEXT NOT NULL,
+                `walletId` TEXT NOT NULL,
+                `network` TEXT NOT NULL,
+                `createdAt` INTEGER NOT NULL,
+                PRIMARY KEY(`depositTxHash`, `depositIndex`)
+            )
+            """.trimIndent()
+        )
+        db.execSQL("CREATE INDEX IF NOT EXISTS `idx_pending_withdraw_wallet_network` ON `pending_dao_withdraws` (`walletId`, `network`)")
+    }
+}
+
 val MIGRATION_10_11 = object : Migration(10, 11) {
     override fun migrate(db: SupportSQLiteDatabase) {
         db.execSQL(

--- a/android/app/src/main/java/com/rjnr/pocketnode/data/database/dao/PendingDaoWithdrawDao.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/database/dao/PendingDaoWithdrawDao.kt
@@ -1,0 +1,25 @@
+package com.rjnr.pocketnode.data.database.dao
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import com.rjnr.pocketnode.data.database.entity.PendingDaoWithdrawEntity
+
+@Dao
+interface PendingDaoWithdrawDao {
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun upsert(entity: PendingDaoWithdrawEntity)
+
+    @Query("SELECT * FROM pending_dao_withdraws WHERE walletId = :walletId AND network = :network")
+    suspend fun getByWalletAndNetwork(walletId: String, network: String): List<PendingDaoWithdrawEntity>
+
+    @Query("DELETE FROM pending_dao_withdraws WHERE depositTxHash = :depositTxHash AND depositIndex = :depositIndex")
+    suspend fun deleteByDeposit(depositTxHash: String, depositIndex: String)
+
+    @Query("DELETE FROM pending_dao_withdraws WHERE network = :network")
+    suspend fun deleteByNetwork(network: String)
+
+    @Query("DELETE FROM pending_dao_withdraws")
+    suspend fun deleteAll()
+}

--- a/android/app/src/main/java/com/rjnr/pocketnode/data/database/entity/PendingDaoWithdrawEntity.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/database/entity/PendingDaoWithdrawEntity.kt
@@ -1,0 +1,28 @@
+package com.rjnr.pocketnode.data.database.entity
+
+import androidx.room.Entity
+import androidx.room.Index
+
+/**
+ * In-flight DAO phase-1 withdraw, keyed by the DEPOSIT cell's outpoint (#347).
+ *
+ * The light client only sees committed chain state, so while a withdraw tx is
+ * in the mempool the deposit cell still scans as DEPOSITED + withdrawable —
+ * the banner ("Withdrawing from DAO…") was in-memory only and the deposit
+ * could be withdrawn twice. This row is the durable marker: it overlays the
+ * deposit's status to WITHDRAWING until the tx commits (deposit cell consumed)
+ * or fails (reverts to DEPOSITED). Persisted, so it survives process death.
+ */
+@Entity(
+    tableName = "pending_dao_withdraws",
+    primaryKeys = ["depositTxHash", "depositIndex"],
+    indices = [Index(value = ["walletId", "network"], name = "idx_pending_withdraw_wallet_network")]
+)
+data class PendingDaoWithdrawEntity(
+    val depositTxHash: String,
+    val depositIndex: String,
+    val withdrawTxHash: String,
+    val walletId: String,
+    val network: String,
+    val createdAt: Long,
+)

--- a/android/app/src/main/java/com/rjnr/pocketnode/data/gateway/DaoSyncManager.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/gateway/DaoSyncManager.kt
@@ -2,6 +2,7 @@ package com.rjnr.pocketnode.data.gateway
 
 import android.util.Log
 import com.rjnr.pocketnode.data.database.dao.DaoCellDao
+import com.rjnr.pocketnode.data.database.dao.PendingDaoWithdrawDao
 import com.rjnr.pocketnode.data.database.dao.HeaderCacheDao
 import com.rjnr.pocketnode.data.database.entity.DaoCellEntity
 import com.rjnr.pocketnode.data.database.entity.HeaderCacheEntity
@@ -13,7 +14,8 @@ import javax.inject.Singleton
 @Singleton
 class DaoSyncManager @Inject constructor(
     private val headerCacheDao: HeaderCacheDao,
-    private val daoCellDao: DaoCellDao
+    private val daoCellDao: DaoCellDao,
+    private val pendingDaoWithdrawDao: PendingDaoWithdrawDao,
 ) {
     // --- Header cache (permanent — block headers are immutable) ---
 
@@ -142,6 +144,7 @@ class DaoSyncManager @Inject constructor(
         try {
             headerCacheDao.deleteByNetwork(network)
             daoCellDao.deleteByNetwork(network)
+            pendingDaoWithdrawDao.deleteByNetwork(network)
             Log.d(TAG, "DAO caches cleared for $network")
         } catch (e: CancellationException) {
             throw e
@@ -154,6 +157,7 @@ class DaoSyncManager @Inject constructor(
         try {
             headerCacheDao.deleteAll()
             daoCellDao.deleteAll()
+            pendingDaoWithdrawDao.deleteAll()
             Log.d(TAG, "All DAO caches cleared")
         } catch (e: CancellationException) {
             throw e

--- a/android/app/src/main/java/com/rjnr/pocketnode/data/gateway/GatewayRepository.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/gateway/GatewayRepository.kt
@@ -1752,7 +1752,66 @@ class GatewayRepository @Inject constructor(
         val info = _walletInfo.value ?: throw Exception("No wallet")
         val currentEpoch = getCurrentEpoch().getOrNull()
         val live = daoDepositReader.list(info.script, currentEpoch, currentNetwork)
-        mergeWithCachedDaoDeposits(live)
+        applyPendingWithdrawOverlay(mergeWithCachedDaoDeposits(live))
+    }
+
+    /**
+     * #347: overlay in-flight phase-1 withdraws onto the deposit list. The
+     * deposit cell scans as DEPOSITED until the withdraw commits and is
+     * indexed, so without this a just-withdrawn deposit looks withdrawable
+     * again (double-withdraw) and the only "withdrawing" signal — the
+     * in-memory banner — is lost on restart. The persisted marker carries the
+     * state across process death; [resolvePendingWithdraw] decides per marker
+     * whether to overlay WITHDRAWING, or retire it (committed / failed).
+     */
+    private suspend fun applyPendingWithdrawOverlay(deposits: List<DaoDeposit>): List<DaoDeposit> {
+        val walletId = activeWalletId
+        if (walletId.isEmpty()) return deposits
+        val network = currentNetwork.name
+        val withdrawDao = appDatabase.pendingDaoWithdrawDao()
+        val pending = runCatching { withdrawDao.getByWalletAndNetwork(walletId, network) }
+            .getOrDefault(emptyList())
+        if (pending.isEmpty()) return deposits
+
+        fun key(txHash: String, index: String) = "$txHash:$index"
+        val depositedKeys = deposits
+            .filter { it.status == DaoCellStatus.DEPOSITED }
+            .map { key(it.outPoint.txHash, it.outPoint.index) }
+            .toSet()
+
+        val overlayKeys = mutableSetOf<String>()
+        for (p in pending) {
+            val k = key(p.depositTxHash, p.depositIndex)
+            val stillDeposited = k in depositedKeys
+            val txStatus = runCatching {
+                appDatabase.transactionDao().getByTxHash(p.withdrawTxHash)?.status
+            }.getOrNull()
+            when (resolvePendingWithdraw(stillDeposited, txStatus)) {
+                PendingWithdrawResolution.OVERLAY -> if (stillDeposited) overlayKeys.add(k)
+                PendingWithdrawResolution.CLEAR_CONFIRMED,
+                PendingWithdrawResolution.CLEAR_FAILED ->
+                    runCatching { withdrawDao.deleteByDeposit(p.depositTxHash, p.depositIndex) }
+            }
+        }
+        if (overlayKeys.isEmpty()) return deposits
+        return deposits.map {
+            if (key(it.outPoint.txHash, it.outPoint.index) in overlayKeys) {
+                it.copy(status = DaoCellStatus.WITHDRAWING)
+            } else it
+        }
+    }
+
+    /**
+     * Deposit outpoints with an in-flight withdraw (#347) — used by the DAO
+     * screen to rehydrate the "Withdrawing from DAO…" banner after restart.
+     */
+    suspend fun getInFlightWithdrawOutPoints(): List<OutPoint> {
+        val walletId = activeWalletId.takeIf { it.isNotEmpty() } ?: return emptyList()
+        return runCatching {
+            appDatabase.pendingDaoWithdrawDao()
+                .getByWalletAndNetwork(walletId, currentNetwork.name)
+                .map { OutPoint(it.depositTxHash, it.depositIndex) }
+        }.getOrDefault(emptyList())
     }
 
     /**
@@ -1961,6 +2020,23 @@ class GatewayRepository @Inject constructor(
             )
         }
         Log.d(TAG, "DAO withdraw (phase 1) sent: $txHash")
+
+        // #347: persist the in-flight withdraw so the deposit renders as
+        // WITHDRAWING ("Confirming…") across restart and can't be withdrawn
+        // twice. Cleared by applyPendingWithdrawOverlay on commit/failure.
+        runCatching {
+            appDatabase.pendingDaoWithdrawDao().upsert(
+                com.rjnr.pocketnode.data.database.entity.PendingDaoWithdrawEntity(
+                    depositTxHash = depositOutPoint.txHash,
+                    depositIndex = depositOutPoint.index,
+                    withdrawTxHash = txHash,
+                    walletId = activeWalletId,
+                    network = currentNetwork.name,
+                    createdAt = System.currentTimeMillis(),
+                )
+            )
+        }.onFailure { Log.w(TAG, "Failed to persist pending withdraw marker: ${it.message}") }
+
         txHash
     }
 

--- a/android/app/src/main/java/com/rjnr/pocketnode/data/gateway/PendingWithdrawResolution.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/gateway/PendingWithdrawResolution.kt
@@ -1,0 +1,34 @@
+package com.rjnr.pocketnode.data.gateway
+
+/** Outcome of reconciling a persisted in-flight DAO withdraw marker (#347). */
+enum class PendingWithdrawResolution {
+    /** Keep the marker; overlay the deposit's status as WITHDRAWING ("Confirming…"). */
+    OVERLAY,
+
+    /** Withdraw committed (deposit cell consumed) — retire the marker. */
+    CLEAR_CONFIRMED,
+
+    /** Withdraw failed — retire the marker so the deposit is withdrawable again. */
+    CLEAR_FAILED,
+}
+
+/**
+ * Decide a pending withdraw marker's fate from two facts:
+ *  - [depositStillDeposited]: is the deposit cell still DEPOSITED in the live
+ *    light-client scan? (false = consumed by a committed withdraw.)
+ *  - [withdrawTxStatus]: the withdraw tx's status in the local cache
+ *    ("PENDING"/"CONFIRMED"/"FAILED"/null), maintained by BroadcastWatchdog.
+ *
+ * The deposit disappearing is the authoritative success signal — it only
+ * happens once the spend is on-chain and indexed. A FAILED tx while the
+ * deposit is still present is the authoritative failure signal. Everything
+ * else means the withdraw is still in flight.
+ */
+fun resolvePendingWithdraw(
+    depositStillDeposited: Boolean,
+    withdrawTxStatus: String?,
+): PendingWithdrawResolution = when {
+    !depositStillDeposited -> PendingWithdrawResolution.CLEAR_CONFIRMED
+    withdrawTxStatus == "FAILED" -> PendingWithdrawResolution.CLEAR_FAILED
+    else -> PendingWithdrawResolution.OVERLAY
+}

--- a/android/app/src/main/java/com/rjnr/pocketnode/di/AppModule.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/di/AppModule.kt
@@ -18,6 +18,7 @@ import com.rjnr.pocketnode.data.database.MIGRATION_7_8
 import com.rjnr.pocketnode.data.database.MIGRATION_8_9
 import com.rjnr.pocketnode.data.database.MIGRATION_9_10
 import com.rjnr.pocketnode.data.database.MIGRATION_10_11
+import com.rjnr.pocketnode.data.database.MIGRATION_11_12
 import com.rjnr.pocketnode.data.database.dao.BalanceCacheDao
 import com.rjnr.pocketnode.data.database.dao.ContactDao
 import com.rjnr.pocketnode.data.database.dao.DaoCellDao
@@ -129,7 +130,7 @@ object AppModule {
     fun provideAppDatabase(@ApplicationContext context: Context): AppDatabase =
         Room.databaseBuilder(context, AppDatabase::class.java, "pocket_node.db")
             .setJournalMode(RoomDatabase.JournalMode.WRITE_AHEAD_LOGGING)
-            .addMigrations(MIGRATION_1_2, MIGRATION_2_3, MIGRATION_3_4, MIGRATION_4_5, MIGRATION_5_6, MIGRATION_6_7, MIGRATION_7_8, MIGRATION_8_9, MIGRATION_9_10, MIGRATION_10_11)
+            .addMigrations(MIGRATION_1_2, MIGRATION_2_3, MIGRATION_3_4, MIGRATION_4_5, MIGRATION_5_6, MIGRATION_6_7, MIGRATION_7_8, MIGRATION_8_9, MIGRATION_9_10, MIGRATION_10_11, MIGRATION_11_12)
             .build()
 
     @Provides
@@ -143,6 +144,11 @@ object AppModule {
 
     @Provides
     fun provideDaoCellDao(db: AppDatabase): DaoCellDao = db.daoCellDao()
+
+    @Provides
+    @Singleton
+    fun providePendingDaoWithdrawDao(db: AppDatabase): com.rjnr.pocketnode.data.database.dao.PendingDaoWithdrawDao =
+        db.pendingDaoWithdrawDao()
 
     @Provides
     fun provideWalletDao(db: AppDatabase): WalletDao = db.walletDao()
@@ -206,8 +212,9 @@ object AppModule {
     @Singleton
     fun provideDaoSyncManager(
         headerCacheDao: HeaderCacheDao,
-        daoCellDao: DaoCellDao
-    ): DaoSyncManager = DaoSyncManager(headerCacheDao, daoCellDao)
+        daoCellDao: DaoCellDao,
+        pendingDaoWithdrawDao: com.rjnr.pocketnode.data.database.dao.PendingDaoWithdrawDao,
+    ): DaoSyncManager = DaoSyncManager(headerCacheDao, daoCellDao, pendingDaoWithdrawDao)
 
     @Provides
     @Singleton

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/dao/DaoViewModel.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/dao/DaoViewModel.kt
@@ -43,6 +43,16 @@ class DaoViewModel @Inject constructor(
     private var pendingDepositAmount: Long = 0L
 
     init {
+        // #347: rehydrate the "Withdrawing from DAO…" banner from the persisted
+        // marker so it survives process death (it was previously in-memory
+        // only). The per-deposit card overlay shows independently via the
+        // repository overlay; this also restores the faster 10s poll cadence.
+        viewModelScope.launch {
+            repository.getInFlightWithdrawOutPoints().firstOrNull()?.let { outPoint ->
+                _uiState.update { it.copy(pendingAction = DaoAction.Withdrawing(outPoint)) }
+            }
+        }
+
         startPolling()
 
         // Refresh DAO deposits when active wallet changes

--- a/android/app/src/test/java/com/rjnr/pocketnode/data/database/WalkingMigrationTest.kt
+++ b/android/app/src/test/java/com/rjnr/pocketnode/data/database/WalkingMigrationTest.kt
@@ -106,6 +106,24 @@ class WalkingMigrationTest {
     }
 
     /**
+     * #347: a v10 file walked all the way to v12 must gain the
+     * `pending_dao_withdraws` table + its index (MIGRATION_11_12), with
+     * schema validation passing.
+     */
+    @Test
+    fun `walk to v12 creates pending_dao_withdraws table`() {
+        bootstrapV10()
+        openViaRoomAndValidate()
+        val db = openedRoomDb!!.openHelper.readableDatabase
+        db.query("SELECT name FROM sqlite_master WHERE type='table' AND name='pending_dao_withdraws'").use { c ->
+            assertTrue("pending_dao_withdraws table missing after MIGRATION_11_12", c.moveToNext())
+        }
+        db.query("SELECT name FROM sqlite_master WHERE type='index' AND name='idx_pending_withdraw_wallet_network'").use { c ->
+            assertTrue("idx_pending_withdraw_wallet_network missing", c.moveToNext())
+        }
+    }
+
+    /**
      * v1.6.x → v1.7.0 path: bootstrap a v9 SQLite file (no `kdfVersion`
      * column on `key_material`) and confirm MIGRATION_9_10 adds the
      * column with default 1, then Room schema validation passes.
@@ -150,7 +168,7 @@ class WalkingMigrationTest {
                 .addMigrations(
                     MIGRATION_1_2, MIGRATION_2_3, MIGRATION_3_4, MIGRATION_4_5,
                     MIGRATION_5_6, MIGRATION_6_7, MIGRATION_7_8, noOpMigration8To9,
-                    MIGRATION_9_10, MIGRATION_10_11,
+                    MIGRATION_9_10, MIGRATION_10_11, MIGRATION_11_12,
                 )
                 .build()
             openedRoomDb = db
@@ -180,7 +198,7 @@ class WalkingMigrationTest {
             .addMigrations(
                 MIGRATION_1_2, MIGRATION_2_3, MIGRATION_3_4, MIGRATION_4_5,
                 MIGRATION_5_6, MIGRATION_6_7, MIGRATION_7_8, MIGRATION_8_9,
-                MIGRATION_9_10, MIGRATION_10_11,
+                MIGRATION_9_10, MIGRATION_10_11, MIGRATION_11_12,
             )
             .build()
         openedRoomDb = db

--- a/android/app/src/test/java/com/rjnr/pocketnode/data/gateway/DaoSyncManagerTest.kt
+++ b/android/app/src/test/java/com/rjnr/pocketnode/data/gateway/DaoSyncManagerTest.kt
@@ -27,7 +27,7 @@ class DaoSyncManagerTest {
         db = Room.inMemoryDatabaseBuilder(context, AppDatabase::class.java)
             .allowMainThreadQueries()
             .build()
-        manager = DaoSyncManager(db.headerCacheDao(), db.daoCellDao())
+        manager = DaoSyncManager(db.headerCacheDao(), db.daoCellDao(), db.pendingDaoWithdrawDao())
     }
 
     @After

--- a/android/app/src/test/java/com/rjnr/pocketnode/data/gateway/PendingWithdrawResolutionTest.kt
+++ b/android/app/src/test/java/com/rjnr/pocketnode/data/gateway/PendingWithdrawResolutionTest.kt
@@ -1,0 +1,65 @@
+package com.rjnr.pocketnode.data.gateway
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * #347: decides what to do with a persisted in-flight DAO withdraw marker on
+ * each DAO refresh, from two observable facts — whether the deposit cell is
+ * still DEPOSITED in the live light-client scan, and the withdraw tx's status
+ * in the local transactions cache (maintained by BroadcastWatchdog).
+ */
+class PendingWithdrawResolutionTest {
+
+    @Test
+    fun `deposit gone from scan means withdraw committed - clear`() {
+        // Deposit cell consumed by the committed withdraw → a new LOCKED
+        // withdrawing cell appears separately; retire the marker.
+        assertEquals(
+            PendingWithdrawResolution.CLEAR_CONFIRMED,
+            resolvePendingWithdraw(depositStillDeposited = false, withdrawTxStatus = "PENDING"),
+        )
+    }
+
+    @Test
+    fun `deposit gone wins even if tx still shows pending`() {
+        assertEquals(
+            PendingWithdrawResolution.CLEAR_CONFIRMED,
+            resolvePendingWithdraw(depositStillDeposited = false, withdrawTxStatus = null),
+        )
+    }
+
+    @Test
+    fun `deposit present and tx failed - clear so user can retry`() {
+        assertEquals(
+            PendingWithdrawResolution.CLEAR_FAILED,
+            resolvePendingWithdraw(depositStillDeposited = true, withdrawTxStatus = "FAILED"),
+        )
+    }
+
+    @Test
+    fun `deposit present and tx pending - keep overlay`() {
+        assertEquals(
+            PendingWithdrawResolution.OVERLAY,
+            resolvePendingWithdraw(depositStillDeposited = true, withdrawTxStatus = "PENDING"),
+        )
+    }
+
+    @Test
+    fun `deposit present and tx confirmed but not yet indexed - keep overlay`() {
+        // Tx committed on-chain but the light client hasn't scanned the spend
+        // yet; keep showing "Confirming" until the cell actually disappears.
+        assertEquals(
+            PendingWithdrawResolution.OVERLAY,
+            resolvePendingWithdraw(depositStillDeposited = true, withdrawTxStatus = "CONFIRMED"),
+        )
+    }
+
+    @Test
+    fun `deposit present and tx status unknown - keep overlay`() {
+        assertEquals(
+            PendingWithdrawResolution.OVERLAY,
+            resolvePendingWithdraw(depositStillDeposited = true, withdrawTxStatus = null),
+        )
+    }
+}


### PR DESCRIPTION
## Summary
Fixes the user report: tap Withdraw → "Withdrawing from DAO…" hangs → close/reopen → banner gone, deposit withdrawable again. Root cause (traced, see #347): the withdraw tx broadcasts fine, but the pending state was **in-memory only** and the confirmation **never reconciled `dao_cells`**, so the deposit kept scanning as DEPOSITED + withdrawable (double-withdraw foot-gun) and the banner evaporated on restart. Separate from #315/#332.

## Fix (full version)
- **Durable marker**: new `pending_dao_withdraws` table (migration v11→v12, single CREATE TABLE + index). `withdrawFromDao` writes a row keyed by the deposit outpoint after broadcast.
- **Status overlay**: `getDaoDeposits` overlays the deposit as `WITHDRAWING` ("Confirming…", non-withdrawable) while a marker is live — survives process death, blocks a second withdraw.
- **Reconciliation** (`resolvePendingWithdraw`, pure + TDD): deposit gone from the live DEPOSITED scan → committed, retire marker (a new LOCKED withdrawing cell appears naturally); deposit still present + withdraw tx `FAILED` in the local cache (maintained by `BroadcastWatchdog`) → retire marker, deposit becomes withdrawable again; otherwise keep the overlay. No change to the watchdog itself — DAO reconciliation reads the tx status it already maintains.
- **Banner rehydration**: `DaoViewModel.init` restores the "Withdrawing from DAO…" banner (and faster 10s poll) from the persisted marker after restart.
- **Cleanup**: markers cleared on network switch / wallet reset via `DaoSyncManager`.

## Tests
- `PendingWithdrawResolutionTest` (6) — reconcile decision, RED-verified first.
- `WalkingMigrationTest` — new `walk to v12 creates pending_dao_withdraws table` + both addMigrations lists updated; v9→v10→v11→v12 walk validates schema.
- `DaoSyncManagerTest` ctor updated for the injected DAO.
- Full `testDebugUnitTest` green.

## Verification status
- Migration-on-upgrade (the crash-risk path) is exercised by CI upgrade-smoke: it installs the prev (v11) build, upgrades to this build, and asserts Home renders — so MIGRATION_11_12 runs on a real device.
- The full withdraw→restart→Confirming→commit loop needs a DAO deposit on an 8114-open network (devnet DAO send is blocked by the hardcoded testnet dep_group, per the #342 notes). Flagged for the next live session; logic is unit-covered.

Closes #347

🤖 Generated with [Claude Code](https://claude.com/claude-code)