### PR TITLE
fix(send): sibling sendTransaction path also showed change as amount (follow-up to #350)

### DIFF
--- a/android/app/src/main/java/com/rjnr/pocketnode/data/gateway/GatewayRepository.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/gateway/GatewayRepository.kt
@@ -1337,14 +1337,25 @@ class GatewayRepository @Inject constructor(
             transaction.cellInputs.map { it.previousOutput }
         )
 
-        // Compute balanceChange = -(smallest output) for the activity row.
-        // For a normal transfer the smallest output is the recipient; for a
-        // "send all" there's only one output. Either way: smallest by capacity.
-        val outgoingAmount = transaction.cellOutputs
-            .mapNotNull { it.capacity.removePrefix("0x").toLongOrNull(16) }.minOrNull()
-            ?: 0L
+        // Outgoing amount for the activity row. This path (DAO unlock,
+        // failed-send retry) has no input capacities, so it sums the outputs
+        // NOT locked to us — the recipient amount. The old code used
+        // min(all outputs), which returned the CHANGE output whenever
+        // change < amount sent (same bug as buildReserveAndSend; see #350).
+        // Transfers via buildReserveAndSend insert their own (more precise)
+        // net-debit row first and skip the insert below, so this only drives
+        // standalone sends. A self-only tx (DAO unlock) sums to 0 and is
+        // reclassified by the synced row.
+        val ourLock = _walletInfo.value?.script
+        val outgoingOutputs = transaction.cellOutputs.map { output ->
+            OutgoingOutput(
+                capacityShannons = output.capacity.removePrefix("0x").toLongOrNull(16) ?: 0L,
+                isOurs = ourLock != null && output.lock == ourLock,
+                isTyped = output.type != null,
+            )
+        }
         // Positive hex per existing convention; `direction = "out"` carries sign.
-        val balanceChangeHex = "0x${outgoingAmount.toString(16)}"
+        val balanceChangeHex = "0x${recipientOutgoingShannons(outgoingOutputs).toString(16)}"
         val now = System.currentTimeMillis()
 
         Log.d(TAG, "📤 sendTransaction: JSON length=${txJson.length}, preHash=$txHash")

--- a/android/app/src/main/java/com/rjnr/pocketnode/data/gateway/OutgoingAmount.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/gateway/OutgoingAmount.kt
@@ -28,3 +28,14 @@ fun computeOutgoingShannons(
     val change = outputs.filter { it.isOurs && !it.isTyped }.sumOf { it.capacityShannons }
     return (inputs - change).coerceAtLeast(0L)
 }
+
+/**
+ * Output-only outgoing amount: the sum of outputs NOT locked to us (the
+ * recipient amount). Used where input capacities are not available —
+ * `sendTransaction`'s standalone insert (DAO unlock, failed-send retry).
+ * Excludes the fee (which lives in the inputs), so it can read marginally
+ * lower than [computeOutgoingShannons], but it never reports the change
+ * output as the amount sent — the bug this replaces.
+ */
+fun recipientOutgoingShannons(outputs: List<OutgoingOutput>): Long =
+    outputs.filter { !it.isOurs }.sumOf { it.capacityShannons }

--- a/android/app/src/test/java/com/rjnr/pocketnode/data/gateway/OutgoingAmountTest.kt
+++ b/android/app/src/test/java/com/rjnr/pocketnode/data/gateway/OutgoingAmountTest.kt
@@ -60,6 +60,31 @@ class OutgoingAmountTest {
         assertEquals(10_201 * ckb, out)
     }
 
+    // recipientOutgoingShannons: the output-only fallback for sendTransaction,
+    // which has no access to input capacities (DAO unlock, failed-send retry).
+    // Sums outputs NOT locked to us — the recipient amount.
+
+    @Test
+    fun `recipient-only sums non-ours outputs, ignoring change`() {
+        val out = recipientOutgoingShannons(
+            listOf(
+                OutgoingOutput(150_000 * ckb, isOurs = false, isTyped = false),
+                OutgoingOutput(17_950_29000000L, isOurs = true, isTyped = false),
+            ),
+        )
+        assertEquals(150_000 * ckb, out)
+    }
+
+    @Test
+    fun `recipient-only is zero when every output returns to us`() {
+        // DAO unlock returns funds to self; no recipient leg. Shows 0 briefly,
+        // then the synced row reclassifies it as dao_unlock (incoming).
+        val out = recipientOutgoingShannons(
+            listOf(OutgoingOutput(10_500 * ckb, isOurs = true, isTyped = false)),
+        )
+        assertEquals(0L, out)
+    }
+
     @Test
     fun `never negative`() {
         val out = computeOutgoingShannons(


### PR DESCRIPTION
## Summary
Follow-up to #350. The same `min(all outputs)` bug lived in `sendTransaction`, which #350's `buildReserveAndSend` fix did not cover. `sendTransaction`'s own pending insert fires on two standalone paths:

- **Failed-send retry** (`retryBroadcast`) — re-sends a transfer; previously re-displayed the change output as the amount, exactly Alex's bug on the retry path.
- **DAO unlock** — inserted a generic "out" row.

`sendTransaction` has no input capacities (so it can't do the full net-debit `buildReserveAndSend` does), but it can sum the outputs NOT locked to the active wallet — the recipient amount. New pure helper `recipientOutgoingShannons(...)`:
- Transfer retry → recipient amount (e.g. 150,000), not the change.
- DAO unlock (all outputs return to self) → 0, then the synced row reclassifies it as `dao_unlock` (incoming). Better than the previous min-output guess.

Plain first-time sends are unaffected (they insert via `buildReserveAndSend` and skip this path via the idempotency guard) — this only corrects the standalone inserts.

## Tests
`OutgoingAmountTest` extended (now 7): recipient-only sums non-ours outputs / is zero when all outputs return to self. Full `testDebugUnitTest` green.

Refs #350. Lands before the v1.7.4 signed build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected transaction balance calculations for outgoing sends to properly distinguish recipient outputs from change outputs, ensuring accurate activity history and transaction retry amounts.

* **Tests**
  * Added unit tests for transaction amount calculation logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->