### PR TITLE
fix: device-test round 3 — no-lock seed reveal + discovery false-EMPTY

### DIFF
--- a/android/app/src/main/java/com/rjnr/pocketnode/data/database/Migrations.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/database/Migrations.kt
@@ -474,6 +474,10 @@ val MIGRATION_10_11 = object : Migration(10, 11) {
  * v13 (#82 phase 1): `sub_account_candidates` — derivable-but-unrestored HD
  * sub-account slots recorded at parent mnemonic import. Public script args
  * only; no key material. Single CREATE TABLE, no existing shape touched.
+ *
+ * `registeredFromBlock` added while v13 was still unreleased (no shipped
+ * versionCode carries v13), so the migration is amended in place rather
+ * than minting v14.
  */
 val MIGRATION_12_13 = object : Migration(12, 13) {
     override fun migrate(db: SupportSQLiteDatabase) {
@@ -485,6 +489,7 @@ val MIGRATION_12_13 = object : Migration(12, 13) {
                 `scriptArgs` TEXT NOT NULL,
                 `state` TEXT NOT NULL,
                 `createdAt` INTEGER NOT NULL,
+                `registeredFromBlock` INTEGER NOT NULL DEFAULT 0,
                 PRIMARY KEY(`parentWalletId`, `accountIndex`)
             )
             """.trimIndent()

--- a/android/app/src/main/java/com/rjnr/pocketnode/data/database/dao/SubAccountCandidateDao.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/database/dao/SubAccountCandidateDao.kt
@@ -29,6 +29,17 @@ interface SubAccountCandidateDao {
     )
     suspend fun updateState(parentId: String, accountIndex: Int, state: String)
 
+    /**
+     * Record the scan start for a registration, keeping the LOWEST block ever
+     * used (deepest coverage). 0 means never registered.
+     */
+    @Query(
+        "UPDATE sub_account_candidates SET registeredFromBlock = :fromBlock " +
+            "WHERE parentWalletId = :parentId AND accountIndex = :accountIndex " +
+            "AND (registeredFromBlock = 0 OR registeredFromBlock > :fromBlock)"
+    )
+    suspend fun updateRegisteredFrom(parentId: String, accountIndex: Int, fromBlock: Long)
+
     @Query("DELETE FROM sub_account_candidates WHERE parentWalletId = :parentId")
     suspend fun deleteForParent(parentId: String)
 }

--- a/android/app/src/main/java/com/rjnr/pocketnode/data/database/entity/SubAccountCandidateEntity.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/database/entity/SubAccountCandidateEntity.kt
@@ -24,6 +24,15 @@ data class SubAccountCandidateEntity(
     val scriptArgs: String,
     val state: String = STATE_PENDING,
     val createdAt: Long,
+    /**
+     * Lowest block this candidate's script was ever registered to scan from
+     * (0 = never registered). The reconciler may only declare EMPTY when
+     * scanned-to-tip AND the scan actually covered chain from here — a
+     * candidate registered at tip has covered nothing, and judging it
+     * "no history" retired every candidate seconds after import
+     * (device-test 2026-07).
+     */
+    val registeredFromBlock: Long = 0,
 ) {
     companion object {
         const val STATE_PENDING = "PENDING"

--- a/android/app/src/main/java/com/rjnr/pocketnode/data/wallet/SubAccountReconciler.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/wallet/SubAccountReconciler.kt
@@ -72,14 +72,17 @@ class SubAccountReconciler @Inject constructor(
                         SubAccountCandidateEntity.STATE_FOUND,
                     )
                 }
-                tipHeight > 0 && scanned >= tipHeight - NEAR_TIP_MARGIN -> {
+                tipHeight > 0 && scanned >= tipHeight - NEAR_TIP_MARGIN &&
+                    candidate.registeredFromBlock > 0 &&
+                    scanned - candidate.registeredFromBlock >= MIN_COVERED_BLOCKS -> {
                     candidateDao.updateState(
                         candidate.parentWalletId,
                         candidate.accountIndex,
                         SubAccountCandidateEntity.STATE_EMPTY,
                     )
                 }
-                // else: still scanning — leave PENDING.
+                // else: still scanning (or the scan never covered real
+                // history) — leave PENDING.
             }
         }
     }
@@ -89,6 +92,18 @@ class SubAccountReconciler @Inject constructor(
 
         /** Scanned-to-within-this-many-blocks of tip counts as "scan complete". */
         const val NEAR_TIP_MARGIN = 1_000L
+
+        /**
+         * EMPTY additionally requires the scan to have actually COVERED this
+         * much chain. Candidates first registered at the tip (the parent had
+         * no sync window yet at import / network switch) report scanned≈tip
+         * immediately while having examined zero history — the first
+         * reconcile pass retired all of them as EMPTY seconds after import
+         * (device-test 2026-07). Imports default to the RECENT window
+         * (~200k blocks), so 50k means at least a quarter of that window was
+         * really examined before "no history" is believed.
+         */
+        const val MIN_COVERED_BLOCKS = 50_000L
 
         /** One pass per interval — the sync poll fires every few seconds. */
         const val RUN_INTERVAL_MS = 30_000L

--- a/android/app/src/main/java/com/rjnr/pocketnode/data/wallet/WalletRepository.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/wallet/WalletRepository.kt
@@ -374,6 +374,25 @@ class WalletRepository @Inject constructor(
                         walletPreferences.getCustomBlockHeight(net, parentWalletId), net, walletId
                     )
                 }
+                // Also inherit the parent's sync PROGRESS. The candidate
+                // script already scanned the window alongside the parent
+                // during discovery (its matched txs sit in light-client
+                // storage); without a progress row the fresh wallet
+                // registered from the window start and re-scanned ~200k
+                // blocks the device had just covered (device-test 2026-07).
+                runCatching {
+                    val spDao = appDatabase.syncProgressDao()
+                    for (net in listOf(NetworkType.MAINNET, NetworkType.TESTNET)) {
+                        spDao.get(parentWalletId, net.name)?.let { parentRow ->
+                            spDao.upsert(
+                                parentRow.copy(
+                                    walletId = walletId,
+                                    updatedAt = System.currentTimeMillis(),
+                                )
+                            )
+                        }
+                    }
+                }.onFailure { Log.w(TAG, "Progress inherit failed (non-fatal)", it) }
             } else {
                 markFreshWalletSyncMode(walletId)
             }

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/home/HomeScreen.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/home/HomeScreen.kt
@@ -226,9 +226,15 @@ fun HomeScreen(
             onDismiss = { viewModel.hidePostImportSyncDialog() },
             onSelectMode = { mode, customBlock ->
                 viewModel.hidePostImportSyncDialog()
-                if (mode != SyncMode.RECENT) {
-                    viewModel.changeSyncMode(mode, customBlock)
-                }
+                // Apply UNCONDITIONALLY. The old `if (mode != RECENT)` assumed
+                // RECENT was already active, but an import can register from
+                // the tip first — picking RECENT was then silently dropped:
+                // Settings kept the stale mode and the wallet never scanned
+                // its history window (device-test 2026-07, also starved
+                // sub-account discovery of coverage). changeSyncMode's
+                // isSyncSettingApplied guard (#362) already makes a genuine
+                // re-selection a safe no-op, so there is nothing to save here.
+                viewModel.changeSyncMode(mode, customBlock)
             },
             onTopicHelp = { topic ->
                 // Close-and-reopen via the post-import flag so dismissing the

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/wallet/WalletSettingsViewModel.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/wallet/WalletSettingsViewModel.kt
@@ -327,6 +327,12 @@ class WalletSettingsViewModel @Inject constructor(
                 if (!authManager.isBiometricEnrolled() && !authManager.hasDeviceCredential()) {
                     Log.i(TAG, "No secure lock — V1 reveal without lazy V2 upgrade for $walletId")
                     loadSensitiveData()
+                    // The screen gate is `seedPhraseUnlocked || !requiresPin`;
+                    // without this flip the words loaded but stayed hidden and
+                    // the tap looked like a no-op (device-test 2026-07). No
+                    // stronger credential exists on a no-lock device — the
+                    // app-level PIN at entry is the gate.
+                    _uiState.update { it.copy(seedPhraseUnlocked = true) }
                     return@launch
                 }
                 val cipher = try {

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/wallet/WalletSettingsViewModel.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/wallet/WalletSettingsViewModel.kt
@@ -317,6 +317,18 @@ class WalletSettingsViewModel @Inject constructor(
             // future reveals follow the standard V2 read path with its
             // own BiometricPrompt.
             if (kdf == 1) {
+                // No secure lock -> the V2 key cannot be minted, so the lazy
+                // V1->V2 upgrade below would throw ("Secure lock screen must
+                // be enabled", wrapped in InvalidAlgorithmParameterException —
+                // seed reveal errored on every no-lock device, device-test
+                // 2026-07). Fall through to the silent V1 read, the strongest
+                // path available without a lock; AuthScreen's migration
+                // upgrades the row once the user enables one.
+                if (!authManager.isBiometricEnrolled() && !authManager.hasDeviceCredential()) {
+                    Log.i(TAG, "No secure lock — V1 reveal without lazy V2 upgrade for $walletId")
+                    loadSensitiveData()
+                    return@launch
+                }
                 val cipher = try {
                     encryptionManager.newEncryptCipherV2()
                 } catch (e: Throwable) {

--- a/android/app/src/test/java/com/rjnr/pocketnode/data/wallet/SubAccountReconcilerTest.kt
+++ b/android/app/src/test/java/com/rjnr/pocketnode/data/wallet/SubAccountReconcilerTest.kt
@@ -40,7 +40,7 @@ class SubAccountReconcilerTest {
     @After
     fun teardown() = db.close()
 
-    private suspend fun seed(index: Int, args: String) {
+    private suspend fun seed(index: Int, args: String, registeredFrom: Long = 1_000L) {
         dao.insertAll(
             listOf(
                 SubAccountCandidateEntity(
@@ -48,6 +48,7 @@ class SubAccountReconcilerTest {
                     accountIndex = index,
                     scriptArgs = args,
                     createdAt = 1L,
+                    registeredFromBlock = registeredFrom,
                 )
             )
         )
@@ -65,10 +66,10 @@ class SubAccountReconcilerTest {
     }
 
     @Test
-    fun `no history near tip retires candidate as EMPTY`() = runTest {
-        seed(1, "0xaa")
+    fun `no history near tip with real coverage retires candidate as EMPTY`() = runTest {
+        seed(1, "0xaa", registeredFrom = 100_000L)
         val r = SubAccountReconciler(dao) { false }
-        r.reconcileNow(mapOf("0xaa" to 9_500L), tipHeight = 10_000L)
+        r.reconcileNow(mapOf("0xaa" to 199_500L), tipHeight = 200_000L)
         assertEquals(SubAccountCandidateEntity.STATE_EMPTY, stateOf(1))
     }
 
@@ -88,6 +89,22 @@ class SubAccountReconcilerTest {
         assertEquals(SubAccountCandidateEntity.STATE_PENDING, stateOf(1))
     }
 
+    /**
+     * Regression: a candidate first registered AT the tip has scanned≈tip
+     * instantly while covering zero history. Judging that as EMPTY retired
+     * every candidate seconds after import (device-test 2026-07). EMPTY needs
+     * real coverage.
+     */
+    @Test
+    fun `no history at tip with zero coverage stays PENDING`() = runTest {
+        seed(1, "0xaa", registeredFrom = 9_990L) // registered basically at tip
+        seed(2, "0xbb", registeredFrom = 0L)     // never recorded a start
+        val r = SubAccountReconciler(dao) { false }
+        r.reconcileNow(mapOf("0xaa" to 10_000L, "0xbb" to 10_000L), tipHeight = 10_000L)
+        assertEquals(SubAccountCandidateEntity.STATE_PENDING, stateOf(1))
+        assertEquals(SubAccountCandidateEntity.STATE_PENDING, stateOf(2))
+    }
+
     @Test
     fun `unregistered script or indeterminate probe stays PENDING`() = runTest {
         seed(1, "0xaa") // not in scannedByArgs
@@ -100,13 +117,13 @@ class SubAccountReconcilerTest {
 
     @Test
     fun `FOUND survives later empty-looking passes`() = runTest {
-        seed(1, "0xaa")
+        seed(1, "0xaa", registeredFrom = 100_000L)
         val r = SubAccountReconciler(dao) { true }
-        r.reconcileNow(mapOf("0xaa" to 9_500L), tipHeight = 10_000L)
+        r.reconcileNow(mapOf("0xaa" to 199_500L), tipHeight = 200_000L)
         // Second pass with a probe that now says no history (e.g. transient
         // light-client hiccup) must not demote FOUND — only PENDING is judged.
         val r2 = SubAccountReconciler(dao) { false }
-        r2.reconcileNow(mapOf("0xaa" to 9_900L), tipHeight = 10_000L)
+        r2.reconcileNow(mapOf("0xaa" to 199_900L), tipHeight = 200_000L)
         assertEquals(SubAccountCandidateEntity.STATE_FOUND, stateOf(1))
     }
 }


### PR DESCRIPTION
Two more from emulator testing, both root-caused from live logcat.

## 1. "View seed phrase" errored on devices with no screen lock
`WalletSettingsViewModel.loadSensitiveData` (V1 branch) performs a lazy V1→V2 upgrade on first reveal — minting the V2 auth-bound key, which Android refuses without a screen lock (`InvalidAlgorithmParameterException` wrapping "Secure lock screen must be enabled"; stack captured at 17:40). Third ungated V2 call site after the two #379 covered. No lock → fall through to the silent V1 read (the strongest path a lock-less device has; the reveal is still PIN-gated by the app). AuthScreen's migration upgrades the row once a lock exists.

## 2. Discovery candidates falsely retired as EMPTY
Logcat sequence: candidates registered (6 scripts, both networks — the round-2 wipe fix works), but they registered from **tip** (parent had no sync window yet right after import / a network switch). The light client immediately reports such scripts as scanned≈tip, so the first reconcile pass judged "near tip + no activity" = EMPTY on all 5 — after covering **zero** history. The later RECENT re-registration then correctly found nothing PENDING.

Fix: candidates track `registeredFromBlock` (keep-min, written at registration; amended into the unreleased v13 schema — no shipped build carries v13). EMPTY now requires scanned≈tip **and** covered ≥ 50k blocks (a quarter of the RECENT import window). Zero/unknown coverage stays PENDING and re-registers with the parent's real window on the next cycle.

## Tests
New coverage-gate cases (tip-start and no-start stay PENDING; genuinely covered scan retires EMPTY); existing reconciler tests updated to provide coverage. Full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Mark sub-account candidates as empty only after sufficient scan coverage near the chain tip, reducing premature “no history” results.
  * More reliably inherit sync progress when restoring discovery-created sub-accounts, preventing incorrect reconciliation outcomes.
  * Improved secure wallet data loading when biometric/device credentials aren’t available, avoiding upgrade/minting failures.
  * Ensure post-import sync mode selections (including RECENT) are applied correctly.
* **New Features**
  * Track when a sub-account candidate first began scanning via a stored “registered from” block value.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->