### PR TITLE
fix(sync): custom restore point applies on first try and honors the exact height (knmo B/C)

### DIFF
--- a/android/app/src/main/java/com/rjnr/pocketnode/data/gateway/GatewayRepository.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/gateway/GatewayRepository.kt
@@ -666,7 +666,12 @@ class GatewayRepository @Inject constructor(
     ): Result<Unit> = runCatching {
         when (walletPreferences.getSyncStrategy()) {
             SyncStrategy.ALL_WALLETS, SyncStrategy.BALANCED -> {
-                registerAllWalletScripts()
+                // Persist the chosen mode/height BEFORE registering: the
+                // SyncCoordinator reads the per-wallet pref to compute each
+                // script's start block, so writing it afterwards meant a
+                // first-time CUSTOM selection registered from the stale default
+                // (RECENT = tip-200k) and only took effect on the next launch
+                // (knmo C).
                 if (savePreference) {
                     val wId = activeWalletId.ifEmpty { null }
                     walletPreferences.setSyncMode(syncMode, walletId = wId)
@@ -675,6 +680,7 @@ class GatewayRepository @Inject constructor(
                     }
                     walletPreferences.setInitialSyncCompleted(true, walletId = wId)
                 }
+                registerAllWalletScripts()
             }
             SyncStrategy.ACTIVE_ONLY -> {
                 registerAccount(syncMode, customBlockHeight, savePreference).getOrThrow()
@@ -782,6 +788,23 @@ class GatewayRepository @Inject constructor(
         walletPreferences.clearZeroCellRescanDone(activeWalletId)
         balanceRescanAttempted.remove(activeWalletId)
         return registerAccount(syncMode, customBlockHeight, savePreference = true, forceResync = true)
+    }
+
+    /**
+     * True when the wallet is already registered at this sync setting, so an
+     * Apply tap should be a no-op (knmo B, Option 2). Compares the request
+     * against the APPLIED per-wallet preference + actual registration, not the
+     * UI's displayed value, which could disagree with what was really applied.
+     */
+    fun isSyncSettingApplied(syncMode: SyncMode, customBlockHeight: Long?): Boolean {
+        val wId = activeWalletId.ifEmpty { null }
+        return syncSettingAlreadyApplied(
+            requestedMode = syncMode,
+            requestedHeight = customBlockHeight,
+            appliedMode = walletPreferences.getSyncMode(walletId = wId),
+            appliedHeight = walletPreferences.getCustomBlockHeight(walletId = wId),
+            isRegistered = _isRegistered.value,
+        )
     }
 
     fun hasCompletedInitialSync(): Boolean = walletPreferences.hasCompletedInitialSync(walletId = activeWalletId.ifEmpty { null })

--- a/android/app/src/main/java/com/rjnr/pocketnode/data/gateway/SyncSettingApplied.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/gateway/SyncSettingApplied.kt
@@ -1,0 +1,28 @@
+package com.rjnr.pocketnode.data.gateway
+
+import com.rjnr.pocketnode.data.gateway.models.SyncMode
+
+/**
+ * True when the wallet is already registered at the requested sync setting, so
+ * tapping "Apply" should be a no-op rather than a resync (knmo B, Option 2).
+ *
+ * Compares the request against the APPLIED setting — the per-wallet preference
+ * written at registration time — not the displayed UI state, which could lie
+ * (issue C persisted CUSTOM while registering RECENT). Requires scripts to be
+ * actually registered, so a never-applied setting always proceeds. Compares the
+ * chosen start mode/height, not sync progress, so an advancing synced block
+ * never makes a genuine re-apply look like a no-op or vice versa.
+ */
+fun syncSettingAlreadyApplied(
+    requestedMode: SyncMode,
+    requestedHeight: Long?,
+    appliedMode: SyncMode,
+    appliedHeight: Long?,
+    isRegistered: Boolean,
+): Boolean {
+    if (!isRegistered) return false
+    if (requestedMode != appliedMode) return false
+    // Height only distinguishes CUSTOM; other modes derive their start block.
+    if (requestedMode == SyncMode.CUSTOM && requestedHeight != appliedHeight) return false
+    return true
+}

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/home/HomeViewModel.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/home/HomeViewModel.kt
@@ -508,12 +508,15 @@ class HomeViewModel @Inject constructor(
      * This will re-register with the light client using the new sync settings.
      */
     fun changeSyncMode(syncMode: SyncMode, customBlockHeight: Long? = null) {
-        // No-op when the user re-selects the currently-active mode (no change to
-        // resync against). Without this guard, re-selecting RECENT after a full
-        // sync would wipe progress and re-sync the last 200k blocks. (#108)
-        val current = _uiState.value
-        if (syncMode == current.currentSyncMode && customBlockHeight == current.savedCustomBlockHeight) {
-            Log.d(TAG, "changeSyncMode: same mode + height already active — no-op")
+        // No-op only when the wallet is ACTUALLY registered at this setting, not
+        // merely when the displayed value matches (knmo B, Option 2). The old
+        // guard compared against UI state, which could disagree with what was
+        // really applied (issue C wrote the pref but registered RECENT), so a
+        // re-tap silently no-opped and the restore point needed an app restart.
+        // Original purpose stands: re-selecting an already-applied mode must not
+        // wipe progress and re-sync (#108).
+        if (repository.isSyncSettingApplied(syncMode, customBlockHeight)) {
+            Log.d(TAG, "changeSyncMode: already registered at this setting — no-op")
             return
         }
         viewModelScope.launch {

--- a/android/app/src/test/java/com/rjnr/pocketnode/data/gateway/SyncSettingAppliedTest.kt
+++ b/android/app/src/test/java/com/rjnr/pocketnode/data/gateway/SyncSettingAppliedTest.kt
@@ -1,0 +1,76 @@
+package com.rjnr.pocketnode.data.gateway
+
+import com.rjnr.pocketnode.data.gateway.models.SyncMode
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * #knmo B (Option 2): "Apply" should re-sync only when the wallet is not
+ * actually registered at the requested sync setting. The old guard compared
+ * against the displayed preference, which could disagree with what was really
+ * applied (issue C wrote the pref but registered RECENT), so re-tapping Apply
+ * silently no-opped and the restore point only took effect after a restart.
+ *
+ * This compares the request against the APPLIED setting (the per-wallet pref,
+ * written at registration) plus whether scripts are actually registered. It
+ * compares the chosen start intent, not sync progress, so it is not fooled by
+ * the synced block advancing.
+ */
+class SyncSettingAppliedTest {
+
+    @Test
+    fun `not applied when not registered, even if pref matches`() {
+        assertFalse(
+            syncSettingAlreadyApplied(
+                requestedMode = SyncMode.CUSTOM, requestedHeight = 19_100_000,
+                appliedMode = SyncMode.CUSTOM, appliedHeight = 19_100_000,
+                isRegistered = false,
+            )
+        )
+    }
+
+    @Test
+    fun `applied when registered and custom height matches`() {
+        assertTrue(
+            syncSettingAlreadyApplied(
+                requestedMode = SyncMode.CUSTOM, requestedHeight = 19_100_000,
+                appliedMode = SyncMode.CUSTOM, appliedHeight = 19_100_000,
+                isRegistered = true,
+            )
+        )
+    }
+
+    @Test
+    fun `not applied when custom height differs`() {
+        assertFalse(
+            syncSettingAlreadyApplied(
+                requestedMode = SyncMode.CUSTOM, requestedHeight = 19_100_000,
+                appliedMode = SyncMode.CUSTOM, appliedHeight = 19_284_000,
+                isRegistered = true,
+            )
+        )
+    }
+
+    @Test
+    fun `not applied when mode differs`() {
+        assertFalse(
+            syncSettingAlreadyApplied(
+                requestedMode = SyncMode.CUSTOM, requestedHeight = 19_100_000,
+                appliedMode = SyncMode.RECENT, appliedHeight = null,
+                isRegistered = true,
+            )
+        )
+    }
+
+    @Test
+    fun `non-custom mode ignores height`() {
+        assertTrue(
+            syncSettingAlreadyApplied(
+                requestedMode = SyncMode.RECENT, requestedHeight = null,
+                appliedMode = SyncMode.RECENT, appliedHeight = 12345,
+                isRegistered = true,
+            )
+        )
+    }
+}


### PR DESCRIPTION
## Report (knmo, on v1.7.4)
- **C**: set a custom restore height of 19,100,000 but sync started at ~19,284,000 (= tip − 200k = RECENT default).
- **B**: the restore point only took effect after an app restart; re-tapping Apply did nothing.

## Root cause
- **C**: under the default ALL_WALLETS/BALANCED strategy, `registerAccountWithStrategy` called `registerAllWalletScripts()` (which reads the per-wallet preference to compute each script's start block) and only persisted the chosen mode/height **after** registering. So a first-time CUSTOM selection registered from the stale default and only took effect on the next launch.
- **B**: `changeSyncMode`'s no-op guard compared the request against the displayed UI state. Because C left the preference saying CUSTOM while the light client was actually at RECENT, the guard treated a re-tap as "already applied" and returned early, so Apply appeared to do nothing until a restart.

## Fix
- **C**: persist the sync mode + custom height **before** `registerAllWalletScripts()`, so the coordinator reads the chosen value in the same pass and registers from the exact height.
- **B (Option 2)**: the guard now no-ops only when the wallet is genuinely registered at the requested setting. `syncSettingAlreadyApplied(...)` (pure, tested) compares the request against the applied per-wallet preference plus `isRegistered`, comparing the chosen start mode/height rather than sync progress, so a real re-apply proceeds while a true no-op stays a no-op (no surprise multi-hour resync, preserving #108).

## Tests
`SyncSettingAppliedTest` (5, RED-verified first): not-applied-when-unregistered, applied-when-height-matches, differs-by-height, differs-by-mode, non-custom-ignores-height. Full `testDebugUnitTest` green. No UI/layout change.

## Known follow-up (not in scope)
`resyncAccount` under a multi-wallet strategy still registers only the active wallet's script (briefly deregistering others). Noted for a later pass.

Refs #332.

🤖 Generated with [Claude Code](https://claude.com/claude-code)