### PR TITLE
fix(send): pending row showed the change output as the amount sent

### DIFF
--- a/android/app/src/main/java/com/rjnr/pocketnode/data/gateway/GatewayRepository.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/gateway/GatewayRepository.kt
@@ -1198,11 +1198,30 @@ class GatewayRepository @Inject constructor(
 
             // Outgoing amount for activity-row balanceChange. Stored as POSITIVE
             // hex per existing convention; `direction = "out"` carries the sign
-            // for the UI. (Prior code used "-0x..." which broke capacityAsLong's
-            // hex parser and rendered as 0.)
-            val outgoingAmount = signed.cellOutputs
-                .mapNotNull { it.capacity.removePrefix("0x").toLongOrNull(16) }.minOrNull()
-                ?: 0L
+            // for the UI.
+            //
+            // Net debit = Σ(our input capacities) − Σ(our plain-change outputs),
+            // matching the confirmed-row formula. The old code used
+            // min(all outputs), which returned the CHANGE output whenever
+            // change < amount sent — a 150,000 CKB send displayed as
+            // "-17,950.29" until the light client synced and corrected it
+            // (Alex, Telegram). A typed self-output (DAO deposit cell) is
+            // capacity leaving spendable, so it is not counted as change.
+            val inputCapacities = signed.cellInputs.mapNotNull { input ->
+                filtered.find { it.outPoint == input.previousOutput }
+                    ?.capacity?.removePrefix("0x")?.toLongOrNull(16)
+            }
+            val outgoingOutputs = signed.cellOutputs.map { output ->
+                val isOurs = runCatching {
+                    AddressUtils.encode(output.lock, senderNetwork)
+                }.getOrNull() == fromAddress
+                OutgoingOutput(
+                    capacityShannons = output.capacity.removePrefix("0x").toLongOrNull(16) ?: 0L,
+                    isOurs = isOurs,
+                    isTyped = output.type != null,
+                )
+            }
+            val outgoingAmount = computeOutgoingShannons(inputCapacities, outgoingOutputs)
             val balanceChangeHex = "0x${outgoingAmount.toString(16)}"
 
             pendingBroadcastDao.insert(

--- a/android/app/src/main/java/com/rjnr/pocketnode/data/gateway/OutgoingAmount.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/gateway/OutgoingAmount.kt
@@ -1,0 +1,30 @@
+package com.rjnr.pocketnode.data.gateway
+
+/** One output of an outgoing tx, classified for the net-debit computation. */
+data class OutgoingOutput(
+    val capacityShannons: Long,
+    /** Locked to the sender's own address. */
+    val isOurs: Boolean,
+    /** Carries a type script (e.g. a Nervos DAO cell) — not plain change. */
+    val isTyped: Boolean,
+)
+
+/**
+ * Net capacity leaving the wallet for an outgoing tx's pending activity row.
+ *
+ * Mirrors the confirmed-row formula (Σ our inputs − Σ our outputs): the only
+ * outputs that come back to spendable balance are our own PLAIN-change
+ * outputs, so those are the only ones subtracted. A typed self-output (a DAO
+ * deposit cell) is capacity leaving spendable, so it is NOT treated as change.
+ *
+ * The previous code stored min(all outputs), which returned the change output
+ * whenever change < amount sent — the "-17,950.29 for a 150,000 send" bug.
+ */
+fun computeOutgoingShannons(
+    inputCapacities: List<Long>,
+    outputs: List<OutgoingOutput>,
+): Long {
+    val inputs = inputCapacities.sum()
+    val change = outputs.filter { it.isOurs && !it.isTyped }.sumOf { it.capacityShannons }
+    return (inputs - change).coerceAtLeast(0L)
+}

--- a/android/app/src/test/java/com/rjnr/pocketnode/data/gateway/OutgoingAmountTest.kt
+++ b/android/app/src/test/java/com/rjnr/pocketnode/data/gateway/OutgoingAmountTest.kt
@@ -1,0 +1,71 @@
+package com.rjnr.pocketnode.data.gateway
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * The pending activity row used to store min(all output capacities) as the
+ * outgoing amount. When change < amount sent, the smallest output IS the
+ * change, so a 150,000 CKB send showed "-17,950.29" until sync corrected it
+ * (Alex, Telegram, 2026-06). The fix mirrors the confirmed-row formula:
+ * net debit = Σ(our input capacities) − Σ(our spendable change outputs).
+ */
+class OutgoingAmountTest {
+
+    private val ckb = 100_000_000L
+
+    @Test
+    fun `transfer with change shows amount sent plus fee, not the change`() {
+        // inputs 167,950.29; recipient 150,000 (not ours); change 17,950.29 (ours)
+        val out = computeOutgoingShannons(
+            inputCapacities = listOf(167_950_29000000L),
+            outputs = listOf(
+                OutgoingOutput(150_000 * ckb, isOurs = false, isTyped = false),
+                OutgoingOutput(17_950_29000000L, isOurs = true, isTyped = false),
+            ),
+        )
+        // 167,950.29 - 17,950.29 = 150,000.00
+        assertEquals(150_000 * ckb, out)
+    }
+
+    @Test
+    fun `send-all with no change equals the inputs`() {
+        val out = computeOutgoingShannons(
+            inputCapacities = listOf(150_000 * ckb),
+            outputs = listOf(OutgoingOutput(150_000 * ckb, isOurs = false, isTyped = false)),
+        )
+        assertEquals(150_000 * ckb, out)
+    }
+
+    @Test
+    fun `self-send consolidation nets to zero`() {
+        val out = computeOutgoingShannons(
+            inputCapacities = listOf(100 * ckb),
+            outputs = listOf(OutgoingOutput(100 * ckb, isOurs = true, isTyped = false)),
+        )
+        assertEquals(0L, out)
+    }
+
+    @Test
+    fun `dao deposit counts the typed self-output as leaving spendable`() {
+        // fee inputs 10,300; DAO cell 10,200 (ours, typed) + change 99 (ours)
+        val out = computeOutgoingShannons(
+            inputCapacities = listOf(10_300 * ckb),
+            outputs = listOf(
+                OutgoingOutput(10_200 * ckb, isOurs = true, isTyped = true),
+                OutgoingOutput(99 * ckb, isOurs = true, isTyped = false),
+            ),
+        )
+        // only the plain change (99) is subtracted → 10,201 (deposit + fee)
+        assertEquals(10_201 * ckb, out)
+    }
+
+    @Test
+    fun `never negative`() {
+        val out = computeOutgoingShannons(
+            inputCapacities = listOf(10 * ckb),
+            outputs = listOf(OutgoingOutput(50 * ckb, isOurs = true, isTyped = false)),
+        )
+        assertEquals(0L, out)
+    }
+}


### PR DESCRIPTION
## Report (Alex, Telegram)
Send 150,000 CKB, background the app. While the send is **Pending**, the activity row shows a "crazy number" in red — e.g. **-17,950.29** — then after the light client syncs it corrects to **-150,000**. Screenshots confirmed: 17,950.29 is the wallet's own **change** output.

## Root cause
The pending activity row stored `min(all output capacities)` as the outgoing amount. For a 150,000 send leaving ~17,950 change, the change output is the smallest, so `minOrNull()` picked it. The confirmed row, built from the light client's `getTransactions`, uses a different (correct) net-debit formula, so the number changed on sync. (`GatewayRepository.buildReserveAndSend`, the old `signed.cellOutputs...minOrNull()`.)

## Fix
Pending insert now computes the same net debit as the confirmed row: **Σ(our input capacities) − Σ(our plain-change outputs)**. Inputs are resolved by matching `signed.cellInputs` against the selected `filtered` cells; an output is "ours" when its lock re-encodes to `fromAddress` (the existing change-detection predicate), and a typed self-output (DAO deposit cell) is treated as leaving spendable, not as change. Extracted as the pure `computeOutgoingShannons(...)` for testability.

For a 150,000 send with 17,950.29 change → 150,000.00, matching the synced value, so the number no longer jumps.

## Tests
`OutgoingAmountTest` (5, RED-verified first): transfer-with-change (Alex's exact numbers), send-all, self-send → 0, DAO deposit (typed output counted), never-negative. Full `testDebugUnitTest` green.

## Notes
- Plain sends are fully covered: they insert via `buildReserveAndSend`, and `sendTransaction`'s own insert is skipped by the existing idempotency guard. `sendTransaction` retains the old min-output expression on the DAO-unlock/direct path (it lacks sender context); unlock rows are reclassified `dao_unlock` on confirm. Worth a follow-up but not the reported path.
- Should land before the v1.7.4 signed build is cut so it ships in this release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)