### PR TITLE
fix(wallet): no-secure-lock V1 fallback inside persistNewWallet (#354 follow-up)

### DIFF
--- a/android/app/src/main/java/com/rjnr/pocketnode/data/wallet/WalletKeyWriter.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/wallet/WalletKeyWriter.kt
@@ -106,23 +106,54 @@ class WalletKeyWriter @Inject constructor(
         promptTitle: String = "Secure wallet",
         promptSubtitle: String = "Use your phone's screen lock — fingerprint, face, or device PIN — to encrypt this wallet's keys.",
     ): Result {
+        // #354 follow-up: a V2 auth-bound key cannot exist without an enrolled
+        // biometric or device credential. AddWalletViewModel pre-gated this,
+        // but other callers (WalletSettings addSubAccount, discovery restore)
+        // called straight in and crashed with "Secure lock screen must be
+        // enabled" on no-lock devices. Gate HERE so every caller falls back to
+        // the V1 software key; the AuthScreen migration loop upgrades the row
+        // to V2 once the user enables a device lock.
+        if (!authManager.isBiometricEnrolled() && !authManager.hasDeviceCredential()) {
+            Log.i(TAG, "No secure lock on device — persisting $walletId at V1 fallback")
+            return persistNewWalletV1Fallback(
+                walletId = walletId,
+                bundle = bundle,
+                walletType = walletType,
+                mnemonicBackedUp = mnemonicBackedUp,
+            )
+        }
+
         val cipher = try {
             encryptionManager.newEncryptCipherV2()
         } catch (e: KeyPermanentlyInvalidatedException) {
             Log.w(TAG, "V2 key invalidated when generating cipher for $walletId", e)
             return Result.KeyInvalidated
+        } catch (e: java.security.InvalidAlgorithmParameterException) {
+            // KeyGenerator.init wraps the Keystore "Secure lock screen must be
+            // enabled" IllegalStateException in InvalidAlgorithmParameterException
+            // (seen on API 35 emulator) — the ISE catch below never fired for
+            // it. Race path only now that the pre-gate above exists (e.g. lock
+            // removed mid-flow): fall back to V1 like the gate would have.
+            if (e.cause?.message?.contains("Secure lock screen", ignoreCase = true) == true) {
+                Log.w(TAG, "V2 key creation refused mid-flow (no secure lock); V1 fallback", e)
+                return persistNewWalletV1Fallback(
+                    walletId = walletId,
+                    bundle = bundle,
+                    walletType = walletType,
+                    mnemonicBackedUp = mnemonicBackedUp,
+                )
+            }
+            throw e
         } catch (e: IllegalStateException) {
-            // Android Keystore throws IllegalStateException("Secure lock
-            // screen must be enabled to create keys requiring user
-            // authentication") when the V2 key (setUserAuthenticationRequired
-            // = true) is asked to generate on a device with no biometric
-            // enrolled AND no device PIN/pattern/password. The onboarding
-            // screen gates on this state, but a race (or a third-party
-            // entry point) could still reach here. Surface a typed result
-            // instead of letting the raw exception bubble up as a toast.
+            // Same condition, unwrapped form (older API levels).
             if (e.message?.contains("Secure lock screen", ignoreCase = true) == true) {
-                Log.w(TAG, "V2 key creation refused: no secure lock on device", e)
-                return Result.NoSecureLock
+                Log.w(TAG, "V2 key creation refused mid-flow (no secure lock); V1 fallback", e)
+                return persistNewWalletV1Fallback(
+                    walletId = walletId,
+                    bundle = bundle,
+                    walletType = walletType,
+                    mnemonicBackedUp = mnemonicBackedUp,
+                )
             }
             throw e
         }

--- a/android/app/src/test/java/com/rjnr/pocketnode/data/wallet/WalletKeyWriterTest.kt
+++ b/android/app/src/test/java/com/rjnr/pocketnode/data/wallet/WalletKeyWriterTest.kt
@@ -74,6 +74,9 @@ class WalletKeyWriterTest {
             keyMaterialDao, encryptionManager, prefs
         )
         authManager = mockk(relaxed = true)
+        // Default: device HAS a secure lock so tests exercise the V2 path.
+        // The no-lock V1 fallback test overrides this.
+        io.mockk.every { authManager.isBiometricEnrolled() } returns true
         keyBackupManager = mockk(relaxed = true)
         writer = WalletKeyWriter(
             keyMaterialDao = keyMaterialDao,
@@ -105,6 +108,30 @@ class WalletKeyWriterTest {
         assertNotNull(entity)
         assertEquals(2, entity!!.kdfVersion)
         coVerify(exactly = 0) { keyBackupManager.writeBackup(any(), any(), any()) }
+    }
+
+    /**
+     * No secure lock on the device: persistNewWallet must fall back to the
+     * V1 software key with NO auth prompt instead of crashing with
+     * "Secure lock screen must be enabled" (emulator repro, #354 follow-up:
+     * WalletSettings addSubAccount and discovery restore hit this — only
+     * AddWalletViewModel had the pre-gate).
+     */
+    @Test
+    fun `persistNewWallet falls back to V1 when device has no secure lock`() = runTest {
+        io.mockk.every { authManager.isBiometricEnrolled() } returns false
+        io.mockk.every { authManager.hasDeviceCredential() } returns false
+
+        val result = writer.persistNewWallet(activity, "w-nolock", bundle, "mnemonic", false)
+
+        assertEquals(WalletKeyWriter.Result.Success, result)
+        val entity = keyMaterialDao.getByWalletId("w-nolock")
+        assertNotNull(entity)
+        assertEquals(1, entity!!.kdfVersion)
+        // The V2 prompt must never fire on the fallback path.
+        coVerify(exactly = 0) {
+            authManager.authenticateForCipher(any(), any<Cipher>(), any(), any())
+        }
     }
 
     @Test


### PR DESCRIPTION
Found during device testing of the #82 batch: creating a sub-account from **Wallet Settings** on a device with no screen lock errored with the raw Keystore failure ("Secure lock screen must be enabled...").

## Root cause
- The #354 no-lock pre-gate only existed in `AddWalletViewModel`; `WalletSettingsViewModel.addSubAccount` and the new discovery-restore path call `persistNewWallet` directly.
- The writer's internal guard caught `IllegalStateException`, but `KeyGenerator.init` wraps it in `InvalidAlgorithmParameterException` (observed on the API 35 emulator), so it never matched.

## Fix
- Gate moved **inside** `WalletKeyWriter.persistNewWallet`: no biometric + no device credential → persist at the V1 software key with no prompt. The AuthScreen migration loop upgrades the row to V2 once a lock exists (same contract as #354).
- Also catch the wrapped `InvalidAlgorithmParameterException` form for the mid-flow race (lock removed between gate and keygen).

## Tests
New: no-lock path returns Success, writes `kdfVersion=1`, never fires the V2 prompt. Existing V2 tests updated to stub an enrolled biometric. Full suite green. Emulator-verified repro.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * New wallets now fall back to a compatible save path when the device doesn’t have secure lock credentials.
  * Improved handling for encryption setup errors so wallet creation continues instead of failing in more cases.
  * Existing protection for permanently invalidated keys remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->