### PR TITLE
fix: device-test round 2 — PIN reset on success, sub-account banner race, discovery wipe

### DIFF
--- a/android/app/src/main/java/com/rjnr/pocketnode/data/auth/PinManager.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/auth/PinManager.kt
@@ -23,10 +23,9 @@ import org.bouncycastle.crypto.params.Argon2Parameters
  * is preserved for verification and silently re-hashed to Argon2id on the
  * first successful entry.
  *
- * The failure counter is cumulative across sessions. It resets only after
- * 24 hours of no failures (the "decay window"), or when the user explicitly
- * re-sets their PIN via `setPin`. Lockout duration escalates with attempt
- * count up to a permanent lockout at 10+ failures.
+ * The failure counter is cumulative across sessions and resets on a
+ * successful verification or an explicit `setPin`. Lockout duration
+ * escalates with attempt count up to a permanent lockout at 10+ failures.
  *
  * The counter (and lockout state) live in EncryptedSharedPreferences, which
  * survive an app upgrade / overwrite install by design (#370). Resetting it
@@ -248,21 +247,19 @@ class PinManager @Inject constructor(
     }
 
     private fun onSuccessfulPin() {
-        val now = timeProvider()
-        val lastFailedAt = prefs.getLong(KEY_LAST_FAILED_AT, 0L)
-        val editor = prefs.edit().remove(KEY_LOCKOUT_UNTIL)
-
-        val sinceLastFailureMs = if (lastFailedAt == 0L) Long.MAX_VALUE else now - lastFailedAt
-        if (sinceLastFailureMs >= LOCKOUT_DECAY_MS) {
-            // Long enough since the last failure that this is genuine usage,
-            // not a quiet attacker grinding between owner-initiated unlocks.
-            // Reset the counter.
-            editor.putInt(KEY_FAILED_ATTEMPTS, 0)
-            editor.remove(KEY_LAST_FAILED_AT)
-        }
-        // Otherwise: leave the counter alone so a near-success-after-failures
-        // does not erase the audit trail.
-        editor.apply()
+        // A correct PIN resets the counter to max, matching platform
+        // convention (Android lockscreen does the same). The previous 24h
+        // decay window kept the counter after success to slow an attacker
+        // grinding between owner unlocks, but in practice it left the OWNER
+        // staring at "out of attempts" + the recovery dialog on every unlock
+        // for a day after fumbling their PIN (device-test report, 2026-07).
+        // Escalating lockouts (30s at 5 failures -> permanent at 10) still
+        // bound brute force between successes.
+        prefs.edit()
+            .remove(KEY_LOCKOUT_UNTIL)
+            .putInt(KEY_FAILED_ATTEMPTS, 0)
+            .remove(KEY_LAST_FAILED_AT)
+            .apply()
     }
 
     private fun hashPinArgon2id(pinBytes: ByteArray): String {

--- a/android/app/src/main/java/com/rjnr/pocketnode/data/gateway/GatewayRepository.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/gateway/GatewayRepository.kt
@@ -772,7 +772,20 @@ class GatewayRepository @Inject constructor(
             )
         )
 
-        val result = setScriptsAndRecord(scriptStatuses, listOf(activeWalletId), LightClientNative.CMD_SET_SCRIPTS_ALL)
+        // CMD_ALL replaces the entire registered set — carry the active
+        // wallet's PENDING discovery candidates or they get silently
+        // unregistered. The import flow's immediate resync hit exactly this:
+        // candidates registered at import were wiped 40s later and discovery
+        // never ran (#82, device-test 2026-07). Empty walletIds keep them out
+        // of per-wallet progress, same contract as registerAllWalletScripts.
+        val candidateStatuses = syncCoordinator.pendingCandidateStatuses(
+            activeWalletId, info.script, blockNumberHex
+        )
+        val result = setScriptsAndRecord(
+            scriptStatuses + candidateStatuses,
+            listOf(activeWalletId) + candidateStatuses.map { "" },
+            LightClientNative.CMD_SET_SCRIPTS_ALL
+        )
         if (!result) throw Exception("Failed to set scripts")
 
         _isRegistered.value = true

--- a/android/app/src/main/java/com/rjnr/pocketnode/data/gateway/SyncCoordinator.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/gateway/SyncCoordinator.kt
@@ -263,6 +263,39 @@ class SyncCoordinator @Inject constructor(
     }
 
     /**
+     * PENDING sub-account discovery candidates for [walletId] as registrable
+     * script statuses (#82 phase 2). Registered with walletId="" by callers —
+     * [setScriptsAndRecord] skips empty ids for the args→wallet mapping and
+     * sync_progress rows, so candidates never pollute per-wallet progress.
+     * Same fromBlock as the parent so candidates scan the parent's window.
+     * Capped to bound per-script filter cost; remaining PENDING slots
+     * register on later cycles as earlier ones resolve FOUND/EMPTY.
+     *
+     * MUST be included by EVERY path that issues CMD_SET_SCRIPTS_ALL for a
+     * wallet: ALL replaces the whole registered set, so a single-wallet
+     * re-registration that omits candidates silently unregisters them —
+     * the import flow's immediate resync did exactly that and killed
+     * discovery before the filter ever scanned (device-test, 2026-07).
+     * Non-parents have no candidate rows, so this is a cheap no-op for them.
+     */
+    suspend fun pendingCandidateStatuses(
+        walletId: String,
+        lockScript: com.rjnr.pocketnode.data.gateway.models.Script,
+        blockNumberHex: String,
+    ): List<JniScriptStatus> = runCatching {
+        subAccountCandidateDao.getForParent(walletId)
+            .filter { it.state == com.rjnr.pocketnode.data.database.entity.SubAccountCandidateEntity.STATE_PENDING }
+            .take(MAX_CANDIDATE_SCRIPTS_PER_PARENT)
+            .map { candidate ->
+                JniScriptStatus(
+                    script = lockScript.copy(args = candidate.scriptArgs),
+                    scriptType = "lock",
+                    blockNumber = blockNumberHex,
+                )
+            }
+    }.getOrDefault(emptyList())
+
+    /**
      * BALANCED strategy filter: drop wallets whose `localSavedBlockNumber`
      * lags the max-progress wallet by more than [BALANCED_LAG_THRESHOLD]
      * blocks. Active wallet always passes regardless of its own lag.
@@ -460,35 +493,10 @@ class SyncCoordinator @Inject constructor(
 
                     // #82 phase 2: register PENDING sub-account discovery
                     // candidates alongside their parent so the filter sync
-                    // covers them. walletId = "" — setScriptsAndRecord skips
-                    // empty ids for the args→wallet mapping and sync_progress
-                    // rows, so candidates never pollute per-wallet progress.
-                    // Same fromBlock as the parent: candidates scan the same
-                    // window the parent's history does. Capped to bound the
-                    // per-script filter cost; remaining PENDING slots register
-                    // on later cycles as earlier ones resolve FOUND/EMPTY.
-                    // (Degradation note: paths that register only the active
-                    // wallet's script replace the whole set without candidates
-                    // — discovery just pauses until the next ALL registration;
-                    // states are in Room, nothing is lost.)
-                    val candidates = if (wallet.parentWalletId == null &&
-                        wallet.type == KeyManager.WALLET_TYPE_MNEMONIC
-                    ) {
-                        runCatching {
-                            subAccountCandidateDao.getForParent(wallet.walletId)
-                                .filter { it.state == com.rjnr.pocketnode.data.database.entity.SubAccountCandidateEntity.STATE_PENDING }
-                                .take(MAX_CANDIDATE_SCRIPTS_PER_PARENT)
-                                .map { candidate ->
-                                    "" to JniScriptStatus(
-                                        script = lockScript.copy(args = candidate.scriptArgs),
-                                        scriptType = "lock",
-                                        blockNumber = blockNumberHex,
-                                    )
-                                }
-                        }.getOrDefault(emptyList())
-                    } else {
-                        emptyList()
-                    }
+                    // covers them. See [pendingCandidateStatuses].
+                    val candidates =
+                        pendingCandidateStatuses(wallet.walletId, lockScript, blockNumberHex)
+                            .map { "" to it }
                     listOf(own) + candidates
                 }
             }.awaitAll().filterNotNull().flatten()

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/auth/PinViewModel.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/auth/PinViewModel.kt
@@ -140,7 +140,18 @@ class PinViewModel @Inject constructor(
                     val ok = withContext(Dispatchers.Default) { pinManager.verifyPin(pin) }
                     if (ok) {
                         authManager.setSessionPin(pin.toCharArray())
-                        _uiState.update { it.copy(isVerifying = false, pinComplete = true) }
+                        // Correct PIN restores full attempts (PinManager reset)
+                        // — mirror that here and drop any recovery dialog so it
+                        // can't reappear after a successful unlock.
+                        _uiState.update {
+                            it.copy(
+                                isVerifying = false,
+                                pinComplete = true,
+                                remainingAttempts = PinManager.MAX_ATTEMPTS,
+                                showRecoveryDialog = false,
+                                isPermanentlyLocked = false,
+                            )
+                        }
                         return@launch
                     }
 

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/home/HomeViewModel.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/home/HomeViewModel.kt
@@ -579,7 +579,11 @@ class HomeViewModel @Inject constructor(
             val type = repository.getWalletType()
             // Sub-accounts (parentWalletId != null) don't hold their own mnemonic —
             // the parent wallet's backup covers them. Don't show backup reminder.
-            val activeWallet = _uiState.value.wallets.find { it.isActive }
+            // Query Room directly: reading `_uiState.value.wallets` raced the
+            // async wallet-list load, so a sub-account opened before the list
+            // arrived was misclassified and got the "Back Up Your Wallet"
+            // banner (device-test report, 2026-07).
+            val activeWallet = walletRepository.getActive()
             val isSubAccount = activeWallet?.parentWalletId != null
             val needsBackup = type == KeyManager.WALLET_TYPE_MNEMONIC
                 && !isSubAccount
@@ -592,8 +596,10 @@ class HomeViewModel @Inject constructor(
         viewModelScope.launch {
             val hasPin = pinManager.hasPin()
             val hasBiometrics = authManager.isBiometricEnabled()
-            // Sub-accounts inherit parent's backup status — treat as backed up
-            val activeWallet = _uiState.value.wallets.find { it.isActive }
+            // Sub-accounts inherit parent's backup status — treat as backed up.
+            // Room query, not _uiState.value.wallets — same load race as
+            // checkBackupStatus.
+            val activeWallet = walletRepository.getActive()
             val isSubAccount = activeWallet?.parentWalletId != null
             val hasMnemonicBackup = isSubAccount || repository.hasMnemonicBackupForActiveWallet()
             _uiState.update {

--- a/android/app/src/test/java/com/rjnr/pocketnode/data/auth/PinManagerTest.kt
+++ b/android/app/src/test/java/com/rjnr/pocketnode/data/auth/PinManagerTest.kt
@@ -174,21 +174,20 @@ class PinManagerTest {
     }
 
     @Test
-    fun `successful verification within 24h does NOT reset failed attempts`() {
+    fun `successful verification resets failed attempts to max`() {
         pinManager.setPin("123456")
         pinManager.verifyPin("000000")
         pinManager.verifyPin("000000")
         assertEquals(PinManager.MAX_ATTEMPTS - 2, pinManager.getRemainingAttempts())
 
-        // Simulate a quiet attacker scenario: legitimate owner unlocks within
-        // the 24h decay window. The counter must NOT reset, so the attacker
-        // cannot grind between owner-initiated unlocks.
+        // Policy change (device-test report, 2026-07): a correct PIN restores
+        // the full attempt count immediately, matching platform convention.
+        // The old 24h decay window kept the owner in an "out of attempts"
+        // state for a day after fumbling; escalating lockouts still bound
+        // brute force between successes.
         fakeTimeMs += 60_000L // 1 minute later
         pinManager.verifyPin("123456")
-        assertEquals(
-            PinManager.MAX_ATTEMPTS - 2,
-            pinManager.getRemainingAttempts()
-        )
+        assertEquals(PinManager.MAX_ATTEMPTS, pinManager.getRemainingAttempts())
     }
 
     @Test


### PR DESCRIPTION
Three fixes from emulator testing of the 1.7.6 batch.

## 1. "Out of PIN attempts" persisted after a correct PIN (#373 follow-up)
`PinManager.onSuccessfulPin` only reset the failed counter after 24h without failures (security-sweep decay window). Consequence: fumble 5 times, wait out the 30s lockout, enter the RIGHT pin — unlock works but the counter stays at 0, so the recovery dialog and "0 attempts" copy reappear on every unlock for a day. Owner decision: correct PIN restores the full count immediately (platform convention; Android lockscreen behaves the same). Escalating lockouts (30s → permanent at 10) still bound brute force between successes. The ViewModel also clears the recovery dialog + permanent-lock flag on success. Decay tests flipped to the new policy.

## 2. "Back Up Your Wallet" banner on sub-account Home
`checkBackupStatus` and `refreshSecurityState` read the active wallet from `uiState.wallets` — empty until the async wallet list loads — so a sub-account was misclassified as a parent and nagged to back up. Both now query Room directly.

## 3. Discovery never detected the funded sub-account (#82)
Emulator logcat showed the exact sequence: import registered parent + 5 candidates (6 scripts), then 40s later the import flow's resync (`registerAccount`, `CMD_SET_SCRIPTS_ALL`) replaced the set with ONLY the parent — candidates silently unregistered, filter never scanned them. Extracted `SyncCoordinator.pendingCandidateStatuses()` and included it in **both** replace-all paths (`registerAllWalletScripts` and `registerAccount`), with a MUST-include warning on the helper for future CMD_ALL paths.

Full unit suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * PIN success now fully clears lockout state and restores the maximum number of attempts.
  * Fixed cases where the app could keep showing recovery or permanent-lockout messaging after a correct PIN.
  * Improved wallet backup reminders so sub-accounts are no longer misidentified during loading.
  * Preserved candidate wallet discovery during sync so relevant wallets are not missed after updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->