### PR TITLE
fix(auth): clear PIN lockout recovery path + honest copy (#373, #370)

### DIFF
--- a/android/app/src/main/java/com/rjnr/pocketnode/data/auth/PinManager.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/auth/PinManager.kt
@@ -27,6 +27,14 @@ import org.bouncycastle.crypto.params.Argon2Parameters
  * 24 hours of no failures (the "decay window"), or when the user explicitly
  * re-sets their PIN via `setPin`. Lockout duration escalates with attempt
  * count up to a permanent lockout at 10+ failures.
+ *
+ * The counter (and lockout state) live in EncryptedSharedPreferences, which
+ * survive an app upgrade / overwrite install by design (#370). Resetting it
+ * on reinstall would let an attacker sideload a build to clear the count and
+ * keep brute-forcing, so it deliberately persists across upgrades. When
+ * attempts run out, the recovery path is "reset and restore from seed"
+ * (surfaced by [com.rjnr.pocketnode.ui.screens.auth.PinEntryScreen], #373),
+ * not a counter reset.
  */
 @Singleton
 class PinManager @Inject constructor(

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/auth/PinEntryScreen.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/auth/PinEntryScreen.kt
@@ -17,6 +17,8 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.CircleShape
 import com.composables.icons.lucide.*
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FilledTonalButton
 import androidx.compose.material3.Icon
@@ -85,6 +87,45 @@ fun PinEntryScreen(
     }
 
     val showBackArrow = mode == PinMode.SETUP || mode == PinMode.CONFIRM
+
+    // Recovery escape hatch when the user runs out of PIN attempts. Points
+    // straight at "reset and restore from seed" so a locked-out user is never
+    // stuck on the keypad with no way forward (#373).
+    if (uiState.showRecoveryDialog) {
+        AlertDialog(
+            onDismissRequest = { viewModel.dismissRecoveryDialog() },
+            title = {
+                Text(
+                    if (uiState.isPermanentlyLocked) "Wallet locked"
+                    else "Out of PIN attempts"
+                )
+            },
+            text = {
+                Text(
+                    if (uiState.isPermanentlyLocked) {
+                        "Too many incorrect PIN attempts. To regain access, reset this wallet and restore it from your recovery phrase. Your funds are safe as long as you have your recovery phrase."
+                    } else {
+                        "You've used all your PIN attempts for now. You can wait for the timer and try again, or reset this wallet and restore it from your recovery phrase. Your funds are safe as long as you have your recovery phrase."
+                    }
+                )
+            },
+            confirmButton = {
+                Button(onClick = {
+                    viewModel.dismissRecoveryDialog()
+                    onForgotPin()
+                }) {
+                    Text("Reset & restore")
+                }
+            },
+            dismissButton = {
+                if (!uiState.isPermanentlyLocked) {
+                    TextButton(onClick = { viewModel.dismissRecoveryDialog() }) {
+                        Text("Wait and try again")
+                    }
+                }
+            }
+        )
+    }
 
     Scaffold(
         containerColor = MaterialTheme.colorScheme.surface,
@@ -169,6 +210,13 @@ fun PinEntryScreen(
                         )
                     }
                 }
+                uiState.isPermanentlyLocked -> {
+                    Text(
+                        text = "Too many attempts. Reset and restore from your recovery phrase to regain access.",
+                        color = MaterialTheme.colorScheme.error,
+                        style = MaterialTheme.typography.bodySmall
+                    )
+                }
                 uiState.isLockedOut -> {
                     Text(
                         text = "Too many attempts. Try again in ${uiState.lockoutRemainingSeconds}s",
@@ -179,6 +227,13 @@ fun PinEntryScreen(
                 uiState.errorMessage != null -> {
                     Text(
                         text = uiState.errorMessage.orEmpty(),
+                        color = MaterialTheme.colorScheme.error,
+                        style = MaterialTheme.typography.bodySmall
+                    )
+                }
+                mode == PinMode.VERIFY && uiState.remainingAttempts == 0 -> {
+                    Text(
+                        text = "No attempts left right now. Wait for the timer, or reset and restore from your recovery phrase.",
                         color = MaterialTheme.colorScheme.error,
                         style = MaterialTheme.typography.bodySmall
                     )
@@ -247,10 +302,23 @@ fun PinEntryScreen(
                 Spacer(modifier = Modifier.height(12.dp))
             }
 
-            // Forgot PIN
+            // Forgot PIN / recovery. Becomes a prominent button once attempts
+            // run low so the escape hatch is obvious under stress (#373);
+            // stays a subtle text link otherwise.
             if (mode == PinMode.VERIFY) {
-                TextButton(onClick = onForgotPin) {
-                    Text("Forgot PIN?")
+                val recoveryProminent = uiState.isPermanentlyLocked ||
+                    uiState.remainingAttempts <= 2
+                if (recoveryProminent) {
+                    Button(
+                        onClick = onForgotPin,
+                        modifier = Modifier.fillMaxWidth()
+                    ) {
+                        Text("Forgot PIN? Reset & restore from seed")
+                    }
+                } else {
+                    TextButton(onClick = onForgotPin) {
+                        Text("Forgot PIN?")
+                    }
                 }
             }
 

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/auth/PinViewModel.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/auth/PinViewModel.kt
@@ -26,6 +26,14 @@ data class PinUiState(
     val isLockedOut: Boolean = false,
     val lockoutRemainingSeconds: Int = 0,
     val remainingAttempts: Int = PinManager.MAX_ATTEMPTS,
+    /** True at the permanent-lockout threshold (10+ failures): no countdown, recovery only. */
+    val isPermanentlyLocked: Boolean = false,
+    /**
+     * Drives the recovery popup that points the user at "reset and restore
+     * from seed" once they run out of attempts. Set when attempts hit zero or
+     * on permanent lock, so the escape hatch is impossible to miss (#373).
+     */
+    val showRecoveryDialog: Boolean = false,
     val pinComplete: Boolean = false,
     /**
      * True while the Argon2id KDF is computing the PIN hash. The PIN entry
@@ -137,16 +145,23 @@ class PinViewModel @Inject constructor(
                     }
 
                     _uiState.update { it.copy(isVerifying = false) }
+                    val remaining = pinManager.getRemainingAttempts()
+                    // Surface the recovery popup the moment attempts run out, so
+                    // the user is never staring at a keypad with no way forward.
+                    val outOfAttempts = remaining == 0 || pinManager.isPermanentlyLocked()
                     if (pinManager.isLockedOut()) {
+                        if (outOfAttempts) {
+                            _uiState.update { it.copy(showRecoveryDialog = true) }
+                        }
                         startLockoutTimer()
                     } else {
-                        val remaining = pinManager.getRemainingAttempts()
                         _uiState.update {
                             it.copy(
                                 isError = true,
                                 errorMessage = "Wrong PIN. $remaining attempts remaining.",
                                 enteredDigits = "",
-                                remainingAttempts = remaining
+                                remainingAttempts = remaining,
+                                showRecoveryDialog = it.showRecoveryDialog || outOfAttempts
                             )
                         }
                         delay(500)
@@ -169,11 +184,17 @@ class PinViewModel @Inject constructor(
         if (pinManager.isLockedOut()) {
             startLockoutTimer()
         } else {
+            val remaining = pinManager.getRemainingAttempts()
             _uiState.update {
                 it.copy(
                     isLockedOut = false,
+                    isPermanentlyLocked = pinManager.isPermanentlyLocked(),
                     lockoutRemainingSeconds = 0,
-                    remainingAttempts = pinManager.getRemainingAttempts()
+                    remainingAttempts = remaining,
+                    // Re-open the recovery prompt for a user who returns to the
+                    // screen already out of attempts.
+                    showRecoveryDialog = it.showRecoveryDialog ||
+                        remaining == 0 || pinManager.isPermanentlyLocked()
                 )
             }
         }
@@ -181,7 +202,21 @@ class PinViewModel @Inject constructor(
 
     private fun startLockoutTimer() {
         lockoutTimerJob?.cancel()
-        _uiState.update { it.copy(isLockedOut = true, enteredDigits = "", errorMessage = null) }
+        val permanent = pinManager.isPermanentlyLocked()
+        _uiState.update {
+            it.copy(
+                isLockedOut = true,
+                isPermanentlyLocked = permanent,
+                enteredDigits = "",
+                errorMessage = null,
+                showRecoveryDialog = it.showRecoveryDialog || permanent
+            )
+        }
+        if (permanent) {
+            // No countdown: the lockout never expires. Recovery (reset +
+            // restore from seed) is the only path forward.
+            return
+        }
         lockoutTimerJob = viewModelScope.launch {
             while (pinManager.isLockedOut()) {
                 val remainingMs = pinManager.getLockoutRemainingMs()
@@ -198,5 +233,9 @@ class PinViewModel @Inject constructor(
                 )
             }
         }
+    }
+
+    fun dismissRecoveryDialog() {
+        _uiState.update { it.copy(showRecoveryDialog = false) }
     }
 }


### PR DESCRIPTION
Fixes #373. Addresses #370 (documented as intended).

## #373 — locked-out wallet looked unrecoverable
The recovery path (Forgot PIN -> reset + restore from seed) already existed and was wired correctly, but the screen hid it:
- "0 attempts remaining" was shown at the first 30s timeout, implying a permanent wall. The lockout is actually a rolling escalation (30s -> 1m -> 5m -> 30m -> 1h -> permanent at 10) and the keypad re-enables after each timeout.
- "Forgot PIN?" was a small text link, easy to miss under stress.
- No explicit permanent-lock handling (countdown would show a giant number).

### Changes
- **Recovery popup** the moment attempts hit zero (or on permanent lock), pointing straight at "Reset & restore from seed".
- **Prominent recovery button** (full-width) once attempts run low (<= 2 or permanent); subtle link otherwise.
- **Honest copy**: separate messages for permanent lock, the rolling timeout, and the transient out-of-attempts state.
- Track `isPermanentlyLocked` so the UI stops showing a countdown once the lock never expires.

## #370 — counter persists across overwrite install
Documented as intended in `PinManager` KDoc: the failed-attempt counter lives in EncryptedSharedPreferences and survives upgrades on purpose (resetting on reinstall would enable a sideload-to-reset brute-force bypass). The #373 copy/recovery work removes the confusion.

## Verification
Compiles clean; PIN unit tests pass. Device check: fail PIN to 0 -> recovery popup + prominent button appear; "Reset & restore" routes to the destructive-recovery screen; correct PIN before lockout still unlocks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)