### PR TITLE
fix(send): fix persistent 'Could not broadcast' + surface the real rejection reason

### DIFF
--- a/android/app/src/main/java/com/rjnr/pocketnode/data/gateway/GatewayRepository.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/gateway/GatewayRepository.kt
@@ -1191,7 +1191,17 @@ class GatewayRepository @Inject constructor(
             // matches the sender's lock (= change output going back to us).
             // If a pending tx ultimately FAILs, downstream txs that consumed its
             // synthetic change will also fail and the watchdog times them out.
-            val pendingChange: List<Cell> = pending.flatMap { row ->
+            //
+            // ONLY session-broadcast rows: a synthetic input resolves only if
+            // its creating tx is in the light client's in-memory pending pool,
+            // which is wiped on restart. Persisted rows from a prior session are
+            // not in the pool, so their change would be unresolvable and reject
+            // every send after a reboot (Alex report). The reservation filter
+            // above still uses ALL pending rows so reserved inputs are never
+            // double-spent.
+            val pendingChange: List<Cell> = pending
+                .filter { it.txHash in broadcastedThisSession }
+                .flatMap { row ->
                 val pendingTx = try {
                     json.decodeFromString<Transaction>(row.signedTxJson)
                 } catch (e: Exception) {
@@ -1214,7 +1224,14 @@ class GatewayRepository @Inject constructor(
                     )
                 }
             }
-            val filtered = liveFiltered + pendingChange
+            // Dedup by outpoint, preferring the real (on-chain) cell: once a
+            // pending tx confirms, its change appears in both liveFiltered and
+            // pendingChange for the brief window before the watchdog clears the
+            // row. Selecting the same outpoint twice would build a tx with a
+            // duplicate input and fail. liveFiltered is first, so distinctBy
+            // keeps the real cell.
+            val filtered = (liveFiltered + pendingChange)
+                .distinctBy { "${it.outPoint.txHash}:${it.outPoint.index}" }
             Log.d(
                 TAG,
                 "buildReserveAndSend: ${cellsResult.items.size} live, ${reserved.size} reserved, " +
@@ -1441,7 +1458,24 @@ class GatewayRepository @Inject constructor(
             throw Exception("Send failed - native returned null")
         }
 
+        // The JNI now returns the real rejection reason with a sentinel prefix
+        // instead of null, so we can surface WHY a broadcast was rejected (e.g.
+        // an unresolvable input from a stale pending tx) rather than blaming the
+        // network. Clean up the row we inserted, same as the null path.
+        if (rawResult.startsWith(BROADCAST_ERROR_PREFIX)) {
+            val reason = rawResult.removePrefix(BROADCAST_ERROR_PREFIX)
+            pendingBroadcastDao.delete(txHash)
+            cacheManager.deleteTransaction(txHash)
+            throw Exception("Broadcast rejected: $reason")
+        }
+
         val returnedHash = rawResult.trim('"')
+        // Broadcast accepted → the tx is now in the light client's in-memory
+        // pending pool this session, so its change is safe to spend as synthetic
+        // change until it confirms. Record both key variants (pre-hash and the
+        // returned hash) since the pending_broadcasts row may be keyed by either.
+        broadcastedThisSession.add(txHash)
+        broadcastedThisSession.add(returnedHash)
         if (returnedHash.lowercase() != txHash.lowercase()) {
             // Step 0 verified equality on testnet; this branch should be unreachable.
             // If it fires in production, the tx WAS broadcast under returnedHash but
@@ -2236,6 +2270,16 @@ class GatewayRepository @Inject constructor(
     private val balanceRescanAttempted =
         java.util.Collections.synchronizedSet(mutableSetOf<String>())
 
+    // Tx hashes broadcast in THIS process session. Only these are safe to spend
+    // as synthetic change: a synthetic change cell resolves only if its creating
+    // tx is in the light client's IN-MEMORY pending pool, which is wiped on every
+    // app restart. A PERSISTED pending_broadcasts row from a prior session is not
+    // in the pool, so feeding its change into a new send makes the light client
+    // fail to resolve the input and reject the tx locally — surfacing as the
+    // misleading "Could not broadcast" error that survived reboots (Alex report).
+    private val broadcastedThisSession =
+        java.util.Collections.synchronizedSet(mutableSetOf<String>())
+
     fun startSyncPolling() {
         if (syncPollingJob?.isActive == true) return
 
@@ -2392,6 +2436,10 @@ class GatewayRepository @Inject constructor(
 
     companion object {
         private const val TAG = "GatewayRepository"
+
+        // Matches SEND_ERROR_PREFIX in the Rust JNI (query.rs): nativeSendTransaction
+        // returns "__SEND_ERROR__:<reason>" on a rejected broadcast instead of null.
+        private const val BROADCAST_ERROR_PREFIX = "__SEND_ERROR__:"
 
         // MAX_CONCURRENT_WALLET_SCRIPTS + BALANCED_LAG_THRESHOLD moved to
         // SyncCoordinator (#106). Tests now import SyncCoordinator.BALANCED_LAG_THRESHOLD

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/send/SendViewModel.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/send/SendViewModel.kt
@@ -604,48 +604,7 @@ class SendViewModel @Inject constructor(
     /**
      * Parse technical error messages into user-friendly descriptions
      */
-    private fun parseErrorMessage(e: Exception): String {
-        val message = e.message ?: "Unknown error"
-
-        return when {
-            // Cell/UTXO errors
-            message.contains("Failed to get cells", ignoreCase = true) ->
-                "Could not fetch your available funds. Please ensure your wallet is synced and try again."
-            message.contains("No cells available", ignoreCase = true) ||
-            message.contains("Insufficient cells", ignoreCase = true) ->
-                "Not enough funds available. Please wait for your wallet to fully sync."
-
-            // Transaction building errors
-            message.contains("Insufficient balance", ignoreCase = true) ->
-                "Insufficient balance for this transaction."
-            message.contains("minimum", ignoreCase = true) && message.contains("61", ignoreCase = true) ->
-                "Minimum transfer amount is 61 CKB due to CKB's cell model."
-            message.contains("Dust change refused", ignoreCase = true) ->
-                "This exact amount would leave less than 61 CKB of change, which CKB cannot store as a separate output and the protocol would silently absorb into the transaction fee. Try sending a slightly different amount, or send your full balance minus the fee."
-
-            // Network/broadcast errors
-            message.contains("Send failed", ignoreCase = true) ||
-            message.contains("broadcast", ignoreCase = true) ->
-                "Could not broadcast transaction. Please check your network connection and try again."
-            message.contains("verification failed", ignoreCase = true) ->
-                "Transaction verification failed. The transaction may be invalid."
-
-            // Sync errors
-            message.contains("not synced", ignoreCase = true) ||
-            message.contains("sync", ignoreCase = true) ->
-                "Wallet is still syncing. Please wait for sync to complete before sending."
-
-            // JSON/parsing errors (likely a bug)
-            message.contains("json", ignoreCase = true) ||
-            message.contains("parse", ignoreCase = true) ||
-            message.contains("serial", ignoreCase = true) ||
-            message.contains("missing", ignoreCase = true) ->
-                "Internal error processing transaction data. Please try again or restart the app."
-
-            // Generic fallback
-            else -> "Transaction failed: $message"
-        }
-    }
+    private fun parseErrorMessage(e: Exception): String = mapSendErrorMessage(e.message)
 
     private fun startPollingTransactionStatus(txHash: String, address: String) {
         pollingJob?.cancel()
@@ -845,5 +804,64 @@ class SendViewModel @Inject constructor(
         super.onCleared()
         sendJob?.cancel()
         pollingJob?.cancel()
+    }
+}
+
+/**
+ * Maps a raw send/broadcast error to a user-facing message. Pure + top-level
+ * for testability. Order matters: the most specific, actionable causes come
+ * first. The Rust JNI now returns the real rejection reason (via the
+ * "Broadcast rejected: ..." exception), so we no longer blame the network for
+ * what are actually local verification failures (Alex report).
+ */
+internal fun mapSendErrorMessage(raw: String?): String {
+    val message = raw ?: "Unknown error"
+    return when {
+        // Cell/UTXO fetch
+        message.contains("Failed to get cells", ignoreCase = true) ->
+            "Could not fetch your available funds. Please ensure your wallet is synced and try again."
+        message.contains("No cells available", ignoreCase = true) ||
+            message.contains("Insufficient cells", ignoreCase = true) ->
+            "Not enough funds available. Please wait for your wallet to fully sync."
+
+        // Amount/build
+        message.contains("Insufficient balance", ignoreCase = true) ->
+            "Insufficient balance for this transaction."
+        message.contains("minimum", ignoreCase = true) && message.contains("61", ignoreCase = true) ->
+            "Minimum transfer amount is 61 CKB due to CKB's cell model."
+        message.contains("Dust change refused", ignoreCase = true) ->
+            "This exact amount would leave less than 61 CKB of change, which CKB cannot store as a separate output and the protocol would silently absorb into the transaction fee. Try sending a slightly different amount, or send your full balance minus the fee."
+
+        // Broadcast rejected with a real reason (from the JNI). Specific,
+        // actionable causes first.
+        message.contains("Unknown(", ignoreCase = true) ->
+            "This send depends on a previous transaction that hasn't confirmed yet. Wait for it to confirm, or reopen the app and try again."
+        message.contains("Dead(", ignoreCase = true) ->
+            "Some of the coins for this transaction were already spent. Reopen the app to refresh your balance, then try again."
+        message.contains("light client not ready", ignoreCase = true) ->
+            "The wallet is still starting up. Please wait a moment and try again."
+        message.contains("verification failed", ignoreCase = true) ->
+            "The network rejected this transaction. Reopen the app to refresh your wallet, then try again."
+        // Any other broadcast rejection: surface a concise reason instead of a
+        // network message, since these are usually deterministic and local.
+        message.contains("Broadcast rejected", ignoreCase = true) ->
+            "The network rejected this transaction. Please reopen the app and try again."
+        message.contains("Send failed", ignoreCase = true) ||
+            message.contains("broadcast", ignoreCase = true) ->
+            "Could not send the transaction. Please reopen the app and try again."
+
+        // Sync
+        message.contains("not synced", ignoreCase = true) ||
+            message.contains("sync", ignoreCase = true) ->
+            "Wallet is still syncing. Please wait for sync to complete before sending."
+
+        // Data/parsing (likely a bug)
+        message.contains("json", ignoreCase = true) ||
+            message.contains("parse", ignoreCase = true) ||
+            message.contains("serial", ignoreCase = true) ||
+            message.contains("missing", ignoreCase = true) ->
+            "Internal error processing transaction data. Please try again or restart the app."
+
+        else -> "Transaction failed: $message"
     }
 }

--- a/android/app/src/test/java/com/rjnr/pocketnode/ui/screens/send/SendErrorMessageTest.kt
+++ b/android/app/src/test/java/com/rjnr/pocketnode/ui/screens/send/SendErrorMessageTest.kt
@@ -1,0 +1,63 @@
+package com.rjnr.pocketnode.ui.screens.send
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * The send-error mapper must surface the REAL cause. The Alex report was a
+ * local verification failure (an unresolvable input from a stale pending tx)
+ * shown as "check your network" — misleading, since network state was
+ * irrelevant. These assert the actionable, non-network-blaming copy.
+ */
+class SendErrorMessageTest {
+
+    @Test
+    fun `unknown input points at the blocking pending tx, not the network`() {
+        val msg = mapSendErrorMessage(
+            "Broadcast rejected: verification failed: Transaction(Resolve(Unknown([OutPoint(0xabc..0)])))"
+        )
+        assertTrue(msg.contains("previous transaction", ignoreCase = true))
+        assertFalse(msg.contains("network connection", ignoreCase = true))
+    }
+
+    @Test
+    fun `dead input tells the user coins were already spent`() {
+        val msg = mapSendErrorMessage("Broadcast rejected: verification failed: Dead(OutPoint(0xabc..0))")
+        assertTrue(msg.contains("already spent", ignoreCase = true))
+        assertFalse(msg.contains("network connection", ignoreCase = true))
+    }
+
+    @Test
+    fun `light client not ready asks to wait, not to check network`() {
+        val msg = mapSendErrorMessage("Broadcast rejected: light client not ready (storage not initialized)")
+        assertTrue(msg.contains("starting up", ignoreCase = true))
+        assertFalse(msg.contains("network connection", ignoreCase = true))
+    }
+
+    @Test
+    fun `null-returned send no longer blames the network`() {
+        val msg = mapSendErrorMessage("Send failed - native returned null")
+        assertFalse(
+            "must not tell the user to check their network for a local failure",
+            msg.contains("network connection", ignoreCase = true),
+        )
+        assertTrue(msg.contains("reopen", ignoreCase = true) || msg.contains("try again", ignoreCase = true))
+    }
+
+    @Test
+    fun `existing build errors still map correctly`() {
+        assertEquals(
+            "Insufficient balance for this transaction.",
+            mapSendErrorMessage("Insufficient balance: have X, need Y"),
+        )
+        assertTrue(mapSendErrorMessage("Dust change refused: ...").contains("61 CKB"))
+        assertTrue(mapSendErrorMessage("Transfer amount must be at least 61 CKB (minimum cell capacity)").contains("Minimum"))
+    }
+
+    @Test
+    fun `null message falls back without crashing`() {
+        assertTrue(mapSendErrorMessage(null).isNotBlank())
+    }
+}

--- a/external/ckb-light-client/light-client-lib/src/jni_bridge/query.rs
+++ b/external/ckb-light-client/light-client-lib/src/jni_bridge/query.rs
@@ -34,6 +34,23 @@ macro_rules! check_running {
     };
 }
 
+/// Sentinel prefix marking a send-transaction error string returned to Kotlin.
+/// Success returns the JSON-quoted tx hash ("0x..."); an error returns
+/// `__SEND_ERROR__:<reason>` so the caller can surface the real cause instead
+/// of collapsing a null into a misleading "check your network" message.
+const SEND_ERROR_PREFIX: &str = "__SEND_ERROR__:";
+
+/// Build the sentinel error jstring for nativeSendTransaction failures.
+fn send_error_jstring(env: &mut JNIEnv, reason: &str) -> jstring {
+    match env.new_string(format!("{}{}", SEND_ERROR_PREFIX, reason)) {
+        Ok(s) => s.into_raw(),
+        Err(e) => {
+            error!("Failed to create send-error JString: {}", e);
+            ptr::null_mut()
+        }
+    }
+}
+
 /// Helper to create JString from serde result
 fn to_jstring<T: serde::Serialize>(env: &mut JNIEnv, value: &T) -> jstring {
     match serde_json::to_string(value) {
@@ -927,7 +944,7 @@ pub extern "C" fn Java_com_nervosnetwork_ckblightclient_LightClientNative_native
         Ok(s) => s.into(),
         Err(e) => {
             error!("Failed to get transaction string: {}", e);
-            return ptr::null_mut();
+            return send_error_jstring(&mut env, &format!("could not read transaction: {}", e));
         }
     };
 
@@ -935,7 +952,7 @@ pub extern "C" fn Java_com_nervosnetwork_ckblightclient_LightClientNative_native
         Ok(t) => t,
         Err(e) => {
             error!("Failed to parse transaction JSON: {}", e);
-            return ptr::null_mut();
+            return send_error_jstring(&mut env, &format!("malformed transaction: {}", e));
         }
     };
 
@@ -943,7 +960,7 @@ pub extern "C" fn Java_com_nervosnetwork_ckblightclient_LightClientNative_native
         Some(s) => s,
         None => {
             error!("Storage not initialized");
-            return ptr::null_mut();
+            return send_error_jstring(&mut env, "light client not ready (storage not initialized)");
         }
     };
 
@@ -951,7 +968,7 @@ pub extern "C" fn Java_com_nervosnetwork_ckblightclient_LightClientNative_native
         Some(c) => Arc::clone(c),
         None => {
             error!("Consensus not initialized");
-            return ptr::null_mut();
+            return send_error_jstring(&mut env, "light client not ready (consensus not initialized)");
         }
     };
 
@@ -964,8 +981,11 @@ pub extern "C" fn Java_com_nervosnetwork_ckblightclient_LightClientNative_native
     let cycles = match verify_tx(tx_view.clone(), swc, consensus, &last_state) {
         Ok(c) => c,
         Err(e) => {
+            // Return the real reason (e.g. Unknown(OutPoint) for an
+            // unresolvable input, Dead, capacity, or a script error) so the
+            // caller can show it instead of a misleading network message.
             error!("Transaction verification failed: {:?}", e);
-            return ptr::null_mut();
+            return send_error_jstring(&mut env, &format!("verification failed: {:?}", e));
         }
     };
 


### PR DESCRIPTION
## Report (Alex, Telegram)
"Transaction Failed — Could not broadcast transaction. Please check your network connection and try again." **persistently**, across wifi, cell, and reboot, sending 15000 CKB with 162k available. Deterministic, not network.

## Root cause (verified in code)
To allow rapid back-to-back sends, `buildReserveAndSend` injects **synthetic change cells** (blockNumber `0x0`) from persisted `pending_broadcasts` rows into coin selection, and `selectCells` sorts **largest-first** — so a large change cell from a prior send is picked as the **first input**. That synthetic input only resolves if its creating tx is in the light client's **in-memory pending pool**, which is **wiped on every app restart**. The `pending_broadcasts` table persists. So after a reboot with a stuck/unconfirmed prior send, every new send selects that stale synthetic input, the light client can't resolve it, local verification fails, the JNI returns null, and the UI shows the generic network message. Reboots/network changes can't fix it. (Likely chained from Alex's earlier stuck 150k send.)

Second problem: the **real reason was discarded** — Rust logged `verification failed: Unknown(OutPoint…)` then returned null; Kotlin collapsed null into "check your network."

## Fixes
**1. Stop the poison (Kotlin, the actual bug):** only inject synthetic change from sends broadcast in the **current process session** (tracked in-memory, populated on a successful broadcast). A persisted row from a prior session can no longer be selected as an input. The reservation filter still uses ALL pending rows (no double-spend). Also dedup available cells by outpoint (prefer the real on-chain cell) so a confirmed tx's change can't appear twice.

**2. Surface the real reason (Rust JNI + Kotlin):** `nativeSendTransaction` now returns `__SEND_ERROR__:<reason>` instead of null on rejection (verification/parse/not-ready), carrying the actual cause (e.g. `Unknown(OutPoint)`). `sendTransaction` propagates it; `mapSendErrorMessage` (extracted, pure, tested) maps causes to actionable copy and **no longer blames the network** for local failures — e.g. an unresolvable input now reads "This send depends on a previous transaction that hasn't confirmed yet…".

## Tests / verification
- `SendErrorMessageTest` (6, RED-verified): Unknown→pending-blocking, Dead→already-spent, not-ready→wait, null→no-network-blame, existing build errors preserved, null-safe.
- Full `testDebugUnitTest` green. Rust `cargo check` clean.
- Device: rebuilt JNI loads + initializes cleanly, onboarding→Home passes on the new lib (arm64 emulator). A live on-chain reject isn't reproducible here (no funds/8114); the path is code-verified + unit-tested.

## For Alex (immediate relief, until this ships)
He likely has a stuck **Pending** send. Clearing app data + re-importing from seed (wipes the stale `pending_broadcasts` record) will let sends work; keeping the app open ~10 min may also let the watchdog time the stuck tx out.

Refs the Telegram broadcast-failure report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Send errors now show clearer, more actionable messages instead of generic failures.
  * Transactions are now tracked more reliably during the current app session.

* **Bug Fixes**
  * Fixed duplicate spend inputs during sending by preferring the real cell when both versions appear.
  * Prevented synthetic change from being reused after restarting the app.
  * Improved handling of broadcast rejections so failed sends are cleaned up properly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->