### PR TITLE
feat(settings): surface update availability in About > Version (#369)

### DIFF
--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/settings/SettingsScreen.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/settings/SettingsScreen.kt
@@ -363,6 +363,7 @@ fun SettingsScreen(
             viewModel.requestNetworkSwitch(it)
         },
         showThemeDialog = { viewModel.showThemeDialog() },
+        onCheckForUpdate = { viewModel.checkForUpdate() },
         onToggleBackgroundSync = { enabled ->
             if (enabled && Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
                 val hasPermission = ContextCompat.checkSelfPermission(
@@ -395,6 +396,7 @@ private fun SettingsScreenUI(
     showSyncStrategyDialog: () -> Unit = {},
     requestNetworkSwitch: (NetworkType) -> Unit,
     showThemeDialog: () -> Unit,
+    onCheckForUpdate: () -> Unit = {},
     onToggleBackgroundSync: (Boolean) -> Unit = {}
 ) {
     Scaffold(
@@ -558,14 +560,57 @@ private fun SettingsScreenUI(
             }
 
             item {
+                val updateStatus = uiState.updateStatus
+                val available = updateStatus as? SettingsViewModel.UpdateStatus.Available
                 SettingsValueRow(
                     icon = Lucide.Info,
                     title = "Version",
                     value = BuildConfig.VERSION_NAME,
-                    onClick = null,
-                    trailing = if (BuildConfig.DEBUG) {
-                        { DebugBuildPill(gitSha = BuildConfig.GIT_SHA) }
-                    } else null
+                    // Tapping the row when an update exists opens the release so
+                    // the user can grab it; otherwise it's a static row.
+                    onClick = available?.let { { com.rjnr.pocketnode.ui.util.openInBrowser(context, it.url) } },
+                    trailing = when {
+                        available != null -> {
+                            {
+                                Text(
+                                    text = "Update available",
+                                    color = MaterialTheme.colorScheme.primary,
+                                    fontSize = 12.sp,
+                                    fontWeight = FontWeight.SemiBold
+                                )
+                            }
+                        }
+                        BuildConfig.DEBUG -> {
+                            { DebugBuildPill(gitSha = BuildConfig.GIT_SHA) }
+                        }
+                        else -> null
+                    }
+                )
+            }
+
+            item {
+                val updateStatus = uiState.updateStatus
+                val statusText = when (updateStatus) {
+                    is SettingsViewModel.UpdateStatus.Checking -> "Checking..."
+                    is SettingsViewModel.UpdateStatus.UpToDate -> "Up to date"
+                    is SettingsViewModel.UpdateStatus.Available ->
+                        "Version ${updateStatus.version} available"
+                    is SettingsViewModel.UpdateStatus.Failed -> "Couldn't check. Tap to retry"
+                    is SettingsViewModel.UpdateStatus.Idle -> null
+                }
+                SettingsValueRow(
+                    icon = Lucide.RefreshCw,
+                    title = "Check for updates",
+                    value = statusText.orEmpty(),
+                    valueColor = MaterialTheme.colorScheme.onSurfaceVariant,
+                    onClick = {
+                        val available = updateStatus as? SettingsViewModel.UpdateStatus.Available
+                        if (available != null) {
+                            com.rjnr.pocketnode.ui.util.openInBrowser(context, available.url)
+                        } else {
+                            onCheckForUpdate()
+                        }
+                    }
                 )
             }
 

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/settings/SettingsViewModel.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/settings/SettingsViewModel.kt
@@ -2,8 +2,10 @@ package com.rjnr.pocketnode.ui.screens.settings
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.rjnr.pocketnode.BuildConfig
 import com.rjnr.pocketnode.data.auth.PinManager
 import com.rjnr.pocketnode.data.gateway.GatewayRepository
+import com.rjnr.pocketnode.data.update.UpdateRepository
 import com.rjnr.pocketnode.data.gateway.models.NetworkType
 import com.rjnr.pocketnode.data.gateway.models.SyncMode
 import com.rjnr.pocketnode.data.wallet.SyncStrategy
@@ -23,8 +25,18 @@ class SettingsViewModel @Inject constructor(
     private val repository: GatewayRepository,
     private val walletPrefs: WalletPreferences,
     private val pinManager: PinManager,
-    private val walletRepository: WalletRepository
+    private val walletRepository: WalletRepository,
+    private val updateRepository: UpdateRepository,
 ) : ViewModel() {
+
+    /** Update-availability state for the About > Version row (#369). */
+    sealed interface UpdateStatus {
+        data object Idle : UpdateStatus
+        data object Checking : UpdateStatus
+        data object UpToDate : UpdateStatus
+        data class Available(val version: String, val url: String) : UpdateStatus
+        data object Failed : UpdateStatus
+    }
 
     data class UiState(
         val isPinEnabled: Boolean = false,
@@ -43,6 +55,7 @@ class SettingsViewModel @Inject constructor(
         // Active wallet address — used by SyncOptionsDialog's "look up on explorer"
         // helper for the CUSTOM mode (#85). Null until the wallet is initialized.
         val address: String? = null,
+        val updateStatus: UpdateStatus = UpdateStatus.Idle,
         val error: com.rjnr.pocketnode.ui.util.UiMessage? = null,
     )
 
@@ -51,6 +64,7 @@ class SettingsViewModel @Inject constructor(
 
     init {
         loadState()
+        checkForUpdate()
 
         // Keep network in sync with repository's live StateFlow
         viewModelScope.launch {
@@ -206,6 +220,36 @@ class SettingsViewModel @Inject constructor(
             repository.startBackgroundSync()
         } else {
             repository.stopBackgroundSync()
+        }
+    }
+
+    /**
+     * Check GitHub for a newer release and surface it on the About > Version
+     * row. Runs on init and on the manual "Check for updates" tap (#369). The
+     * Home screen already shows an update dialog; this puts the same signal
+     * where users look for it. Non-fatal: failures show a retry-able state.
+     */
+    fun checkForUpdate() {
+        _uiState.update { it.copy(updateStatus = UpdateStatus.Checking) }
+        viewModelScope.launch {
+            updateRepository.checkForUpdate(BuildConfig.VERSION_NAME)
+                .onSuccess { info ->
+                    _uiState.update {
+                        it.copy(
+                            updateStatus = if (info != null) {
+                                UpdateStatus.Available(
+                                    version = info.latestVersion,
+                                    url = info.downloadUrl,
+                                )
+                            } else {
+                                UpdateStatus.UpToDate
+                            }
+                        )
+                    }
+                }
+                .onFailure {
+                    _uiState.update { it.copy(updateStatus = UpdateStatus.Failed) }
+                }
         }
     }
 


### PR DESCRIPTION
Fixes #369.

## Context
The app already checks GitHub `releases/latest` on the Home screen and pops an update dialog when a newer version exists (`isNewer` compare + APK asset lookup). But the tester looked in **Settings > About > Version**, which had no update indicator, so it seemed like the app wasn't checking.

## Change
- `SettingsViewModel` checks for a newer release on open (reusing `UpdateRepository`) and exposes an `UpdateStatus` (Idle / Checking / UpToDate / Available / Failed).
- The **Version** row shows an "Update available" indicator and opens the release when tapped.
- New **Check for updates** row runs the check manually and shows Checking / Up to date / "Version x.y.z available" / retry.

Home update dialog is unchanged; this just puts the same signal where users look.

## Verification
Compiles clean; full unit suite passes. Device check: on an older build, Settings shows "Update available" and the manual check reports status.

🤖 Generated with [Claude Code](https://claude.com/claude-code)