### PR TITLE
feat(wallet): sub-account discovery phase 2 — sync, reconcile, one-tap restore (#82, #371)

### DIFF
--- a/android/app/src/main/java/com/rjnr/pocketnode/data/database/dao/SubAccountCandidateDao.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/database/dao/SubAccountCandidateDao.kt
@@ -19,6 +19,10 @@ interface SubAccountCandidateDao {
     @Query("SELECT * FROM sub_account_candidates WHERE state = :state")
     suspend fun getByState(state: String): List<SubAccountCandidateEntity>
 
+    /** Flow — drives the "Found N sub-accounts" restore banner. */
+    @Query("SELECT * FROM sub_account_candidates WHERE state = :state ORDER BY parentWalletId, accountIndex")
+    fun observeByState(state: String): kotlinx.coroutines.flow.Flow<List<SubAccountCandidateEntity>>
+
     @Query(
         "UPDATE sub_account_candidates SET state = :state " +
             "WHERE parentWalletId = :parentId AND accountIndex = :accountIndex"

--- a/android/app/src/main/java/com/rjnr/pocketnode/data/gateway/GatewayRepository.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/gateway/GatewayRepository.kt
@@ -109,6 +109,7 @@ class GatewayRepository @Inject constructor(
     private val daoHeaderResolver: DaoHeaderResolver,
     private val daoDepositReader: DaoDepositReader,
     private val lightClient: LightClientReadOnly,
+    private val subAccountReconciler: com.rjnr.pocketnode.data.wallet.SubAccountReconciler,
 ) : TipSource {
     private val sendMutex = Mutex()
 
@@ -1040,6 +1041,19 @@ class GatewayRepository @Inject constructor(
         if (anyUpdated && walletPreferences.getSyncStrategy() == SyncStrategy.BALANCED) {
             maybeReregisterBalanced()
         }
+
+        // #82 phase 2: resolve PENDING sub-account discovery candidates.
+        // Their scripts ride along in `scripts` (registered with empty
+        // walletId, so the wallet loop above skips them). Throttled
+        // internally; never allowed to break the status poll.
+        runCatching {
+            subAccountReconciler.reconcile(
+                scannedByArgs = scripts.associate { s ->
+                    s.script.args to (s.blockNumber.removePrefix("0x").toLongOrNull(16) ?: 0L)
+                },
+                tipHeight = tipNumber,
+            )
+        }.onFailure { Log.w(TAG, "Sub-account candidate reconcile failed (non-fatal)", it) }
 
         // Active wallet's block for the sync-progress display below.
         val activeArgs = _walletInfo.value?.script?.args

--- a/android/app/src/main/java/com/rjnr/pocketnode/data/gateway/SyncCoordinator.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/gateway/SyncCoordinator.kt
@@ -138,6 +138,7 @@ class SyncCoordinator @Inject constructor(
     private val keyManager: KeyManager,
     private val json: Json,
     private val lightClient: LightClientBridge,
+    private val subAccountCandidateDao: com.rjnr.pocketnode.data.database.dao.SubAccountCandidateDao,
 ) {
 
     /**
@@ -451,13 +452,46 @@ class SyncCoordinator @Inject constructor(
                     }
                     val blockNumberHex = "0x${blockNum.toLongOrNull()?.toString(16) ?: "0"}"
 
-                    wallet.walletId to JniScriptStatus(
+                    val own = wallet.walletId to JniScriptStatus(
                         script = lockScript,
                         scriptType = "lock",
                         blockNumber = blockNumberHex,
                     )
+
+                    // #82 phase 2: register PENDING sub-account discovery
+                    // candidates alongside their parent so the filter sync
+                    // covers them. walletId = "" — setScriptsAndRecord skips
+                    // empty ids for the args→wallet mapping and sync_progress
+                    // rows, so candidates never pollute per-wallet progress.
+                    // Same fromBlock as the parent: candidates scan the same
+                    // window the parent's history does. Capped to bound the
+                    // per-script filter cost; remaining PENDING slots register
+                    // on later cycles as earlier ones resolve FOUND/EMPTY.
+                    // (Degradation note: paths that register only the active
+                    // wallet's script replace the whole set without candidates
+                    // — discovery just pauses until the next ALL registration;
+                    // states are in Room, nothing is lost.)
+                    val candidates = if (wallet.parentWalletId == null &&
+                        wallet.type == KeyManager.WALLET_TYPE_MNEMONIC
+                    ) {
+                        runCatching {
+                            subAccountCandidateDao.getForParent(wallet.walletId)
+                                .filter { it.state == com.rjnr.pocketnode.data.database.entity.SubAccountCandidateEntity.STATE_PENDING }
+                                .take(MAX_CANDIDATE_SCRIPTS_PER_PARENT)
+                                .map { candidate ->
+                                    "" to JniScriptStatus(
+                                        script = lockScript.copy(args = candidate.scriptArgs),
+                                        scriptType = "lock",
+                                        blockNumber = blockNumberHex,
+                                    )
+                                }
+                        }.getOrDefault(emptyList())
+                    } else {
+                        emptyList()
+                    }
+                    listOf(own) + candidates
                 }
-            }.awaitAll().filterNotNull()
+            }.awaitAll().filterNotNull().flatten()
         }
 
         if (pairs.isEmpty()) {
@@ -493,6 +527,14 @@ class SyncCoordinator @Inject constructor(
          * https://github.com/nervosnetwork/neuron/blob/develop/packages/neuron-wallet/src/block-sync-renderer/sync/light-synchronizer.ts#L22
          */
         const val BALANCED_LAG_THRESHOLD = 100_000L
+
+        /**
+         * PENDING discovery candidates registered per parent per cycle (#82).
+         * Each registered script adds filter-sync work in the light client,
+         * so scan the low indices first — sub-accounts are created
+         * contiguously from 1, so the first few cover real usage.
+         */
+        private const val MAX_CANDIDATE_SCRIPTS_PER_PARENT = 5
 
         /**
          * How long to wait for a non-null tip header before falling back to

--- a/android/app/src/main/java/com/rjnr/pocketnode/data/wallet/SubAccountReconciler.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/wallet/SubAccountReconciler.kt
@@ -1,0 +1,96 @@
+package com.rjnr.pocketnode.data.wallet
+
+import android.util.Log
+import com.rjnr.pocketnode.data.database.dao.SubAccountCandidateDao
+import com.rjnr.pocketnode.data.database.entity.SubAccountCandidateEntity
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Probe for "does this lock script have any on-chain history?". Same
+ * fun-interface seam idiom as BroadcastWatchdog's TransactionStatusGateway:
+ * production wires nativeGetTransactions(limit=1); tests fake it. Returns
+ * null when the light client can't answer right now (indeterminate — the
+ * reconciler retries on a later pass rather than mis-classifying).
+ */
+fun interface SubAccountActivityProbe {
+    suspend fun hasActivity(scriptArgs: String): Boolean?
+}
+
+/**
+ * Resolves PENDING sub-account candidates (#82 phase 2).
+ *
+ * A candidate's activity can only be judged once the light client has
+ * scanned its script over the sync window. Each pass:
+ *
+ *  - PENDING + probe sees history            -> FOUND (offer restore)
+ *  - PENDING + no history + scanned near tip -> EMPTY (retire)
+ *  - script not registered / probe null      -> stays PENDING, retry later
+ *
+ * EMPTY requires the scanned block within [NEAR_TIP_MARGIN] of the tip:
+ * declaring "no history" mid-scan would permanently hide a real
+ * sub-account whose transactions live in the unscanned remainder.
+ */
+@Singleton
+class SubAccountReconciler @Inject constructor(
+    private val candidateDao: SubAccountCandidateDao,
+    private val probe: SubAccountActivityProbe,
+) {
+
+    private var lastRunAt = 0L
+
+    /**
+     * Throttled entry point for the sync poll. [scannedByArgs] is the
+     * per-script scanned height from nativeGetScripts; [tipHeight] the
+     * current chain tip (0 = unknown, EMPTY never declared).
+     */
+    suspend fun reconcile(scannedByArgs: Map<String, Long>, tipHeight: Long) {
+        val now = System.currentTimeMillis()
+        if (now - lastRunAt < RUN_INTERVAL_MS) return
+        lastRunAt = now
+        reconcileNow(scannedByArgs, tipHeight)
+    }
+
+    /** Un-throttled core — direct target for unit tests. */
+    suspend fun reconcileNow(scannedByArgs: Map<String, Long>, tipHeight: Long) {
+        val pending = candidateDao.getByState(SubAccountCandidateEntity.STATE_PENDING)
+        if (pending.isEmpty()) return
+
+        pending.forEach { candidate ->
+            val scanned = scannedByArgs[candidate.scriptArgs] ?: return@forEach
+            val active = probe.hasActivity(candidate.scriptArgs) ?: return@forEach
+            when {
+                active -> {
+                    Log.i(
+                        TAG,
+                        "Candidate found: parent=${candidate.parentWalletId} " +
+                            "index=${candidate.accountIndex} has on-chain history"
+                    )
+                    candidateDao.updateState(
+                        candidate.parentWalletId,
+                        candidate.accountIndex,
+                        SubAccountCandidateEntity.STATE_FOUND,
+                    )
+                }
+                tipHeight > 0 && scanned >= tipHeight - NEAR_TIP_MARGIN -> {
+                    candidateDao.updateState(
+                        candidate.parentWalletId,
+                        candidate.accountIndex,
+                        SubAccountCandidateEntity.STATE_EMPTY,
+                    )
+                }
+                // else: still scanning — leave PENDING.
+            }
+        }
+    }
+
+    companion object {
+        private const val TAG = "SubAccountReconciler"
+
+        /** Scanned-to-within-this-many-blocks of tip counts as "scan complete". */
+        const val NEAR_TIP_MARGIN = 1_000L
+
+        /** One pass per interval — the sync poll fires every few seconds. */
+        const val RUN_INTERVAL_MS = 30_000L
+    }
+}

--- a/android/app/src/main/java/com/rjnr/pocketnode/data/wallet/WalletRepository.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/wallet/WalletRepository.kt
@@ -303,6 +303,7 @@ class WalletRepository @Inject constructor(
         parentWalletId: String,
         name: String,
         parentMnemonic: List<String>,
+        explicitIndex: Int? = null,
         persistKeys: suspend (walletId: String, bundle: WalletKeyBundle) -> WalletKeyWriter.Result,
     ): Result<WalletEntity> = runCatching {
         val parent = walletDao.getById(parentWalletId)
@@ -312,7 +313,18 @@ class WalletRepository @Inject constructor(
         }
 
         val existingSubs = walletDao.getSubAccountsList(parentWalletId)
-        val nextIndex = if (existingSubs.isEmpty()) 1 else existingSubs.maxOf { it.accountIndex } + 1
+        // explicitIndex = discovery restore (#82): recreate the account at the
+        // exact index whose script showed on-chain history. Default path keeps
+        // the contiguous max+1 scheme.
+        val nextIndex = if (explicitIndex != null) {
+            require(explicitIndex >= 1) { "Sub-account index must be >= 1" }
+            require(existingSubs.none { it.accountIndex == explicitIndex }) {
+                "Sub-account index $explicitIndex already exists"
+            }
+            explicitIndex
+        } else {
+            if (existingSubs.isEmpty()) 1 else existingSubs.maxOf { it.accountIndex } + 1
+        }
         val seed = mnemonicManager.mnemonicToSeed(parentMnemonic)
         val privateKey = mnemonicManager.derivePrivateKey(seed, accountIndex = nextIndex)
         val publicKey = keyManager.derivePublicKey(privateKey)
@@ -350,12 +362,36 @@ class WalletRepository @Inject constructor(
             walletDao.deactivateAll()
             walletDao.insert(entity)
             walletPreferences.setActiveWalletId(walletId)
-            markFreshWalletSyncMode(walletId)
+            if (explicitIndex != null) {
+                // Discovery restore: the account has on-chain HISTORY — fresh
+                // from-tip sync would hide exactly what made it discoverable.
+                // Inherit the parent's sync window per network instead.
+                for (net in listOf(NetworkType.MAINNET, NetworkType.TESTNET)) {
+                    walletPreferences.setSyncMode(
+                        walletPreferences.getSyncMode(net, parentWalletId), net, walletId
+                    )
+                    walletPreferences.setCustomBlockHeight(
+                        walletPreferences.getCustomBlockHeight(net, parentWalletId), net, walletId
+                    )
+                }
+            } else {
+                markFreshWalletSyncMode(walletId)
+            }
         } catch (e: Throwable) {
             Log.e(TAG, "Post-persist sub-account insert failed for $walletId; attempting rollback", e)
             runCatching { keyMaterialDao.delete(walletId) }
                 .onFailure { Log.e(TAG, "Rollback delete failed for $walletId", it) }
             throw e
+        }
+
+        // Retire the discovery candidate at this index if one exists (any
+        // creation at index N supersedes the candidate row; IGNORE-on-insert
+        // means a plain no-candidate create is a harmless 0-row update).
+        runCatching {
+            subAccountCandidateDao.updateState(
+                parentWalletId, nextIndex,
+                com.rjnr.pocketnode.data.database.entity.SubAccountCandidateEntity.STATE_RESTORED,
+            )
         }
 
         Log.d(TAG, "Created sub-account: $walletId (parent: $parentWalletId, index: $nextIndex)")

--- a/android/app/src/main/java/com/rjnr/pocketnode/di/AppModule.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/di/AppModule.kt
@@ -262,5 +262,40 @@ object AppModule {
         daoHeaderResolver: com.rjnr.pocketnode.data.gateway.DaoHeaderResolver,
         daoDepositReader: com.rjnr.pocketnode.data.gateway.DaoDepositReader,
         lightClient: com.rjnr.pocketnode.data.gateway.LightClientReadOnly,
-    ): GatewayRepository = GatewayRepository(context, keyManager, walletPreferences, json, transactionBuilder, cacheManager, daoSyncManager, walletMigrationHelper, walletDao, appDatabase, headerCacheDao, syncProgressDao, pendingBroadcastDao, broadcastClient, syncCoordinator, daoHeaderResolver, daoDepositReader, lightClient)
+        subAccountReconciler: com.rjnr.pocketnode.data.wallet.SubAccountReconciler,
+    ): GatewayRepository = GatewayRepository(context, keyManager, walletPreferences, json, transactionBuilder, cacheManager, daoSyncManager, walletMigrationHelper, walletDao, appDatabase, headerCacheDao, syncProgressDao, pendingBroadcastDao, broadcastClient, syncCoordinator, daoHeaderResolver, daoDepositReader, lightClient, subAccountReconciler)
+
+    /**
+     * Production activity probe for sub-account discovery (#82 phase 2):
+     * one nativeGetTransactions(limit=1) against the candidate's lock
+     * script. Null (indeterminate) when the light client returns null —
+     * the reconciler retries on a later pass instead of mis-classifying.
+     */
+    @Provides
+    @Singleton
+    fun provideSubAccountActivityProbe(json: Json): com.rjnr.pocketnode.data.wallet.SubAccountActivityProbe =
+        com.rjnr.pocketnode.data.wallet.SubAccountActivityProbe { scriptArgs ->
+            runCatching {
+                val searchKey = com.rjnr.pocketnode.data.gateway.models.JniSearchKey(
+                    script = com.rjnr.pocketnode.data.gateway.models.Script(
+                        codeHash = com.rjnr.pocketnode.data.gateway.models.Script.SECP256K1_CODE_HASH,
+                        hashType = "type",
+                        args = scriptArgs,
+                    )
+                )
+                val raw = com.nervosnetwork.ckblightclient.LightClientNative.nativeGetTransactions(
+                    json.encodeToString(
+                        com.rjnr.pocketnode.data.gateway.models.JniSearchKey.serializer(),
+                        searchKey,
+                    ),
+                    "desc",
+                    1,
+                    null,
+                ) ?: return@runCatching null
+                val page = json.decodeFromString<
+                    com.rjnr.pocketnode.data.gateway.models.JniPagination<
+                        com.rjnr.pocketnode.data.gateway.models.JniTxWithCell>>(raw)
+                page.objects.isNotEmpty()
+            }.getOrNull()
+        }
 }

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/wallet/WalletManagerScreen.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/wallet/WalletManagerScreen.kt
@@ -103,6 +103,46 @@ fun WalletManagerScreen(
         ) {
             item { Spacer(Modifier.height(8.dp)) }
 
+            // Discovery restore banner (#82 / #371): sub-account slots from
+            // an imported seed whose scripts have on-chain history.
+            if (uiState.foundCandidates.isNotEmpty()) {
+                item {
+                    val count = uiState.foundCandidates.size
+                    Card(
+                        modifier = Modifier.fillMaxWidth(),
+                        colors = CardDefaults.cardColors(
+                            containerColor = MaterialTheme.colorScheme.primaryContainer
+                        )
+                    ) {
+                        Column(Modifier.padding(16.dp)) {
+                            Text(
+                                text = if (count == 1) "Found 1 sub-account with history"
+                                else "Found $count sub-accounts with history",
+                                style = MaterialTheme.typography.titleSmall,
+                                color = MaterialTheme.colorScheme.onPrimaryContainer
+                            )
+                            Spacer(Modifier.height(4.dp))
+                            Text(
+                                text = "This seed phrase has sub-accounts with on-chain activity. Restore them to see their balances and history.",
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.onPrimaryContainer
+                            )
+                            Spacer(Modifier.height(8.dp))
+                            androidx.compose.material3.Button(
+                                onClick = {
+                                    (context as? androidx.fragment.app.FragmentActivity)?.let {
+                                        viewModel.restoreFoundSubAccounts(it)
+                                    }
+                                },
+                                enabled = !uiState.isRestoring,
+                            ) {
+                                Text(if (uiState.isRestoring) "Restoring..." else "Restore")
+                            }
+                        }
+                    }
+                }
+            }
+
             items(uiState.walletGroups, key = { it.wallet.walletId }) { group ->
                 WalletGroupCard(
                     group = group,

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/wallet/WalletManagerViewModel.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/wallet/WalletManagerViewModel.kt
@@ -19,7 +19,10 @@ private const val TAG = "WalletManagerVM"
 @HiltViewModel
 class WalletManagerViewModel @Inject constructor(
     private val walletRepository: WalletRepository,
-    private val gatewayRepository: GatewayRepository
+    private val gatewayRepository: GatewayRepository,
+    private val subAccountCandidateDao: com.rjnr.pocketnode.data.database.dao.SubAccountCandidateDao,
+    private val walletKeyReader: com.rjnr.pocketnode.data.wallet.WalletKeyReader,
+    private val walletKeyWriter: com.rjnr.pocketnode.data.wallet.WalletKeyWriter,
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow(WalletManagerUiState())
@@ -36,6 +39,83 @@ class WalletManagerViewModel @Inject constructor(
                     )
                 }
                 _uiState.update { it.copy(walletGroups = groups) }
+            }
+        }
+        // Discovery restore banner (#82 phase 2): sub-account slots whose
+        // scripts showed on-chain history after a parent seed import.
+        viewModelScope.launch {
+            subAccountCandidateDao
+                .observeByState(
+                    com.rjnr.pocketnode.data.database.entity.SubAccountCandidateEntity.STATE_FOUND
+                )
+                .collect { found ->
+                    _uiState.update { it.copy(foundCandidates = found) }
+                }
+        }
+    }
+
+    /**
+     * One-tap restore of discovered sub-accounts (#82 / #371). Per parent:
+     * one auth prompt to read the parent mnemonic, then one persist prompt
+     * per restored account — the same two-prompt contract as manual
+     * sub-account creation, just batched and user-initiated from the banner.
+     */
+    fun restoreFoundSubAccounts(activity: androidx.fragment.app.FragmentActivity) {
+        val found = _uiState.value.foundCandidates
+        if (found.isEmpty() || _uiState.value.isRestoring) return
+        _uiState.update { it.copy(isRestoring = true) }
+        viewModelScope.launch {
+            try {
+                var restored = 0
+                found.groupBy { it.parentWalletId }.forEach { (parentId, candidates) ->
+                    val readResult = walletKeyReader.readKeyMaterial(
+                        activity = activity,
+                        walletId = parentId,
+                        promptTitle = "Authenticate to restore",
+                        promptSubtitle = "Verify your identity to restore discovered sub-accounts.",
+                    )
+                    if (readResult !is com.rjnr.pocketnode.data.wallet.WalletKeyReader.MaterialResult.Success) {
+                        return@forEach
+                    }
+                    val words = readResult.mnemonic?.split(" ")
+                    if (words.isNullOrEmpty()) return@forEach
+
+                    candidates.sortedBy { it.accountIndex }.forEach { candidate ->
+                        walletRepository.createSubAccount(
+                            parentWalletId = parentId,
+                            name = "Sub-account ${candidate.accountIndex}",
+                            parentMnemonic = words,
+                            explicitIndex = candidate.accountIndex,
+                            persistKeys = { newWalletId, bundle ->
+                                walletKeyWriter.persistNewWallet(
+                                    activity = activity,
+                                    walletId = newWalletId,
+                                    bundle = bundle,
+                                    walletType = com.rjnr.pocketnode.data.wallet.KeyManager.WALLET_TYPE_MNEMONIC,
+                                    mnemonicBackedUp = false,
+                                    promptTitle = "Secure restored sub-account",
+                                    promptSubtitle = "Encrypt sub-account ${candidate.accountIndex}'s keys.",
+                                )
+                            },
+                        ).onSuccess { wallet ->
+                            restored++
+                            gatewayRepository.onActiveWalletChanged(wallet)
+                        }.onFailure { e ->
+                            Log.e(TAG, "Restore failed for $parentId index ${candidate.accountIndex}", e)
+                        }
+                    }
+                }
+                if (restored == 0) {
+                    _uiState.update {
+                        it.copy(
+                            error = com.rjnr.pocketnode.ui.util.UiMessage.Raw(
+                                "Could not restore sub-accounts. Authenticate and try again."
+                            )
+                        )
+                    }
+                }
+            } finally {
+                _uiState.update { it.copy(isRestoring = false) }
             }
         }
     }
@@ -67,5 +147,8 @@ class WalletManagerViewModel @Inject constructor(
 
 data class WalletManagerUiState(
     val walletGroups: List<WalletGroup> = emptyList(),
+    /** Discovered-but-unrestored sub-account slots with on-chain history (#82). */
+    val foundCandidates: List<com.rjnr.pocketnode.data.database.entity.SubAccountCandidateEntity> = emptyList(),
+    val isRestoring: Boolean = false,
     val error: com.rjnr.pocketnode.ui.util.UiMessage? = null,
 )

--- a/android/app/src/test/java/com/rjnr/pocketnode/data/gateway/SyncCoordinatorCustomBlockTest.kt
+++ b/android/app/src/test/java/com/rjnr/pocketnode/data/gateway/SyncCoordinatorCustomBlockTest.kt
@@ -107,6 +107,7 @@ class SyncCoordinatorCustomBlockTest {
             keyManager = keyManager,
             json = json,
             lightClient = fakeBridge,
+            subAccountCandidateDao = db.subAccountCandidateDao(),
         )
     }
 

--- a/android/app/src/test/java/com/rjnr/pocketnode/data/wallet/SubAccountReconcilerTest.kt
+++ b/android/app/src/test/java/com/rjnr/pocketnode/data/wallet/SubAccountReconcilerTest.kt
@@ -1,0 +1,112 @@
+package com.rjnr.pocketnode.data.wallet
+
+import android.content.Context
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import com.rjnr.pocketnode.data.database.AppDatabase
+import com.rjnr.pocketnode.data.database.dao.SubAccountCandidateDao
+import com.rjnr.pocketnode.data.database.entity.SubAccountCandidateEntity
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+/**
+ * State machine under test: PENDING -> FOUND on history, PENDING -> EMPTY
+ * only when scanned near tip with no history, PENDING preserved when the
+ * scan is incomplete or the probe can't answer. Mis-declaring EMPTY
+ * mid-scan would permanently hide a real sub-account.
+ */
+@RunWith(RobolectricTestRunner::class)
+class SubAccountReconcilerTest {
+
+    private lateinit var db: AppDatabase
+    private lateinit var dao: SubAccountCandidateDao
+
+    private val parent = "parent-1"
+
+    @Before
+    fun setup() {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        db = Room.inMemoryDatabaseBuilder(context, AppDatabase::class.java)
+            .allowMainThreadQueries()
+            .build()
+        dao = db.subAccountCandidateDao()
+    }
+
+    @After
+    fun teardown() = db.close()
+
+    private suspend fun seed(index: Int, args: String) {
+        dao.insertAll(
+            listOf(
+                SubAccountCandidateEntity(
+                    parentWalletId = parent,
+                    accountIndex = index,
+                    scriptArgs = args,
+                    createdAt = 1L,
+                )
+            )
+        )
+    }
+
+    private suspend fun stateOf(index: Int): String =
+        dao.getForParent(parent).first { it.accountIndex == index }.state
+
+    @Test
+    fun `history flips PENDING to FOUND`() = runTest {
+        seed(1, "0xaa")
+        val r = SubAccountReconciler(dao) { true }
+        r.reconcileNow(mapOf("0xaa" to 500L), tipHeight = 10_000L)
+        assertEquals(SubAccountCandidateEntity.STATE_FOUND, stateOf(1))
+    }
+
+    @Test
+    fun `no history near tip retires candidate as EMPTY`() = runTest {
+        seed(1, "0xaa")
+        val r = SubAccountReconciler(dao) { false }
+        r.reconcileNow(mapOf("0xaa" to 9_500L), tipHeight = 10_000L)
+        assertEquals(SubAccountCandidateEntity.STATE_EMPTY, stateOf(1))
+    }
+
+    @Test
+    fun `no history mid-scan stays PENDING`() = runTest {
+        seed(1, "0xaa")
+        val r = SubAccountReconciler(dao) { false }
+        r.reconcileNow(mapOf("0xaa" to 2_000L), tipHeight = 10_000L)
+        assertEquals(SubAccountCandidateEntity.STATE_PENDING, stateOf(1))
+    }
+
+    @Test
+    fun `unknown tip never declares EMPTY`() = runTest {
+        seed(1, "0xaa")
+        val r = SubAccountReconciler(dao) { false }
+        r.reconcileNow(mapOf("0xaa" to 9_999_999L), tipHeight = 0L)
+        assertEquals(SubAccountCandidateEntity.STATE_PENDING, stateOf(1))
+    }
+
+    @Test
+    fun `unregistered script or indeterminate probe stays PENDING`() = runTest {
+        seed(1, "0xaa") // not in scannedByArgs
+        seed(2, "0xbb") // probe returns null
+        val r = SubAccountReconciler(dao) { args -> if (args == "0xbb") null else true }
+        r.reconcileNow(mapOf("0xbb" to 9_500L), tipHeight = 10_000L)
+        assertEquals(SubAccountCandidateEntity.STATE_PENDING, stateOf(1))
+        assertEquals(SubAccountCandidateEntity.STATE_PENDING, stateOf(2))
+    }
+
+    @Test
+    fun `FOUND survives later empty-looking passes`() = runTest {
+        seed(1, "0xaa")
+        val r = SubAccountReconciler(dao) { true }
+        r.reconcileNow(mapOf("0xaa" to 9_500L), tipHeight = 10_000L)
+        // Second pass with a probe that now says no history (e.g. transient
+        // light-client hiccup) must not demote FOUND — only PENDING is judged.
+        val r2 = SubAccountReconciler(dao) { false }
+        r2.reconcileNow(mapOf("0xaa" to 9_900L), tipHeight = 10_000L)
+        assertEquals(SubAccountCandidateEntity.STATE_FOUND, stateOf(1))
+    }
+}

--- a/android/app/src/test/java/com/rjnr/pocketnode/data/wallet/WalletRepositoryTest.kt
+++ b/android/app/src/test/java/com/rjnr/pocketnode/data/wallet/WalletRepositoryTest.kt
@@ -197,6 +197,60 @@ class WalletRepositoryTest {
         assertNotEquals(parent.mainnetAddress, sub.mainnetAddress)
     }
 
+    /**
+     * Discovery restore (#82 phase 2): explicitIndex recreates the account
+     * at the EXACT index whose script had history — not max+1. Same index
+     * must derive the same address a manual creation would have, and a
+     * taken index must be refused rather than silently shifted.
+     */
+    @Test
+    fun `createSubAccount explicitIndex restores the requested index`() = runTest {
+        val parentWords = mnemonicManager.generateMnemonic(MnemonicManager.WordCount.TWELVE)
+        val parent = repo.importFromMnemonic(
+            words = parentWords,
+            name = "Parent",
+            persistKeys = { walletId, bundle -> fakePersistV2(walletId, bundle) },
+        ).getOrThrow()
+
+        // Restore index 3 directly (indices 1-2 not yet restored).
+        val sub3 = repo.createSubAccount(
+            parentWalletId = parent.walletId,
+            name = "Sub 3",
+            parentMnemonic = parentWords,
+            explicitIndex = 3,
+            persistKeys = { walletId, bundle -> fakePersistV2(walletId, bundle) },
+        ).getOrThrow()
+        assertEquals(3, sub3.accountIndex)
+        assertEquals("m/44'/309'/3'/0/0", sub3.derivationPath)
+
+        // Same index again: refused.
+        val dup = repo.createSubAccount(
+            parentWalletId = parent.walletId,
+            name = "Sub 3 again",
+            parentMnemonic = parentWords,
+            explicitIndex = 3,
+            persistKeys = { walletId, bundle -> fakePersistV2(walletId, bundle) },
+        )
+        assertTrue(dup.isFailure)
+
+        // Address parity with the derivation contract: restoring index 3
+        // yields the address the discovery candidate's args imply.
+        val expectedArgs = SubAccountDiscovery(mnemonicManager, keyManager)
+            .deriveCandidates(parentWords).first { it.accountIndex == 3 }.scriptArgs
+        val restoredArgs = keyManager.deriveLockScriptFromAddress(sub3.testnetAddress).args
+        assertEquals(expectedArgs, restoredArgs)
+
+        // Default max+1 path still works around the explicit row: next
+        // auto-create lands at 4 (max existing is 3).
+        val sub4 = repo.createSubAccount(
+            parentWalletId = parent.walletId,
+            name = "Sub 4",
+            parentMnemonic = parentWords,
+            persistKeys = { walletId, bundle -> fakePersistV2(walletId, bundle) },
+        ).getOrThrow()
+        assertEquals(4, sub4.accountIndex)
+    }
+
     @Test
     fun `deleteWallet refuses to delete active wallet`() = runTest {
         val wallet1 = repo.createWallet(

--- a/android/app/src/test/java/com/rjnr/pocketnode/ui/screens/wallet/AddWalletViewModelTest.kt
+++ b/android/app/src/test/java/com/rjnr/pocketnode/ui/screens/wallet/AddWalletViewModelTest.kt
@@ -107,7 +107,7 @@ class AddWalletViewModelTest {
             walletKeyWriter.persistNewWallet(any(), any(), any(), any(), any(), any(), any())
         }
         coVerify(exactly = 0) {
-            walletRepository.createSubAccount(any(), any(), any(), any())
+            walletRepository.createSubAccount(any(), any(), any(), any(), any())
         }
         coVerify(exactly = 0) { gatewayRepository.onActiveWalletChanged(any()) }
         assertNull(vm.uiState.value.createdWallet)


### PR DESCRIPTION
Part 2 of 2. Closes #82, closes #371. Builds on #377 (phase 1).

## Flow (end to end)
1. Import parent seed → candidates for indices 1–10 recorded (phase 1).
2. **This PR:** `SyncCoordinator` registers PENDING candidate scripts alongside the parent (cap 5/parent, same fromBlock, `walletId=""` so they never pollute per-wallet progress or BALANCED filtering).
3. Sync-poll-hooked `SubAccountReconciler` (30s throttle, non-fatal) judges candidates: history → `FOUND`; no history **and scanned within 1000 blocks of tip** → `EMPTY` (never declared mid-scan — that would permanently hide a real account); indeterminate → retry later. FOUND is never demoted.
4. Wallet Manager shows **"Found N sub-accounts with history — Restore"**. One tap → one auth prompt per parent (read mnemonic) + one persist prompt per account — the same two-prompt contract as manual sub-account creation, just user-initiated from the banner (no surprise background prompts, per the agreed UX).
5. `createSubAccount(explicitIndex)` restores the **exact** discovered index (not max+1), refuses taken indices, inherits the parent's sync window (from-tip sync would hide the discovered history), and marks the candidate `RESTORED`.

## Safety
- Every new hook is `runCatching`-guarded: discovery can never break import, the sync poll, or registration.
- Candidate scripts ride the existing `CMD_SET_SCRIPTS_ALL` path; paths that register only the active wallet simply pause discovery (states are in Room, nothing lost).
- No key material stored; keys re-derived only during user-initiated restore.

## Tests
Reconciler state machine (6 cases incl. mid-scan and FOUND-not-demoted), explicitIndex restore + address parity with the discovery candidate's args + duplicate-index refusal + max+1 coexistence. Full unit suite green.

## Device test (with phase 1 merged)
1. Create wallet A, create 2 sub-accounts, fund one, note the seed.
2. Clear data, import the seed, wait for sync.
3. Wallet Manager shows "Found sub-accounts" banner → Restore → accounts reappear with history.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a discovery restore banner that shows when recoverable sub-accounts are found.
  * Added one-tap restoration for discovered sub-accounts.
  * Improved sub-account creation so a specific account index can be restored when needed.

* **Bug Fixes**
  * Discovery results are now refreshed more reliably during wallet sync.
  * Restored sub-accounts now keep the correct sync settings and continue numbering correctly for new accounts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->