### PR TITLE
fix(db): mint v14 for registeredFromBlock instead of amending v13

### DIFF
--- a/android/app/src/main/java/com/rjnr/pocketnode/data/database/AppDatabase.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/database/AppDatabase.kt
@@ -63,7 +63,10 @@ import com.rjnr.pocketnode.data.database.entity.WalletEntity
     // Bumped from 12 to 13 for #82 phase 1: adds `sub_account_candidates`
     // (HD discovery slots recorded at parent import). MIGRATION_12_13 is a
     // single CREATE TABLE.
-    version = 13,
+    //
+    // Bumped from 13 to 14: sub_account_candidates gains registeredFromBlock
+    // (#82 coverage gate). MIGRATION_13_14 is a single ALTER TABLE.
+    version = 14,
     // Schema export deliberately OFF until the Room 2.8.4 / kotlinx-serialization
     // 1.8.0 binary incompatibility is resolved (tracked in #149). Enabling it
     // crashes KSP with AbstractMethodError in Room's bundled

--- a/android/app/src/main/java/com/rjnr/pocketnode/data/database/Migrations.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/database/Migrations.kt
@@ -474,10 +474,6 @@ val MIGRATION_10_11 = object : Migration(10, 11) {
  * v13 (#82 phase 1): `sub_account_candidates` — derivable-but-unrestored HD
  * sub-account slots recorded at parent mnemonic import. Public script args
  * only; no key material. Single CREATE TABLE, no existing shape touched.
- *
- * `registeredFromBlock` added while v13 was still unreleased (no shipped
- * versionCode carries v13), so the migration is amended in place rather
- * than minting v14.
  */
 val MIGRATION_12_13 = object : Migration(12, 13) {
     override fun migrate(db: SupportSQLiteDatabase) {
@@ -489,10 +485,24 @@ val MIGRATION_12_13 = object : Migration(12, 13) {
                 `scriptArgs` TEXT NOT NULL,
                 `state` TEXT NOT NULL,
                 `createdAt` INTEGER NOT NULL,
-                `registeredFromBlock` INTEGER NOT NULL DEFAULT 0,
                 PRIMARY KEY(`parentWalletId`, `accountIndex`)
             )
             """.trimIndent()
+        )
+    }
+}
+
+/**
+ * v14: `registeredFromBlock` on sub_account_candidates — lowest block a
+ * candidate's script was registered to scan from; gates the reconciler's
+ * EMPTY verdict on real coverage (#82). A proper version bump: amending
+ * v13 in place broke build-over-build upgrades (Room identity-hash crash
+ * caught by upgrade-smoke) even though no RELEASE shipped v13.
+ */
+val MIGRATION_13_14 = object : Migration(13, 14) {
+    override fun migrate(db: SupportSQLiteDatabase) {
+        db.execSQL(
+            "ALTER TABLE `sub_account_candidates` ADD COLUMN `registeredFromBlock` INTEGER NOT NULL DEFAULT 0"
         )
     }
 }

--- a/android/app/src/main/java/com/rjnr/pocketnode/di/AppModule.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/di/AppModule.kt
@@ -20,6 +20,7 @@ import com.rjnr.pocketnode.data.database.MIGRATION_9_10
 import com.rjnr.pocketnode.data.database.MIGRATION_10_11
 import com.rjnr.pocketnode.data.database.MIGRATION_11_12
 import com.rjnr.pocketnode.data.database.MIGRATION_12_13
+import com.rjnr.pocketnode.data.database.MIGRATION_13_14
 import com.rjnr.pocketnode.data.database.dao.BalanceCacheDao
 import com.rjnr.pocketnode.data.database.dao.ContactDao
 import com.rjnr.pocketnode.data.database.dao.DaoCellDao
@@ -131,7 +132,7 @@ object AppModule {
     fun provideAppDatabase(@ApplicationContext context: Context): AppDatabase =
         Room.databaseBuilder(context, AppDatabase::class.java, "pocket_node.db")
             .setJournalMode(RoomDatabase.JournalMode.WRITE_AHEAD_LOGGING)
-            .addMigrations(MIGRATION_1_2, MIGRATION_2_3, MIGRATION_3_4, MIGRATION_4_5, MIGRATION_5_6, MIGRATION_6_7, MIGRATION_7_8, MIGRATION_8_9, MIGRATION_9_10, MIGRATION_10_11, MIGRATION_11_12, MIGRATION_12_13)
+            .addMigrations(MIGRATION_1_2, MIGRATION_2_3, MIGRATION_3_4, MIGRATION_4_5, MIGRATION_5_6, MIGRATION_6_7, MIGRATION_7_8, MIGRATION_8_9, MIGRATION_9_10, MIGRATION_10_11, MIGRATION_11_12, MIGRATION_12_13, MIGRATION_13_14)
             .build()
 
     @Provides

--- a/android/app/src/test/java/com/rjnr/pocketnode/data/database/WalkingMigrationTest.kt
+++ b/android/app/src/test/java/com/rjnr/pocketnode/data/database/WalkingMigrationTest.kt
@@ -129,12 +129,19 @@ class WalkingMigrationTest {
      * validation passing.
      */
     @Test
-    fun `walk to v13 creates sub_account_candidates table`() {
+    fun `walk to v14 creates sub_account_candidates with registeredFromBlock`() {
         bootstrapV10()
         openViaRoomAndValidate()
         val db = openedRoomDb!!.openHelper.readableDatabase
         db.query("SELECT name FROM sqlite_master WHERE type='table' AND name='sub_account_candidates'").use { c ->
             assertTrue("sub_account_candidates table missing after MIGRATION_12_13", c.moveToNext())
+        }
+        db.query("PRAGMA table_info(`sub_account_candidates`)").use { c ->
+            var found = false
+            while (c.moveToNext()) {
+                if (c.getString(c.getColumnIndexOrThrow("name")) == "registeredFromBlock") found = true
+            }
+            assertTrue("registeredFromBlock column missing after MIGRATION_13_14", found)
         }
     }
 
@@ -183,7 +190,7 @@ class WalkingMigrationTest {
                 .addMigrations(
                     MIGRATION_1_2, MIGRATION_2_3, MIGRATION_3_4, MIGRATION_4_5,
                     MIGRATION_5_6, MIGRATION_6_7, MIGRATION_7_8, noOpMigration8To9,
-                    MIGRATION_9_10, MIGRATION_10_11, MIGRATION_11_12, MIGRATION_12_13,
+                    MIGRATION_9_10, MIGRATION_10_11, MIGRATION_11_12, MIGRATION_12_13, MIGRATION_13_14,
                 )
                 .build()
             openedRoomDb = db
@@ -213,7 +220,7 @@ class WalkingMigrationTest {
             .addMigrations(
                 MIGRATION_1_2, MIGRATION_2_3, MIGRATION_3_4, MIGRATION_4_5,
                 MIGRATION_5_6, MIGRATION_6_7, MIGRATION_7_8, MIGRATION_8_9,
-                MIGRATION_9_10, MIGRATION_10_11, MIGRATION_11_12, MIGRATION_12_13,
+                MIGRATION_9_10, MIGRATION_10_11, MIGRATION_11_12, MIGRATION_12_13, MIGRATION_13_14,
             )
             .build()
         openedRoomDb = db


### PR DESCRIPTION
Fixes the real upgrade-smoke failure on #383 (not the #330 flake).

#383 amended `MIGRATION_12_13` in place to add `registeredFromBlock`, reasoning that no release shipped v13. True for releases — but the upgrade-smoke harness (and any tester on a recent main debug build) upgrades **build-over-build**: the previous build had already created v13 in its original shape, so the reshaped v13 hit Room's identity-hash check and crashed post-upgrade. The gate caught exactly what it exists to catch.

- `MIGRATION_12_13` restored to its original `CREATE TABLE`.
- New `MIGRATION_13_14`: single `ALTER TABLE ADD COLUMN registeredFromBlock INTEGER NOT NULL DEFAULT 0`.
- DB version 13 → 14; walking-migration test extended with a v14 column assertion.

All upgrade paths now converge: v12 (1.7.5 users) → 13 → 14, and v13-original (recent debug builds) → 14. Full unit suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)