### PR TITLE
fix(dao): remove duplicate Confirming card after phase-1 withdraw commits (#357)

### DIFF
--- a/android/app/src/main/java/com/rjnr/pocketnode/data/gateway/DaoDedup.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/gateway/DaoDedup.kt
@@ -1,0 +1,23 @@
+package com.rjnr.pocketnode.data.gateway
+
+import com.rjnr.pocketnode.data.gateway.models.DaoCellStatus
+import com.rjnr.pocketnode.data.gateway.models.DaoDeposit
+
+/**
+ * #357: drop a deposit's stale DEPOSITED entry once its phase-1 withdraw has
+ * committed. A confirmed phase-1 tx consumes the deposit cell and creates a
+ * new withdrawing cell, but the light client's get_cells can surface the new
+ * withdrawing cell before its spent-outpoint filter drops the old deposit, so
+ * both briefly appear — the deposit then rendered a duplicate "Confirming…"
+ * card next to the real withdrawing position.
+ *
+ * Each withdrawing entry carries [DaoDeposit.consumedDepositOutPoints] (the
+ * inputs of its phase-1 tx). Any DEPOSITED entry whose outpoint was consumed
+ * by a withdrawing entry is the spent original — drop it. Only DEPOSITED
+ * entries are dropped, so a withdrawing/unlockable position is never removed.
+ */
+fun dedupeWithdrawnDeposits(deposits: List<DaoDeposit>): List<DaoDeposit> {
+    val consumed = deposits.flatMap { it.consumedDepositOutPoints }.toSet()
+    if (consumed.isEmpty()) return deposits
+    return deposits.filterNot { it.status == DaoCellStatus.DEPOSITED && it.outPoint in consumed }
+}

--- a/android/app/src/main/java/com/rjnr/pocketnode/data/gateway/DaoDepositReader.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/gateway/DaoDepositReader.kt
@@ -161,6 +161,7 @@ class DaoDepositReader @Inject constructor(
         var lockRemainingHours: Int? = null
         var depositTimestampMs = 0L
         var apc = 0.0
+        var consumedDepositOutPoints: List<com.rjnr.pocketnode.data.gateway.models.OutPoint> = emptyList()
 
         // Get block header for compensation & epoch data (cache-first).
         val blockHash = daoHeaderResolver.getBlockHashForCell(cell.outPoint.txHash)
@@ -195,6 +196,11 @@ class DaoDepositReader @Inject constructor(
                 // Get original deposit header for compensation (cache-first)
                 val withdrawTxJson = LightClientNative.nativeGetTransaction(cell.outPoint.txHash)
                 val withdrawTx = withdrawTxJson?.let { json.decodeFromString<JniTransactionWithStatus>(it) }
+                // #357: record what this phase-1 tx consumed so the caller can
+                // drop the original deposit's stale DEPOSITED entry that the
+                // light client may still list until its spent-filter catches up.
+                consumedDepositOutPoints = withdrawTx?.transaction?.inputs
+                    ?.map { it.previousOutput } ?: emptyList()
                 val origDepositBlockHash = withdrawTx?.transaction?.headerDeps?.firstOrNull()
                 if (origDepositBlockHash != null) {
                     depositBlockHash = origDepositBlockHash
@@ -316,6 +322,7 @@ class DaoDepositReader @Inject constructor(
             cyclePhase = cyclePhaseFromProgress(cycleProgress),
             depositTimestamp = depositTimestampMs,
             apc = apc,
+            consumedDepositOutPoints = consumedDepositOutPoints,
         )
     }
 

--- a/android/app/src/main/java/com/rjnr/pocketnode/data/gateway/GatewayRepository.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/gateway/GatewayRepository.kt
@@ -1791,7 +1791,11 @@ class GatewayRepository @Inject constructor(
         val info = _walletInfo.value ?: throw Exception("No wallet")
         val currentEpoch = getCurrentEpoch().getOrNull()
         val live = daoDepositReader.list(info.script, currentEpoch, currentNetwork)
-        applyPendingWithdrawOverlay(mergeWithCachedDaoDeposits(live))
+        // #357: drop a spent deposit's stale DEPOSITED entry that the light
+        // client still lists alongside its new withdrawing cell, before the
+        // pending-withdraw overlay would paint it a duplicate "Confirming…".
+        val deduped = dedupeWithdrawnDeposits(live)
+        applyPendingWithdrawOverlay(mergeWithCachedDaoDeposits(deduped))
     }
 
     /**

--- a/android/app/src/main/java/com/rjnr/pocketnode/data/gateway/models/DaoModels.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/gateway/models/DaoModels.kt
@@ -72,7 +72,13 @@ data class DaoDeposit(
     // #332: deposit known from the Room cache but created BEFORE the script's
     // current sync window — the light client cannot see it, so compensation/
     // status may be stale until the user runs a deeper rescan.
-    val outsideSyncWindow: Boolean = false
+    val outsideSyncWindow: Boolean = false,
+    // #357: for a WITHDRAWING cell, the outpoints its phase-1 tx consumed. Used
+    // to drop the original deposit's stale DEPOSITED entry that the light client
+    // still lists for a short window after the withdraw commits (get_cells
+    // surfaces the new withdrawing cell before the spent-outpoint filter catches
+    // up). Transient — never persisted to dao_cells.
+    val consumedDepositOutPoints: List<OutPoint> = emptyList()
 )
 
 // -- Aggregate overview --

--- a/android/app/src/test/java/com/rjnr/pocketnode/data/gateway/DaoDedupTest.kt
+++ b/android/app/src/test/java/com/rjnr/pocketnode/data/gateway/DaoDedupTest.kt
@@ -1,0 +1,75 @@
+package com.rjnr.pocketnode.data.gateway
+
+import com.rjnr.pocketnode.data.gateway.models.DaoCellStatus
+import com.rjnr.pocketnode.data.gateway.models.DaoDeposit
+import com.rjnr.pocketnode.data.gateway.models.OutPoint
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * #357: after a phase-1 withdraw commits, the light client briefly lists both
+ * the new withdrawing cell AND the now-spent deposit cell (its spent-outpoint
+ * filter lags get_cells), so the deposit showed a duplicate "Confirming…"
+ * card. The withdrawing cell carries the outpoints its tx consumed; drop any
+ * DEPOSITED entry that one of them consumed.
+ */
+class DaoDedupTest {
+
+    private fun op(tx: String, idx: String = "0x0") = OutPoint(txHash = tx, index = idx)
+
+    private fun deposit(
+        tx: String,
+        status: DaoCellStatus,
+        consumed: List<OutPoint> = emptyList(),
+    ) = DaoDeposit(
+        outPoint = op(tx),
+        capacity = 102_00000000L,
+        status = status,
+        depositBlockNumber = 100,
+        consumedDepositOutPoints = consumed,
+    )
+
+    @Test
+    fun `drops the deposit consumed by a withdrawing cell`() {
+        val depositD = deposit("0xdeposit", DaoCellStatus.DEPOSITED)
+        val withdrawingW = deposit("0xwithdraw", DaoCellStatus.LOCKED, consumed = listOf(op("0xdeposit")))
+        val out = dedupeWithdrawnDeposits(listOf(depositD, withdrawingW))
+        assertEquals(listOf(withdrawingW), out)
+    }
+
+    @Test
+    fun `keeps an unrelated deposit`() {
+        val other = deposit("0xother", DaoCellStatus.DEPOSITED)
+        val withdrawingW = deposit("0xwithdraw", DaoCellStatus.LOCKED, consumed = listOf(op("0xdeposit")))
+        val out = dedupeWithdrawnDeposits(listOf(other, withdrawingW))
+        assertTrue(other in out && withdrawingW in out)
+        assertEquals(2, out.size)
+    }
+
+    @Test
+    fun `index must match, not just tx hash`() {
+        // A deposit at index 1 is NOT the one consumed at index 0.
+        val depositD1 = deposit("0xdeposit", DaoCellStatus.DEPOSITED).copy(outPoint = op("0xdeposit", "0x1"))
+        val withdrawingW = deposit("0xwithdraw", DaoCellStatus.LOCKED, consumed = listOf(op("0xdeposit", "0x0")))
+        val out = dedupeWithdrawnDeposits(listOf(depositD1, withdrawingW))
+        assertEquals(2, out.size)
+    }
+
+    @Test
+    fun `no withdrawing cells leaves the list unchanged`() {
+        val a = deposit("0xa", DaoCellStatus.DEPOSITED)
+        val b = deposit("0xb", DaoCellStatus.DEPOSITED)
+        assertEquals(listOf(a, b), dedupeWithdrawnDeposits(listOf(a, b)))
+    }
+
+    @Test
+    fun `only DEPOSITED entries are dropped, not a withdrawing one`() {
+        // Defensive: a consumed outpoint should never match a non-DEPOSITED
+        // entry, but if it did we must not drop the withdrawing position.
+        val w1 = deposit("0xw1", DaoCellStatus.LOCKED, consumed = listOf(op("0xw2")))
+        val w2 = deposit("0xw2", DaoCellStatus.UNLOCKABLE)
+        val out = dedupeWithdrawnDeposits(listOf(w1, w2))
+        assertEquals(2, out.size)
+    }
+}


### PR DESCRIPTION
## Report (#357)
After a phase-1 withdraw confirmed on-chain, the DAO page showed the real withdrawing position AND an extra "Confirming…" card for the same 102 CKB deposit.

## Root cause
A confirmed phase-1 tx consumes the deposit cell and creates a new withdrawing cell. The light client's `get_cells` surfaces the new withdrawing cell before its spent-outpoint filter drops the consumed deposit, so both briefly appear. The pending-withdraw overlay (#348) then painted the lingering deposit "Confirming…", duplicating the position. Verified on-chain: phase-1 tx `0xcf2bd2…` consumes deposit `0x609034c9:0` and outputs the 102 CKB withdrawing cell `0xcf2bd2…:0`, both on the same address.

## Fix (Option B — link via tx inputs, timing-independent)
The withdrawing cell now records the outpoints its phase-1 tx consumed (`DaoDeposit.consumedDepositOutPoints`, read from the withdraw tx inputs which `DaoDepositReader` already fetches). `dedupeWithdrawnDeposits` drops any DEPOSITED entry whose outpoint was consumed by a withdrawing entry, applied to the live list before the merge/overlay. Once dropped, the overlay's existing logic clears the pending marker (deposit no longer DEPOSITED → CLEAR_CONFIRMED). This is independent of cache/tx-status timing and matches by full outpoint (tx hash AND index), so it never removes an unrelated or non-DEPOSITED position.

## Tests
`DaoDedupTest` (5, RED-verified first): drops the consumed deposit, keeps unrelated, index must match, no-op without withdrawing cells, never drops a non-DEPOSITED entry. Full `testDebugUnitTest` green. No UI change.

Refs #348, #357.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved DAO deposit display so spent deposits are no longer shown as active during a brief sync window.
  * Prevents stale deposit entries from appearing when a related withdrawal is already in progress.
  * Keeps unrelated deposits and non-deposit entries visible as expected.

* **Tests**
  * Added coverage for deposit deduplication, including matching by both transaction and output index and handling empty withdrawal states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->