### PR TITLE
fix(read): classify null JNI reads as not-ready vs transient

### DIFF
--- a/android/app/src/main/java/com/rjnr/pocketnode/data/gateway/GatewayRepository.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/gateway/GatewayRepository.kt
@@ -833,7 +833,7 @@ class GatewayRepository @Inject constructor(
         Log.d(TAG, "🔍 Fetching balance for script args ${searchKey.script.args.redactAddress()}")
 
         val responseJson = LightClientNative.nativeGetCellsCapacity(json.encodeToString(searchKey))
-            ?: throw Exception("Failed to get capacity - null response")
+            ?: throw Exception(readPathNullMessage("get balance", lightClientReadyForRead()))
 
         Log.d(TAG, "📊 Raw capacity response: $responseJson")
 
@@ -1110,7 +1110,7 @@ class GatewayRepository @Inject constructor(
             "desc",
             limit,
             cursor
-        ) ?: throw Exception("Failed to get cells - native returned null")
+        ) ?: throw Exception(readPathNullMessage("get cells", lightClientReadyForRead()))
 
         Log.d(TAG, "📦 getCells: Raw response length: ${resultJson.length}")
 
@@ -1139,6 +1139,17 @@ class GatewayRepository @Inject constructor(
     }
 
     private suspend fun currentTipNumberOrZero(): Long = lightClient.currentTipNumberOrZero()
+
+    /**
+     * Readiness probe for the read-path null classifier ([readPathNullMessage]).
+     * A tip header means the light client is up and reporting chain state; its
+     * absence means cold start / still starting up. Only ever called on an
+     * already-failed read, so the extra JNI hop is off the hot path. Any
+     * exception here is treated as "not ready" so we never upgrade a real
+     * outage into a misleading transient message.
+     */
+    private suspend fun lightClientReadyForRead(): Boolean =
+        runCatching { lightClient.getTipHeader() != null }.getOrDefault(false)
 
     /**
      * Single mutex-guarded prepare-and-send shared by plain transfers and DAO

--- a/android/app/src/main/java/com/rjnr/pocketnode/data/gateway/ReadPathError.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/gateway/ReadPathError.kt
@@ -1,0 +1,30 @@
+package com.rjnr.pocketnode.data.gateway
+
+/**
+ * Read-path null classification (#365 follow-up).
+ *
+ * The light client returns `null` from a query for two very different
+ * reasons, and the caller can't tell them apart from the null alone:
+ *
+ *  1. It hasn't reported a tip header yet — cold start, still starting up,
+ *     or mid-restart. Any read is expected to be empty; the user just needs
+ *     to wait.
+ *  2. It IS up (a tip is present) but this one read came back empty — a
+ *     transient RPC hiccup worth a retry.
+ *
+ * Before this, both threw the same "native returned null" text, which
+ * `mapSendErrorMessage` fell through to the reopen-the-app copy — actionable,
+ * but wrong when the node was merely still syncing. This produces a message
+ * whose wording routes correctly:
+ *  - not ready -> contains "light client not ready" -> "still starting up"
+ *  - ready     -> names the [operation] so the next bug report is diagnosable.
+ *
+ * Pure so it's unit-testable without JNI; the readiness probe stays at the
+ * call site.
+ */
+internal fun readPathNullMessage(operation: String, lightClientReady: Boolean): String =
+    if (!lightClientReady) {
+        "light client not ready (no tip yet) while trying to $operation"
+    } else {
+        "Failed to $operation - light client returned no data (transient); please try again"
+    }

--- a/android/app/src/test/java/com/rjnr/pocketnode/data/gateway/ReadPathErrorTest.kt
+++ b/android/app/src/test/java/com/rjnr/pocketnode/data/gateway/ReadPathErrorTest.kt
@@ -1,0 +1,35 @@
+package com.rjnr.pocketnode.data.gateway
+
+import com.rjnr.pocketnode.ui.screens.send.mapSendErrorMessage
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * A null read must say WHY: still syncing vs a transient hiccup. Neither may
+ * blame the network (the Alex-report mistake). The not-ready branch must also
+ * carry the token `mapSendErrorMessage` routes to the "still starting up" copy.
+ */
+class ReadPathErrorTest {
+
+    @Test
+    fun `not ready names the wait, never the network`() {
+        val msg = readPathNullMessage("read cells", lightClientReady = false)
+        assertTrue(msg.contains("light client not ready", ignoreCase = true))
+        assertFalse(msg.contains("network connection", ignoreCase = true))
+    }
+
+    @Test
+    fun `ready but null names the operation and calls it transient`() {
+        val msg = readPathNullMessage("read balance", lightClientReady = true)
+        assertTrue(msg.contains("read balance", ignoreCase = true))
+        assertTrue(msg.contains("transient", ignoreCase = true))
+        assertFalse(msg.contains("network connection", ignoreCase = true))
+    }
+
+    @Test
+    fun `not ready message routes to the starting-up user copy`() {
+        val raw = readPathNullMessage("read cells", lightClientReady = false)
+        assertTrue(mapSendErrorMessage(raw).contains("starting up", ignoreCase = true))
+    }
+}


### PR DESCRIPTION
## Summary
Follow-up to #365. `getCells` and `getCellsCapacity` threw a generic `native returned null` on any empty read, which `mapSendErrorMessage` fell through to the reopen-the-app copy — even when the light client was merely still starting up (no tip yet). Same class of misleading error as the Alex broadcast report.

## Change
- New pure `readPathNullMessage(operation, lightClientReady)` classifier (unit-tested, no JNI).
- `lightClientReadyForRead()` tip-header probe — only runs on an already-failed read, off the hot path; any exception is treated as not-ready so a real outage never gets downgraded to "transient".
- Not-ready → routes to "still starting up". Ready-but-null → names the operation, calls it transient (diagnosable next report).
- `getTransactionStatus` deliberately untouched: it returns `"unknown"` and the `BroadcastWatchdog` depends on that classification.

## Tests
- `ReadPathErrorTest` (3): not-ready never blames the network + carries the routing token; ready-but-null names the op + "transient"; not-ready maps to the starting-up user copy.
- Full `testDebugUnitTest` suite green; no success-path behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved balance and cell fetching error messages to distinguish between a not-yet-ready client and a transient read issue.
  * User-facing messages now better reflect whether the app is still starting up or whether a read request returned no data.
* **Tests**
  * Added coverage for the new error-message behavior, including readiness checks and startup messaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->