### PR TITLE
fix(sync): stop per-launch rescan loop + false stall banner on rewind (knmo)

### DIFF
--- a/android/app/src/main/java/com/rjnr/pocketnode/data/gateway/GatewayRepository.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/gateway/GatewayRepository.kt
@@ -777,6 +777,10 @@ class GatewayRepository @Inject constructor(
         _isRegistered.value = false
         // Clear saved sync progress when explicitly resyncing (per-wallet)
         setWalletSyncBlock(activeWalletId, 0L)
+        // Re-arm the zero-cell rescue rescan: an explicit resync is the user
+        // deliberately asking us to look again (knmo).
+        walletPreferences.clearZeroCellRescanDone(activeWalletId)
+        balanceRescanAttempted.remove(activeWalletId)
         return registerAccount(syncMode, customBlockHeight, savePreference = true, forceResync = true)
     }
 
@@ -896,11 +900,16 @@ class GatewayRepository @Inject constructor(
                             spendableCapacity = liveCapacity,
                             typedCellCount = typedCellCount,
                             hasTransactions = txPag.objects.isNotEmpty(),
-                            alreadyAttempted = activeWalletId in balanceRescanAttempted,
+                            // Persisted across launches (knmo): without this the
+                            // in-memory set re-armed every cold start and a
+                            // permanently-empty primary rewound on every launch.
+                            alreadyAttempted = activeWalletId in balanceRescanAttempted ||
+                                walletPreferences.isZeroCellRescanDone(activeWalletId),
                             isSyncing = _syncProgress.value.isSyncing,
                         )
                     ) {
                         balanceRescanAttempted.add(activeWalletId)
+                        walletPreferences.setZeroCellRescanDone(activeWalletId)
                         Log.w(TAG, "🔄 Have ${txPag.objects.size} transactions but 0 live cells - triggering rescan")
                         val earliestBlock = txPag.objects
                             .mapNotNull { it.blockNumber.removePrefix("0x").toLongOrNull(16) }

--- a/android/app/src/main/java/com/rjnr/pocketnode/data/sync/SyncStallDetector.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/sync/SyncStallDetector.kt
@@ -7,7 +7,8 @@ package com.rjnr.pocketnode.data.sync
  *
  * Contract:
  *  - First [evaluate] call captures the baseline; never reports stalled.
- *  - Every advance (syncedBlock > lastObservedBlock) refreshes the baseline.
+ *  - Any change in syncedBlock (forward OR a rewind from a rescan/windowing
+ *    recovery) refreshes the baseline; only a frozen block accrues stall time.
  *  - When syncedBlock has not advanced for >= [stallThresholdMs] AND we are
  *    not within [SYNC_TOLERANCE] of tip, [StallInfo.isStalled] is true.
  *  - When within tolerance of tip, baseline resets and stall flag clears.
@@ -44,7 +45,13 @@ class SyncStallDetector(
             return StallInfo(false, 0L, syncedBlock, tipBlock)
         }
 
-        if (syncedBlock > lastObservedBlock) {
+        // Rebaseline on ANY change, not just forward. A rescue rescan or
+        // windowing recovery rewinds the registered script start block, so
+        // syncedToBlock drops below the prior high-water mark (knmo). That is
+        // the light client re-scanning forward from an earlier point, not a
+        // stall — treating a regression as "no advance" made the banner fire
+        // while blocks were actively progressing.
+        if (syncedBlock != lastObservedBlock) {
             lastObservedBlock = syncedBlock
             lastAdvanceAtMs = nowMs
             return StallInfo(false, 0L, syncedBlock, tipBlock)

--- a/android/app/src/main/java/com/rjnr/pocketnode/data/wallet/WalletPreferences.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/wallet/WalletPreferences.kt
@@ -193,6 +193,31 @@ class WalletPreferences @Inject constructor(
         prefs.edit().putBoolean(key, completed).apply()
     }
 
+    // --- Zero-live-cell rescue rescan (#332 / knmo) ---
+    // The rescue rescan rewinds the script to find cells the light client may
+    // have missed. For a wallet whose primary address legitimately has no live
+    // cells (e.g. funds on HD-derived addresses created by another wallet) the
+    // rescan finds nothing. The in-memory once-per-process latch stopped the
+    // within-session loop, but every cold start re-armed and re-rewound, so the
+    // user saw "Catching up from..." on every launch. This persists the attempt
+    // per wallet+network so it does not repeat each launch; cleared only by an
+    // explicit resync.
+
+    fun isZeroCellRescanDone(walletId: String, network: NetworkType? = null): Boolean {
+        val net = network ?: getSelectedNetwork()
+        return prefs.getBoolean(walletNetworkKey(walletId, net.name, KEY_ZERO_CELL_RESCAN_DONE), false)
+    }
+
+    fun setZeroCellRescanDone(walletId: String, network: NetworkType? = null) {
+        val net = network ?: getSelectedNetwork()
+        prefs.edit().putBoolean(walletNetworkKey(walletId, net.name, KEY_ZERO_CELL_RESCAN_DONE), true).apply()
+    }
+
+    fun clearZeroCellRescanDone(walletId: String, network: NetworkType? = null) {
+        val net = network ?: getSelectedNetwork()
+        prefs.edit().remove(walletNetworkKey(walletId, net.name, KEY_ZERO_CELL_RESCAN_DONE)).apply()
+    }
+
     // --- Background sync (global, not per-network) ---
 
     fun isBackgroundSyncEnabled(): Boolean {
@@ -337,6 +362,7 @@ class WalletPreferences @Inject constructor(
         private const val KEY_SYNC_MODE = "sync_mode"
         private const val KEY_CUSTOM_BLOCK_HEIGHT = "custom_block_height"
         private const val KEY_INITIAL_SYNC_COMPLETED = "initial_sync_completed"
+        private const val KEY_ZERO_CELL_RESCAN_DONE = "zero_cell_rescan_done"
         private const val KEY_ACTIVE_WALLET_ID = "active_wallet_id"
         private const val KEY_SYNC_STRATEGY = "sync_strategy"
         private const val KEY_THEME_MODE = "theme_mode"

--- a/android/app/src/test/java/com/rjnr/pocketnode/data/sync/SyncStallDetectorTest.kt
+++ b/android/app/src/test/java/com/rjnr/pocketnode/data/sync/SyncStallDetectorTest.kt
@@ -41,6 +41,28 @@ class SyncStallDetectorTest {
     }
 
     @Test
+    fun `block regression rebaselines and does not report stalled`() {
+        // knmo: a rescue rescan / windowing recovery rewinds the script start
+        // block, so syncedToBlock drops below the prior high-water mark. The
+        // light client is actively scanning forward from the rewound point,
+        // but the old detector saw "not greater than baseline" and falsely
+        // reported a stall after 5 min. A regression must rebaseline.
+        detector.evaluate(19_000_000, 19_500_000, 0L)
+        val rewound = detector.evaluate(18_800_000, 19_500_000, 6L * 60L * 1000L)
+        assertFalse("regression must not be stalled", rewound.isStalled)
+        val advancing = detector.evaluate(18_900_000, 19_500_000, 6L * 60L * 1000L + 60_000L)
+        assertFalse(advancing.isStalled)
+    }
+
+    @Test
+    fun `genuine freeze after a regression still stalls`() {
+        detector.evaluate(19_000_000, 19_500_000, 0L)
+        detector.evaluate(18_800_000, 19_500_000, 1000L) // rewind rebaselines
+        val info = detector.evaluate(18_800_000, 19_500_000, 1000L + 6L * 60L * 1000L)
+        assertTrue(info.isStalled)
+    }
+
+    @Test
     fun `not stalled below threshold`() {
         detector.evaluate(5_000_000, 10_000_000, 0L)
         // Same block 4 minutes later — under 5 min threshold

--- a/android/app/src/test/java/com/rjnr/pocketnode/data/wallet/WalletPreferencesTest.kt
+++ b/android/app/src/test/java/com/rjnr/pocketnode/data/wallet/WalletPreferencesTest.kt
@@ -50,6 +50,27 @@ class WalletPreferencesTest {
         assertEquals(NetworkType.MAINNET, newPrefs().getSelectedNetwork())
     }
 
+    // --- Zero-cell rescue rescan flag (knmo: per-launch loop fix) ---
+
+    @Test
+    fun `zero-cell rescan flag defaults false, persists, and clears`() {
+        val prefs = newPrefs()
+        assertFalse(prefs.isZeroCellRescanDone("wallet-1"))
+        prefs.setZeroCellRescanDone("wallet-1")
+        assertTrue("persists across instances", newPrefs().isZeroCellRescanDone("wallet-1"))
+        prefs.clearZeroCellRescanDone("wallet-1")
+        assertFalse(newPrefs().isZeroCellRescanDone("wallet-1"))
+    }
+
+    @Test
+    fun `zero-cell rescan flag is per wallet and per network`() {
+        val prefs = newPrefs()
+        prefs.setZeroCellRescanDone("wallet-1", NetworkType.MAINNET)
+        assertFalse("other wallet unaffected", prefs.isZeroCellRescanDone("wallet-2", NetworkType.MAINNET))
+        assertFalse("other network unaffected", prefs.isZeroCellRescanDone("wallet-1", NetworkType.TESTNET))
+        assertTrue(prefs.isZeroCellRescanDone("wallet-1", NetworkType.MAINNET))
+    }
+
     // --- Per-network isolation: sync mode ---
 
     @Test


### PR DESCRIPTION
## Summary
Two sync bugs knmo hit on v1.7.4, both downstream of restoring a seed whose funds live on HD-derived addresses created by another wallet (so the primary address has history but permanently zero live cells). Root cause of the missing deposits themselves is the single-address limitation tracked in #82; this PR fixes the two sync symptoms.

### A. Per-launch rescan loop ("Catching up from..." on every restart)
The zero-live-cell rescue rescan (#332) was latched once-per-process in memory only. A primary with history but permanently 0 live cells re-armed on every cold start and rewound the script to `earliestTx-100` again, re-scanning for hours and finding nothing. Now the attempt is persisted per wallet+network (`WalletPreferences.isZeroCellRescanDone`), so it runs at most once and does not repeat each launch. An explicit resync re-arms it (clears the flag + the in-memory set), since that is the user deliberately asking us to look again.

### D. False "Sync hasn't progressed in 5 min" while blocks are advancing
`SyncStallDetector` only rebaselined on a forward move. A rescue rescan or windowing recovery rewinds the script start block, so `syncedToBlock` drops below the prior high-water mark; the detector treated that as "no advance" and fired the stall banner even though the light client was actively scanning forward from the rewound point. It now rebaselines on ANY change (forward or rewind); only a genuinely frozen block accrues stall time.

## Tests
- `SyncStallDetectorTest`: regression rebaselines / does not stall; genuine freeze after a regression still stalls.
- `WalletPreferencesTest`: zero-cell flag defaults false, persists, clears, and is per wallet + per network.
- Full `testDebugUnitTest` green.

## Not in this PR
- #82 (HD multi-address discovery) — the real fix for "only 1 of 4 DAO deposits shows"; the 4 deposits are on 4 different derived addresses Pocket Node never scans (confirmed on-chain).
- B (custom-restore Apply needs restart) and C (custom height falls back to RECENT) — same registration code, batching next.

Refs #332, #82.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resync behavior so a manual resync can re-enable recovery scanning when needed.
  * Fixed sync stall detection so temporary block rollbacks no longer get misreported as stalls.
  * Made recovery scan completion tracking persist correctly across app launches and stay separate for each wallet/network.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->