### PR TITLE
fix(ui): See All opens All tab, network chip opens switcher, clearer Remove-PIN copy (#359/#353/#358)

### DIFF
--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/MainScreen.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/MainScreen.kt
@@ -140,7 +140,24 @@ fun MainScreen(
                         }
                     },
                     onNavigateToActivity = {
+                        // "See All" opens a fresh Activity list on the default
+                        // "All" tab. restoreState is intentionally false here so
+                        // it does NOT restore the tab's last-used filter (e.g.
+                        // Sent) — the #359 report. The Activity bottom tab still
+                        // restores its own state normally.
                         innerNav.navigate(BottomTab.Activity.route) {
+                            popUpTo(innerNav.graph.findStartDestination().id) {
+                                saveState = true
+                            }
+                            launchSingleTop = true
+                            restoreState = false
+                        }
+                    },
+                    onNavigateToFaq = onNavigateToFaq,
+                    onNavigateToSettings = {
+                        // #353: Home network chip routes to the Settings tab,
+                        // where Current Network switches networks.
+                        innerNav.navigate(BottomTab.Settings.route) {
                             popUpTo(innerNav.graph.findStartDestination().id) {
                                 saveState = true
                             }
@@ -148,7 +165,6 @@ fun MainScreen(
                             restoreState = true
                         }
                     },
-                    onNavigateToFaq = onNavigateToFaq,
                 )
             }
             composable(BottomTab.Activity.route) {

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/home/HomeScreen.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/home/HomeScreen.kt
@@ -128,6 +128,7 @@ fun HomeScreen(
     onNavigateToSecurityChecklist: () -> Unit = {},
     onNavigateToFaq: (anchor: String?) -> Unit = {},
     onNavigateToNodeStatus: () -> Unit = {},
+    onNavigateToSettings: () -> Unit = {},
     viewModel: HomeViewModel = hiltViewModel()
 ) {
     val uiState by viewModel.uiState.collectAsState()
@@ -467,6 +468,7 @@ fun HomeScreen(
                     onNavigateToActivity = onNavigateToActivity,
                     onNavigateToSecurityChecklist = onNavigateToSecurityChecklist,
                     onNavigateToNodeStatus = onNavigateToNodeStatus,
+                    onNavigateToSettings = onNavigateToSettings,
                     dismissBackupReminder = { viewModel.dismissBackupReminder() },
                     onToggleBalanceVisibility = { viewModel.toggleBalanceVisibility() },
                     clipboardManager = clipboardManager,
@@ -538,6 +540,7 @@ fun HomeScreenUI(
     onNavigateToActivity: () -> Unit = {},
     onNavigateToSecurityChecklist: () -> Unit = {},
     onNavigateToNodeStatus: () -> Unit = {},
+    onNavigateToSettings: () -> Unit = {},
     dismissBackupReminder: () -> Unit,
     onToggleBalanceVisibility: () -> Unit,
     clipboardManager: androidx.compose.ui.platform.ClipboardManager,
@@ -587,7 +590,10 @@ fun HomeScreenUI(
             }
 
             item {
-                NetworkBadge(network = uiState.currentNetwork)
+                NetworkBadge(
+                    network = uiState.currentNetwork,
+                    onClick = onNavigateToSettings,
+                )
                 Spacer(Modifier.width(4.dp))
             }
 
@@ -1231,7 +1237,7 @@ private fun DetailRow(
 }
 
 @Composable
-private fun NetworkBadge(network: NetworkType) {
+private fun NetworkBadge(network: NetworkType, onClick: (() -> Unit)? = null) {
     val isTestnet = network == NetworkType.TESTNET
     val backgroundColor = if (isTestnet) TestnetOrange else MaterialTheme.colorScheme.primary
     val textColor = if (isTestnet) Color.White else MaterialTheme.colorScheme.onPrimary
@@ -1241,7 +1247,12 @@ private fun NetworkBadge(network: NetworkType) {
     Surface(
         shape = RoundedCornerShape(12.dp),
         color = backgroundColor,
-        modifier = Modifier.padding(8.dp)
+        // #353: the chip looked tappable but wasn't. Tapping it now opens
+        // Settings, where the network switcher (with its restart-confirm
+        // dialog) lives.
+        modifier = Modifier
+            .padding(8.dp)
+            .then(if (onClick != null) Modifier.clickable { onClick() } else Modifier)
     ) {
         Row(
             modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/settings/SecuritySettingsScreen.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/settings/SecuritySettingsScreen.kt
@@ -109,8 +109,8 @@ fun SecuritySettingsScreen(
                 title = { Text(stringResource(R.string.security_settings_pin_required_title)) },
                 text = {
                     Text(
-                        "A PIN is mandatory while you have a wallet. It protects your PIN-encrypted recovery backup.\n\n" +
-                        "To remove the PIN, first delete every wallet in Wallet Manager. Make sure you have your recovery phrase written down before deleting."
+                        "This is intentional, not an error. Your PIN encrypts the recovery backup that can restore a wallet, so a PIN stays required as long as any wallet exists.\n\n" +
+                        "To remove the PIN, first write down your recovery phrase, then delete every wallet in Wallet Manager. The option becomes available once no wallets remain."
                     )
                 },
                 confirmButton = {


### PR DESCRIPTION
Three v1.7.4 UI reports from the team. Approaches confirmed with the maintainer.

## #359 — "See All" opened Activity on the previous filter (Sent), not All
Activity is a bottom-nav tab whose state (including the last-used filter) is restored. Tapping "See All" navigated to it with `restoreState = true`, so it restored the saved filter. The "See All" navigation now uses `restoreState = false`, so it opens a fresh list on the default "All" tab. The Activity bottom tab still restores its own state normally.

## #353 — Home network chip looked tappable but wasn't (Option A)
`NetworkBadge` is now clickable and routes to the Settings tab, where Current Network performs the switch (with its existing "app will close and reopen" confirm dialog). Wired `onNavigateToSettings` Home → MainScreen → Settings tab.

## #358 — "Remove PIN" blocked while a wallet exists (Option A: keep behavior, clarify copy)
The behavior is intentional (the PIN encrypts the recovery backup). Reworded the dialog to say so up front ("This is intentional, not an error...") and to give the exact steps, instead of reading like an error.

## Tests
Pure UI/nav/string changes; full `testDebugUnitTest` green. No logic touched.

Refs #359, #353, #358.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The Home screen network chip is now tappable and opens the Settings tab.
  * “See All” for Activity now opens without restoring the previous Activity filter, so you see the full list consistently.

* **Bug Fixes**
  * Updated the PIN removal prompt to better explain why the option may be unavailable and what steps are needed before removing a PIN.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->