### PR TITLE
fix(backup): sub-account 'Got it' no longer dead-ends (#372)

### DIFF
--- a/android/app/src/main/java/com/rjnr/pocketnode/data/gateway/GatewayRepository.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/gateway/GatewayRepository.kt
@@ -613,6 +613,16 @@ class GatewayRepository @Inject constructor(
      * Used by MainActivity to gate access to the dashboard until backup is done.
      */
     suspend fun needsMnemonicBackup(): Boolean {
+        // Sub-accounts are derived from the parent's seed and have no
+        // independent mnemonic to back up; they inherit the parent's backup
+        // status. Never prompt them to back up. Besides being wrong, this used
+        // to make the sub-account backup notice the nav START destination,
+        // where its "Got it" button (popBackStack) no-oped on an empty back
+        // stack and the user was stuck (#372).
+        val activeWallet = walletDao.getActive()
+            ?: activeWalletId.takeIf { it.isNotBlank() }?.let { walletDao.getById(it) }
+        if (activeWallet?.parentWalletId != null) return false
+
         return resolveActiveWalletType() == KeyManager.WALLET_TYPE_MNEMONIC
             && !hasMnemonicBackupForActiveWallet()
     }

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/navigation/NavGraph.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/navigation/NavGraph.kt
@@ -170,7 +170,18 @@ fun CkbNavGraph(
                         launchSingleTop = true
                     }
                 },
-                onNavigateBack = { navController.popBackStack() },
+                onNavigateBack = {
+                    // Fall back to a safe destination when there's nothing to
+                    // pop. The sub-account backup notice can be the START
+                    // destination, where popBackStack() no-ops and the "Got it"
+                    // button appeared dead (#372).
+                    if (!navController.popBackStack()) {
+                        navController.navigate(destinationAfterWalletReady()) {
+                            popUpTo(Screen.MnemonicBackup.BASE) { inclusive = true }
+                            launchSingleTop = true
+                        }
+                    }
+                },
                 onNavigateToPinVerify = {
                     navController.navigate(Screen.PinEntry.createRoute("verify"))
                 },


### PR DESCRIPTION
Fixes #372.

## Bug
On the sub-account **Back Up Your Wallet** notice, tapping **Got it** does nothing.

## Root cause
`needsMnemonicBackup()` checked wallet type but not `parentWalletId`. A sub-account has no independent seed to back up (it inherits the parent's backup), yet it reported `true`. That made the sub-account backup notice the navigation **start destination**, where its "Got it" button (`popBackStack()`) no-oped on an empty back stack.

## Fix
- Exclude sub-accounts from `needsMnemonicBackup()`. Also stops sub-accounts being nagged to back up.
- `MnemonicBackup` `onNavigateBack` now falls back to a safe destination when the back stack is empty, so "Got it"/back can never be a no-op (defense in depth).

## Verification
Compiles clean. Device check: create a sub-account, open its backup notice, tap Got it → returns to Home; sub-account no longer shows a backup prompt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved mnemonic backup prompts so they no longer appear for sub-accounts.
  * Made the back action from the mnemonic backup screen more reliable by sending users to a fallback destination when there’s nothing to go back to.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->