### PR TITLE
chore(copy): drop battery-use warning from bg-sync opt-in and Settings

### DIFF
--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/onboarding/BackgroundSyncOptInScreen.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/onboarding/BackgroundSyncOptInScreen.kt
@@ -136,7 +136,7 @@ fun BackgroundSyncOptInScreen(
             Text(
                 text = "Pocket Node can keep syncing while the app is closed, so your " +
                     "balance and history are fresher when you come back. This shows a " +
-                    "small ongoing notification and uses some extra battery.\n\n" +
+                    "small ongoing notification.\n\n" +
                     "Android limits background work, so syncing may still pause until " +
                     "you next open the app. You can change this anytime in Settings → Sync.",
                 style = MaterialTheme.typography.bodyMedium,

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/settings/SettingsScreen.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/settings/SettingsScreen.kt
@@ -487,8 +487,8 @@ private fun SettingsScreenUI(
             item {
                 Text(
                     text = "Keeps your balance fresh while the app is closed, with a small " +
-                        "ongoing notification and some extra battery use. Android may still " +
-                        "pause it after extended background time.",
+                        "ongoing notification. Android may still pause it after extended " +
+                        "background time.",
                     style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                     modifier = Modifier


### PR DESCRIPTION
Device-test feedback: remove the "uses some extra battery" clause from both places it appeared:
- Onboarding background-sync opt-in screen
- Settings > Background Sync one-line blurb

Ongoing-notification and Android-may-pause caveats kept; only the battery clause dropped. Copy-only, no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)