### PR TITLE
fix(wallet): sub-account works without a device lock (#354) + balance refreshes promptly after confirm (#355/#356)

### DIFF
--- a/android/app/src/main/java/com/rjnr/pocketnode/data/gateway/GatewayRepository.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/gateway/GatewayRepository.kt
@@ -2257,7 +2257,12 @@ class GatewayRepository @Inject constructor(
                 } catch (e: Throwable) {
                     Log.e(TAG, "syncPoll iteration failed; continuing", e)
                 }
-                val delayMs = if (_syncProgress.value.isSyncing) 5_000L else 30_000L
+                // Synced cadence is 10s (was 30s): balance only refreshes off
+                // this poll, so a confirmed incoming tx could lag up to ~30s
+                // after "Synced" (#355/#356). The poll is cheap local JNI
+                // (tip header + account status); 10s bounds the lag without
+                // meaningful battery cost. Catch-up stays at 5s.
+                val delayMs = if (_syncProgress.value.isSyncing) 5_000L else 10_000L
                 delay(delayMs)
             }
         }

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/wallet/AddWalletViewModel.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/wallet/AddWalletViewModel.kt
@@ -47,7 +47,52 @@ class AddWalletViewModel @Inject constructor(
     private val mnemonicManager: MnemonicManager,
     private val walletKeyReader: WalletKeyReader,
     private val walletKeyWriter: WalletKeyWriter,
+    private val authManager: com.rjnr.pocketnode.data.auth.AuthManager,
 ) : ViewModel() {
+
+    /**
+     * #354: a V2 auth-bound Keystore key needs an enrolled biometric or a
+     * device credential. Without one, key creation throws
+     * IllegalStateException("Secure lock screen must be enabled..."). The
+     * main-wallet flow already falls back to a software-only V1 key in that
+     * case; the add-wallet / sub-account flows did not, so they crashed.
+     * Mirror the same gate here.
+     */
+    private fun canCreateV2BoundKey(): Boolean =
+        authManager.isBiometricEnrolled() || authManager.hasDeviceCredential()
+
+    /**
+     * Persist a new wallet's keys, choosing the V1 software-only fallback when
+     * the device has no secure lock (#354). AuthScreen's migration loop
+     * upgrades the row to V2 once the user enables a device lock.
+     */
+    private suspend fun persistWalletKeys(
+        activity: FragmentActivity,
+        walletId: String,
+        bundle: com.rjnr.pocketnode.data.migration.WalletKeyBundle,
+        walletType: String,
+        mnemonicBackedUp: Boolean,
+        promptTitle: String = "Secure wallet",
+        promptSubtitle: String = "Use your phone's screen lock to encrypt the new wallet's keys.",
+    ): WalletKeyWriter.Result =
+        if (!canCreateV2BoundKey()) {
+            walletKeyWriter.persistNewWalletV1Fallback(
+                walletId = walletId,
+                bundle = bundle,
+                walletType = walletType,
+                mnemonicBackedUp = mnemonicBackedUp,
+            )
+        } else {
+            walletKeyWriter.persistNewWallet(
+                activity = activity,
+                walletId = walletId,
+                bundle = bundle,
+                walletType = walletType,
+                mnemonicBackedUp = mnemonicBackedUp,
+                promptTitle = promptTitle,
+                promptSubtitle = promptSubtitle,
+            )
+        }
 
     /**
      * Optional parent-wallet hint forwarded from the WalletManager
@@ -161,7 +206,7 @@ class AddWalletViewModel @Inject constructor(
             // Distinct title/subtitle from prompt #1 so the user understands
             // they're securing the NEW sub-account, not re-confirming the parent.
             val result = walletRepository.createSubAccount(parentId, name, parentMnemonic) { walletId, bundle ->
-                walletKeyWriter.persistNewWallet(
+                persistWalletKeys(
                     activity = activity,
                     walletId = walletId,
                     bundle = bundle,
@@ -262,7 +307,7 @@ class AddWalletViewModel @Inject constructor(
             val result = walletRepository.createWallet(
                 name = name,
                 persistKeys = { walletId, bundle ->
-                    walletKeyWriter.persistNewWallet(
+                    persistWalletKeys(
                         activity = activity,
                         walletId = walletId,
                         bundle = bundle,
@@ -311,7 +356,7 @@ class AddWalletViewModel @Inject constructor(
                 words = words,
                 name = name,
                 persistKeys = { walletId, bundle ->
-                    walletKeyWriter.persistNewWallet(
+                    persistWalletKeys(
                         activity = activity,
                         walletId = walletId,
                         bundle = bundle,
@@ -347,7 +392,7 @@ class AddWalletViewModel @Inject constructor(
         viewModelScope.launch {
             _uiState.update { it.copy(isLoading = true, error = null) }
             val result = walletRepository.importRawKey(key, name) { walletId, bundle ->
-                walletKeyWriter.persistNewWallet(
+                persistWalletKeys(
                     activity = activity,
                     walletId = walletId,
                     bundle = bundle,
@@ -381,6 +426,8 @@ class AddWalletViewModel @Inject constructor(
                     UiMessage.Raw("Failed to save wallet: ${r.cause.message ?: "unknown error"}")
                 WalletKeyWriter.Result.KeyInvalidated ->
                     UiMessage.Raw("Wallet keys must be re-imported")
+                WalletKeyWriter.Result.NoSecureLock ->
+                    UiMessage.Raw("Could not secure the wallet. Enable a screen lock in device settings and try again.")
                 null -> error.message?.let(UiMessage::Raw)
                 else -> error.message?.let(UiMessage::Raw)
             }

--- a/android/app/src/test/java/com/rjnr/pocketnode/ui/screens/wallet/AddWalletViewModelTest.kt
+++ b/android/app/src/test/java/com/rjnr/pocketnode/ui/screens/wallet/AddWalletViewModelTest.kt
@@ -49,6 +49,7 @@ class AddWalletViewModelTest {
     private lateinit var mnemonicManager: MnemonicManager
     private lateinit var walletKeyReader: WalletKeyReader
     private lateinit var walletKeyWriter: WalletKeyWriter
+    private lateinit var authManager: com.rjnr.pocketnode.data.auth.AuthManager
     private lateinit var activity: FragmentActivity
 
     private val parentMnemonicWords = "abandon abandon abandon abandon abandon abandon " +
@@ -65,6 +66,11 @@ class AddWalletViewModelTest {
         mnemonicManager = mockk(relaxed = true)
         walletKeyReader = mockk(relaxed = true)
         walletKeyWriter = mockk(relaxed = true)
+        authManager = mockk(relaxed = true)
+        // Default: device has a secure lock, so the V2 path runs (matches
+        // the pre-#354 behavior these tests were written against).
+        io.mockk.every { authManager.isBiometricEnrolled() } returns true
+        io.mockk.every { authManager.hasDeviceCredential() } returns true
         activity = mockk(relaxed = true)
     }
 
@@ -80,6 +86,7 @@ class AddWalletViewModelTest {
         mnemonicManager = mnemonicManager,
         walletKeyReader = walletKeyReader,
         walletKeyWriter = walletKeyWriter,
+        authManager = authManager,
     )
 
     @Test


### PR DESCRIPTION
## #354 — sub-account creation crashed with no device lock
The main-wallet flow falls back to a software-only V1 key when the device has no biometric/credential, then upgrades to V2 once a lock is enabled. The add-wallet / sub-account flows (`AddWalletViewModel`) skipped that gate and called the V2 writer unconditionally, so `IllegalStateException: Secure lock screen must be enabled…` leaked to a snackbar and no wallet was created.

Fix: inject `AuthManager`, add the same `canCreateV2BoundKey()` gate as `OnboardingViewModel`, and route all four creation paths (sub-account, create, import mnemonic, import raw key) through a shared `persistWalletKeys` helper that picks `persistNewWalletV1Fallback` when there's no lock. Also added a friendly `Result.NoSecureLock` branch to `persistErrorMessage` as defense-in-depth.

Note: the writer success path can't be unit-tested here — this file documents a MockK inline-`Result` limitation that blocks stubbing `WalletRepository.createSubAccount`. The fix mirrors the audited Onboarding fallback; the existing reader-path tests still pass, and it should get a no-lock device check before release.

## #355/#356 — balance lags ~1 min after a confirm
Balance only refreshes off the sync poll, which runs every 30s once synced, so a confirmed incoming tx could take up to ~30s+ to show despite "Synced". Shortened the synced-state poll from 30s to 10s (catch-up stays 5s). The poll is cheap local JNI (tip header + account status), so the battery cost is modest. #356 is a duplicate of #355 — closing it.

## Tests
`AddWalletViewModelTest` updated for the new dependency (defaults to device-has-lock, preserving prior behavior). Full `testDebugUnitTest` green. No UI/layout change.

Refs #354, #355, #356.

🤖 Generated with [Claude Code](https://claude.com/claude-code)