### PR TITLE
feat(wallet): HD sub-account discovery phase 1 — candidates at import (#82, #371)

### DIFF
--- a/android/app/src/main/java/com/rjnr/pocketnode/data/database/AppDatabase.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/database/AppDatabase.kt
@@ -15,6 +15,7 @@ import com.rjnr.pocketnode.data.database.dao.WalletDao
 import com.rjnr.pocketnode.data.database.entity.BalanceCacheEntity
 import com.rjnr.pocketnode.data.database.entity.ContactEntity
 import com.rjnr.pocketnode.data.database.entity.PendingDaoWithdrawEntity
+import com.rjnr.pocketnode.data.database.entity.SubAccountCandidateEntity
 import com.rjnr.pocketnode.data.database.entity.DaoCellEntity
 import com.rjnr.pocketnode.data.database.entity.HeaderCacheEntity
 import com.rjnr.pocketnode.data.database.entity.KeyMaterialEntity
@@ -35,6 +36,7 @@ import com.rjnr.pocketnode.data.database.entity.WalletEntity
         PendingBroadcastEntity::class,
         ContactEntity::class,
         PendingDaoWithdrawEntity::class,
+        SubAccountCandidateEntity::class,
     ],
     // Bumped from 8 to 9 in v1.5.2 because TransactionEntity / BalanceCacheEntity
     // / DaoCellEntity gained @Index(idx_tx_pending) + @ColumnInfo(defaultValue)
@@ -57,7 +59,11 @@ import com.rjnr.pocketnode.data.database.entity.WalletEntity
     // Bumped from 11 to 12 for #347: adds the `pending_dao_withdraws` table —
     // durable marker for an in-flight DAO phase-1 withdraw. MIGRATION_11_12 is
     // a single CREATE TABLE + 1 CREATE INDEX.
-    version = 12,
+    //
+    // Bumped from 12 to 13 for #82 phase 1: adds `sub_account_candidates`
+    // (HD discovery slots recorded at parent import). MIGRATION_12_13 is a
+    // single CREATE TABLE.
+    version = 13,
     // Schema export deliberately OFF until the Room 2.8.4 / kotlinx-serialization
     // 1.8.0 binary incompatibility is resolved (tracked in #149). Enabling it
     // crashes KSP with AbstractMethodError in Room's bundled
@@ -79,4 +85,5 @@ abstract class AppDatabase : RoomDatabase() {
     abstract fun pendingBroadcastDao(): PendingBroadcastDao
     abstract fun contactDao(): ContactDao
     abstract fun pendingDaoWithdrawDao(): PendingDaoWithdrawDao
+    abstract fun subAccountCandidateDao(): com.rjnr.pocketnode.data.database.dao.SubAccountCandidateDao
 }

--- a/android/app/src/main/java/com/rjnr/pocketnode/data/database/Migrations.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/database/Migrations.kt
@@ -469,3 +469,25 @@ val MIGRATION_10_11 = object : Migration(10, 11) {
         db.execSQL("CREATE INDEX IF NOT EXISTS `idx_contacts_walletId` ON `contacts` (`walletId`)")
     }
 }
+
+/**
+ * v13 (#82 phase 1): `sub_account_candidates` — derivable-but-unrestored HD
+ * sub-account slots recorded at parent mnemonic import. Public script args
+ * only; no key material. Single CREATE TABLE, no existing shape touched.
+ */
+val MIGRATION_12_13 = object : Migration(12, 13) {
+    override fun migrate(db: SupportSQLiteDatabase) {
+        db.execSQL(
+            """
+            CREATE TABLE IF NOT EXISTS `sub_account_candidates` (
+                `parentWalletId` TEXT NOT NULL,
+                `accountIndex` INTEGER NOT NULL,
+                `scriptArgs` TEXT NOT NULL,
+                `state` TEXT NOT NULL,
+                `createdAt` INTEGER NOT NULL,
+                PRIMARY KEY(`parentWalletId`, `accountIndex`)
+            )
+            """.trimIndent()
+        )
+    }
+}

--- a/android/app/src/main/java/com/rjnr/pocketnode/data/database/dao/SubAccountCandidateDao.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/database/dao/SubAccountCandidateDao.kt
@@ -1,0 +1,30 @@
+package com.rjnr.pocketnode.data.database.dao
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import com.rjnr.pocketnode.data.database.entity.SubAccountCandidateEntity
+
+@Dao
+interface SubAccountCandidateDao {
+
+    /** IGNORE: re-import of the same parent must not clobber FOUND/RESTORED states. */
+    @Insert(onConflict = OnConflictStrategy.IGNORE)
+    suspend fun insertAll(candidates: List<SubAccountCandidateEntity>)
+
+    @Query("SELECT * FROM sub_account_candidates WHERE parentWalletId = :parentId ORDER BY accountIndex ASC")
+    suspend fun getForParent(parentId: String): List<SubAccountCandidateEntity>
+
+    @Query("SELECT * FROM sub_account_candidates WHERE state = :state")
+    suspend fun getByState(state: String): List<SubAccountCandidateEntity>
+
+    @Query(
+        "UPDATE sub_account_candidates SET state = :state " +
+            "WHERE parentWalletId = :parentId AND accountIndex = :accountIndex"
+    )
+    suspend fun updateState(parentId: String, accountIndex: Int, state: String)
+
+    @Query("DELETE FROM sub_account_candidates WHERE parentWalletId = :parentId")
+    suspend fun deleteForParent(parentId: String)
+}

--- a/android/app/src/main/java/com/rjnr/pocketnode/data/database/entity/SubAccountCandidateEntity.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/database/entity/SubAccountCandidateEntity.kt
@@ -1,0 +1,34 @@
+package com.rjnr.pocketnode.data.database.entity
+
+import androidx.room.Entity
+
+/**
+ * A derivable-but-not-yet-restored sub-account slot recorded at parent
+ * mnemonic import (#82 / #371 phase 1). Holds ONLY the public lock-script
+ * args for m/44'/309'/{accountIndex}'/0/0 — never key material; keys are
+ * re-derived from the parent mnemonic if the user restores the slot.
+ *
+ * Lifecycle (phase 2 consumes these):
+ *  PENDING  -> registered for sync, activity unknown
+ *  FOUND    -> on-chain activity seen; offer one-tap restore
+ *  RESTORED -> user restored it (wallet row exists now)
+ *  EMPTY    -> sync completed with no activity; candidate retired
+ */
+@Entity(
+    tableName = "sub_account_candidates",
+    primaryKeys = ["parentWalletId", "accountIndex"],
+)
+data class SubAccountCandidateEntity(
+    val parentWalletId: String,
+    val accountIndex: Int,
+    val scriptArgs: String,
+    val state: String = STATE_PENDING,
+    val createdAt: Long,
+) {
+    companion object {
+        const val STATE_PENDING = "PENDING"
+        const val STATE_FOUND = "FOUND"
+        const val STATE_RESTORED = "RESTORED"
+        const val STATE_EMPTY = "EMPTY"
+    }
+}

--- a/android/app/src/main/java/com/rjnr/pocketnode/data/wallet/SubAccountDiscovery.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/wallet/SubAccountDiscovery.kt
@@ -1,0 +1,68 @@
+package com.rjnr.pocketnode.data.wallet
+
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Candidate derivation for HD sub-account discovery (#82 / #371).
+ *
+ * Sub-account N derives at m/44'/309'/N'/0/0 (the account index is the only
+ * variable — see [MnemonicManager.derivePrivateKey] and
+ * [WalletRepository.createSubAccount]). Restoring a parent seed therefore
+ * makes its sub-accounts *derivable*, but the embedded light client can only
+ * report history for scripts it has been told to sync. Discovery is a
+ * two-step dance:
+ *
+ *  1. At import, while the mnemonic is in memory, compute the lock-script
+ *     args for candidate indices 1..[CANDIDATE_WINDOW] (this class) and
+ *     persist them — args only, never key material.
+ *  2. Register those scripts for sync; once the filter sync has run, any
+ *     candidate with on-chain activity is offered to the user as a one-tap
+ *     restore (phase 2).
+ *
+ * Sub-account indices are assigned contiguously from 1 (max+1 on create), so
+ * a modest window covers real usage; the standard BIP44 gap-limit scan is
+ * unnecessary here and each extra registered script costs light-client sync
+ * time.
+ */
+@Singleton
+class SubAccountDiscovery @Inject constructor(
+    private val mnemonicManager: MnemonicManager,
+    private val keyManager: KeyManager,
+) {
+
+    /** A derivable sub-account slot: its BIP44 account index + lock args. */
+    data class Candidate(val accountIndex: Int, val scriptArgs: String)
+
+    /**
+     * Derive the candidate lock-script args for [window] sub-account indices
+     * (1-based; index 0 is the parent itself). Pure computation — no I/O, no
+     * key material retained beyond the call.
+     */
+    fun deriveCandidates(
+        words: List<String>,
+        passphrase: String = "",
+        window: Int = CANDIDATE_WINDOW,
+    ): List<Candidate> {
+        require(window > 0) { "window must be positive" }
+        val seed = mnemonicManager.mnemonicToSeed(words, passphrase)
+        return (1..window).map { index ->
+            val privateKey = mnemonicManager.derivePrivateKey(seed, accountIndex = index)
+            val publicKey = keyManager.derivePublicKey(privateKey)
+            privateKey.fill(0) // wipe: args are public, the key must not linger
+            Candidate(
+                accountIndex = index,
+                scriptArgs = keyManager.deriveLockScript(publicKey).args,
+            )
+        }
+    }
+
+    companion object {
+        /**
+         * Indices scanned per parent. Sub-accounts are created contiguously
+         * from 1, so 10 covers any realistic wallet; phase 2 can extend the
+         * window when the highest index in it turns out active.
+         */
+        const val CANDIDATE_WINDOW = 10
+    }
+}

--- a/android/app/src/main/java/com/rjnr/pocketnode/data/wallet/WalletRepository.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/wallet/WalletRepository.kt
@@ -32,6 +32,8 @@ class WalletRepository @Inject constructor(
     private val balanceCacheDao: BalanceCacheDao,
     private val daoCellDao: DaoCellDao,
     private val keyMaterialDao: KeyMaterialDao,
+    private val subAccountCandidateDao: com.rjnr.pocketnode.data.database.dao.SubAccountCandidateDao,
+    private val subAccountDiscovery: SubAccountDiscovery,
 ) {
     val walletsFlow: Flow<List<WalletEntity>> = walletDao.getAllFlow()
 
@@ -209,6 +211,23 @@ class WalletRepository @Inject constructor(
                 .onFailure { Log.e(TAG, "Rollback delete failed for $walletId", it) }
             throw e
         }
+
+        // #82 phase 1: record derivable sub-account slots while the mnemonic
+        // is in memory. Args only, no keys. Never allowed to fail the import —
+        // discovery is an enhancement, the wallet row above is the product.
+        runCatching {
+            val now2 = System.currentTimeMillis()
+            subAccountCandidateDao.insertAll(
+                subAccountDiscovery.deriveCandidates(words, passphrase).map {
+                    com.rjnr.pocketnode.data.database.entity.SubAccountCandidateEntity(
+                        parentWalletId = walletId,
+                        accountIndex = it.accountIndex,
+                        scriptArgs = it.scriptArgs,
+                        createdAt = now2,
+                    )
+                }
+            )
+        }.onFailure { Log.w(TAG, "Sub-account candidate derivation failed (non-fatal)", it) }
 
         Log.d(TAG, "Imported wallet: ${entity.walletId} (${entity.name})")
         entity

--- a/android/app/src/main/java/com/rjnr/pocketnode/di/AppModule.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/di/AppModule.kt
@@ -19,6 +19,7 @@ import com.rjnr.pocketnode.data.database.MIGRATION_8_9
 import com.rjnr.pocketnode.data.database.MIGRATION_9_10
 import com.rjnr.pocketnode.data.database.MIGRATION_10_11
 import com.rjnr.pocketnode.data.database.MIGRATION_11_12
+import com.rjnr.pocketnode.data.database.MIGRATION_12_13
 import com.rjnr.pocketnode.data.database.dao.BalanceCacheDao
 import com.rjnr.pocketnode.data.database.dao.ContactDao
 import com.rjnr.pocketnode.data.database.dao.DaoCellDao
@@ -130,7 +131,7 @@ object AppModule {
     fun provideAppDatabase(@ApplicationContext context: Context): AppDatabase =
         Room.databaseBuilder(context, AppDatabase::class.java, "pocket_node.db")
             .setJournalMode(RoomDatabase.JournalMode.WRITE_AHEAD_LOGGING)
-            .addMigrations(MIGRATION_1_2, MIGRATION_2_3, MIGRATION_3_4, MIGRATION_4_5, MIGRATION_5_6, MIGRATION_6_7, MIGRATION_7_8, MIGRATION_8_9, MIGRATION_9_10, MIGRATION_10_11, MIGRATION_11_12)
+            .addMigrations(MIGRATION_1_2, MIGRATION_2_3, MIGRATION_3_4, MIGRATION_4_5, MIGRATION_5_6, MIGRATION_6_7, MIGRATION_7_8, MIGRATION_8_9, MIGRATION_9_10, MIGRATION_10_11, MIGRATION_11_12, MIGRATION_12_13)
             .build()
 
     @Provides
@@ -152,6 +153,10 @@ object AppModule {
 
     @Provides
     fun provideWalletDao(db: AppDatabase): WalletDao = db.walletDao()
+
+    @Provides
+    fun provideSubAccountCandidateDao(db: AppDatabase): com.rjnr.pocketnode.data.database.dao.SubAccountCandidateDao =
+        db.subAccountCandidateDao()
 
     @Provides
     fun provideKeyMaterialDao(db: AppDatabase): KeyMaterialDao = db.keyMaterialDao()

--- a/android/app/src/test/java/com/rjnr/pocketnode/data/database/WalkingMigrationTest.kt
+++ b/android/app/src/test/java/com/rjnr/pocketnode/data/database/WalkingMigrationTest.kt
@@ -124,6 +124,21 @@ class WalkingMigrationTest {
     }
 
     /**
+     * #82 phase 1: a v10 file walked to v13 must gain the
+     * `sub_account_candidates` table (MIGRATION_12_13), with schema
+     * validation passing.
+     */
+    @Test
+    fun `walk to v13 creates sub_account_candidates table`() {
+        bootstrapV10()
+        openViaRoomAndValidate()
+        val db = openedRoomDb!!.openHelper.readableDatabase
+        db.query("SELECT name FROM sqlite_master WHERE type='table' AND name='sub_account_candidates'").use { c ->
+            assertTrue("sub_account_candidates table missing after MIGRATION_12_13", c.moveToNext())
+        }
+    }
+
+    /**
      * v1.6.x → v1.7.0 path: bootstrap a v9 SQLite file (no `kdfVersion`
      * column on `key_material`) and confirm MIGRATION_9_10 adds the
      * column with default 1, then Room schema validation passes.
@@ -168,7 +183,7 @@ class WalkingMigrationTest {
                 .addMigrations(
                     MIGRATION_1_2, MIGRATION_2_3, MIGRATION_3_4, MIGRATION_4_5,
                     MIGRATION_5_6, MIGRATION_6_7, MIGRATION_7_8, noOpMigration8To9,
-                    MIGRATION_9_10, MIGRATION_10_11, MIGRATION_11_12,
+                    MIGRATION_9_10, MIGRATION_10_11, MIGRATION_11_12, MIGRATION_12_13,
                 )
                 .build()
             openedRoomDb = db
@@ -198,7 +213,7 @@ class WalkingMigrationTest {
             .addMigrations(
                 MIGRATION_1_2, MIGRATION_2_3, MIGRATION_3_4, MIGRATION_4_5,
                 MIGRATION_5_6, MIGRATION_6_7, MIGRATION_7_8, MIGRATION_8_9,
-                MIGRATION_9_10, MIGRATION_10_11, MIGRATION_11_12,
+                MIGRATION_9_10, MIGRATION_10_11, MIGRATION_11_12, MIGRATION_12_13,
             )
             .build()
         openedRoomDb = db

--- a/android/app/src/test/java/com/rjnr/pocketnode/data/wallet/SubAccountDiscoveryTest.kt
+++ b/android/app/src/test/java/com/rjnr/pocketnode/data/wallet/SubAccountDiscoveryTest.kt
@@ -1,0 +1,82 @@
+package com.rjnr.pocketnode.data.wallet
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+/**
+ * Discovery derives candidate lock args at m/44'/309'/N'/0/0 for N=1..window.
+ * The contract that matters: deterministic (same seed -> same args, so a
+ * re-import finds the same sub-accounts), distinct per index, index 0 (the
+ * parent) excluded, and args match what createSubAccount would produce for
+ * the same index — otherwise discovery would look for the wrong scripts.
+ */
+@RunWith(RobolectricTestRunner::class)
+class SubAccountDiscoveryTest {
+
+    private lateinit var discovery: SubAccountDiscovery
+    private lateinit var mnemonicManager: MnemonicManager
+    private lateinit var keyManager: KeyManager
+
+    private val words =
+        "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about"
+            .split(" ")
+
+    @Before
+    fun setup() {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        mnemonicManager = MnemonicManager()
+        keyManager = KeyManager(context, mnemonicManager)
+        discovery = SubAccountDiscovery(mnemonicManager, keyManager)
+    }
+
+    @Test
+    fun `candidates are deterministic across calls`() {
+        val a = discovery.deriveCandidates(words)
+        val b = discovery.deriveCandidates(words)
+        assertEquals(a, b)
+    }
+
+    @Test
+    fun `window of N yields indices 1 through N with distinct args`() {
+        val candidates = discovery.deriveCandidates(words, window = 5)
+        assertEquals((1..5).toList(), candidates.map { it.accountIndex })
+        assertEquals(5, candidates.map { it.scriptArgs }.toSet().size)
+        candidates.forEach { assertTrue(it.scriptArgs.startsWith("0x")) }
+    }
+
+    @Test
+    fun `parent index 0 is not a candidate`() {
+        val parentArgs = keyManager
+            .deriveLockScript(
+                keyManager.derivePublicKey(mnemonicManager.mnemonicToPrivateKey(words))
+            )
+            .args
+        discovery.deriveCandidates(words).forEach {
+            assertNotEquals(parentArgs, it.scriptArgs)
+        }
+    }
+
+    @Test
+    fun `candidate args match createSubAccount derivation for the same index`() {
+        // Mirror WalletRepository.createSubAccount's exact derivation for
+        // index 2; a mismatch means discovery scans scripts no restored
+        // sub-account would ever own.
+        val seed = mnemonicManager.mnemonicToSeed(words)
+        val expected = keyManager
+            .deriveLockScript(
+                keyManager.derivePublicKey(
+                    mnemonicManager.derivePrivateKey(seed, accountIndex = 2)
+                )
+            )
+            .args
+        val candidate = discovery.deriveCandidates(words).first { it.accountIndex == 2 }
+        assertEquals(expected, candidate.scriptArgs)
+    }
+}

--- a/android/app/src/test/java/com/rjnr/pocketnode/data/wallet/WalletRepositoryTest.kt
+++ b/android/app/src/test/java/com/rjnr/pocketnode/data/wallet/WalletRepositoryTest.kt
@@ -70,7 +70,8 @@ class WalletRepositoryTest {
         walletPreferences = WalletPreferences(context)
         repo = WalletRepository(
             walletDao, keyManager, walletPreferences, mnemonicManager, db,
-            db.transactionDao(), db.balanceCacheDao(), db.daoCellDao(), db.keyMaterialDao()
+            db.transactionDao(), db.balanceCacheDao(), db.daoCellDao(), db.keyMaterialDao(),
+            db.subAccountCandidateDao(), SubAccountDiscovery(mnemonicManager, keyManager)
         )
     }
 


### PR DESCRIPTION
Part 1 of 2 for #82 / #371.

## Why phased
The embedded light client can only report history for scripts it has been told to sync, so "does sub-account N have activity?" cannot be answered at the import screen — candidate scripts must be registered and synced first. And Keystore V2 auth means silently creating found wallets would fire surprise biometric prompts, so the end UX (agreed) is auto-detect + one-tap restore.

## This PR (phase 1)
- **SubAccountDiscovery**: pure derivation of candidate lock-script args at `m/44'/309'/N'/0/0`, N=1..10, computed at import while the mnemonic is in memory. Script args only; private keys wiped immediately, nothing sensitive stored.
- **DB v13** (`MIGRATION_12_13`): `sub_account_candidates` (parentWalletId, accountIndex, scriptArgs, state, createdAt). Insert `IGNORE` so a re-import never clobbers FOUND/RESTORED states.
- **Import hook** in `WalletRepository.importFromMnemonic` — `runCatching`-guarded, discovery can never fail an import.
- **Tests**: determinism, distinct args per index, parent (index 0) excluded, derivation parity with `createSubAccount` for the same index (the contract that makes discovery find real sub-accounts), walking-migration to v13. Full suite green.

## Phase 2 (next PR)
Register candidate scripts with the light client, post-sync activity reconciler (PENDING -> FOUND/EMPTY), and the "Found N sub-accounts — Restore" one-tap UI that runs the existing createSubAccount flow at the found indices.

🤖 Generated with [Claude Code](https://claude.com/claude-code)