### PR TITLE
feat(#382): Tier 1 gap-limit signature detection, calm banner, FAQ

### DIFF
--- a/android/app/src/main/java/com/rjnr/pocketnode/data/database/dao/SubAccountCandidateDao.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/database/dao/SubAccountCandidateDao.kt
@@ -19,6 +19,10 @@ interface SubAccountCandidateDao {
     @Query("SELECT * FROM sub_account_candidates WHERE state = :state")
     suspend fun getByState(state: String): List<SubAccountCandidateEntity>
 
+    /** All candidate script args across parents — feeds the #382 known-scripts set. */
+    @Query("SELECT scriptArgs FROM sub_account_candidates")
+    suspend fun getAllScriptArgs(): List<String>
+
     /** Flow — drives the "Found N sub-accounts" restore banner. */
     @Query("SELECT * FROM sub_account_candidates WHERE state = :state ORDER BY parentWalletId, accountIndex")
     fun observeByState(state: String): kotlinx.coroutines.flow.Flow<List<SubAccountCandidateEntity>>

--- a/android/app/src/main/java/com/rjnr/pocketnode/data/gateway/GapLimitSignature.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/gateway/GapLimitSignature.kt
@@ -1,0 +1,33 @@
+package com.rjnr.pocketnode.data.gateway
+
+import com.rjnr.pocketnode.data.gateway.models.CellOutput
+import com.rjnr.pocketnode.data.gateway.models.Script
+
+/**
+ * #382 gap-limit signature: an outgoing transaction whose change went to no
+ * script we know. Seeds imported from Neuron (or any standard BIP44 wallet)
+ * spread funds across m/44'/309'/0'/{0|1}/{i}; Pocket Node derives only
+ * /N'/0/0, so change constructed by the other wallet lands on sibling
+ * addresses we never derived and the send reads as fund loss.
+ *
+ * Flags a transaction when ALL of:
+ *  - it is outgoing (negative net change against our known scripts),
+ *  - no output lock args match any script we track (nothing came back),
+ *  - it has at least two outputs (a single output with nothing back is the
+ *    legitimate send-max shape, not a missing change leg),
+ *  - at least one output is a plain untyped secp256k1 lock — the only shape a
+ *    change cell can take, on either the receiving or change chain.
+ */
+fun isUnknownChangeSignature(
+    netChangeShannons: Long,
+    outputs: List<CellOutput>,
+    knownLockArgs: Set<String>,
+): Boolean {
+    if (netChangeShannons >= 0) return false
+    if (outputs.size < 2) return false
+
+    val known = knownLockArgs.map { it.lowercase() }.toSet()
+    if (outputs.any { it.lock.args.lowercase() in known }) return false
+
+    return outputs.any { it.type == null && it.lock.codeHash == Script.SECP256K1_CODE_HASH }
+}

--- a/android/app/src/main/java/com/rjnr/pocketnode/data/gateway/GatewayRepository.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/gateway/GatewayRepository.kt
@@ -832,6 +832,18 @@ class GatewayRepository @Inject constructor(
     }
 
     fun hasCompletedInitialSync(): Boolean = walletPreferences.hasCompletedInitialSync(walletId = activeWalletId.ifEmpty { null })
+
+    /** #382: gap-limit banner is visible when the signature was detected for the active wallet and not dismissed. */
+    fun isGapLimitBannerVisible(): Boolean {
+        if (activeWalletId.isEmpty()) return false
+        return walletPreferences.isGapLimitSignalDetected(currentNetwork, activeWalletId) &&
+            !walletPreferences.isGapLimitBannerDismissed(currentNetwork, activeWalletId)
+    }
+
+    fun dismissGapLimitBanner() {
+        if (activeWalletId.isEmpty()) return
+        walletPreferences.setGapLimitBannerDismissed(currentNetwork, activeWalletId)
+    }
     
     suspend fun forceResetSync(): Result<Unit> = runCatching {
         Log.w(TAG, "Forcing sync reset...")
@@ -1685,6 +1697,31 @@ class GatewayRepository @Inject constructor(
         // Group by transaction hash to show a clean "one entry per transaction" UI
         val groupedTransactions = allInteractions.groupBy { it.transaction.hash }
 
+        // #382 gap-limit signature: every lock-script args we track — all
+        // wallets (both networks share args; the address differs, the script
+        // args don't) plus every sub-account candidate. Failure here must
+        // never break the transaction list; an incomplete set only means the
+        // banner may not arm this pass.
+        val knownLockArgs: Set<String> = runCatching {
+            buildSet {
+                add(myScript.args)
+                val addressPicker: (com.rjnr.pocketnode.data.database.entity.WalletEntity) -> String =
+                    if (currentNetwork == NetworkType.MAINNET) { w -> w.mainnetAddress } else { w -> w.testnetAddress }
+                walletDao.getAll().forEach { w ->
+                    val addr = addressPicker(w)
+                    if (addr.isNotBlank()) {
+                        runCatching { keyManager.deriveLockScriptFromAddress(addr) }
+                            .getOrNull()?.let { add(it.args) }
+                    }
+                }
+                addAll(appDatabase.subAccountCandidateDao().getAllScriptArgs())
+            }
+        }.getOrElse {
+            Log.w(TAG, "getTransactions: known-scripts set incomplete: ${it.message}")
+            setOf(myScript.args)
+        }
+        var gapLimitSignal = false
+
         // Fetch tip height once for confirmation calculations (avoid per-tx JNI calls)
         val tipHeight = runCatching {
             LightClientNative.nativeGetTipHeader()
@@ -1711,6 +1748,16 @@ class GatewayRepository @Inject constructor(
                 netChangeShannons > 0 -> "in"
                 netChangeShannons < 0 -> "out"
                 else -> "self"
+            }
+
+            // #382: outgoing tx whose change went to no script we know —
+            // the seed was likely also used in a standard BIP44 wallet
+            // (Neuron) whose change chain we don't derive yet.
+            if (!gapLimitSignal &&
+                isUnknownChangeSignature(netChangeShannons, tx.outputs, knownLockArgs)
+            ) {
+                gapLimitSignal = true
+                Log.i(TAG, "getTransactions: gap-limit signature in $txHash (#382)")
             }
 
             // For display, we show the absolute value as the amount
@@ -1812,6 +1859,15 @@ class GatewayRepository @Inject constructor(
         // Activity tab pages from Room, so completeness here is what makes
         // its "All" list actually mean all. ---
         cacheManager.cacheTransactions(items, currentNetwork.name, walletId = activeWalletId)
+
+        // Sticky: once armed, only the Tier 2 deep scan clears it. Detection
+        // is not re-evaluated downward — a later partial walk (runaway cap)
+        // must not un-detect.
+        if (gapLimitSignal && activeWalletId.isNotEmpty() &&
+            !walletPreferences.isGapLimitSignalDetected(currentNetwork, activeWalletId)
+        ) {
+            walletPreferences.setGapLimitSignalDetected(true, currentNetwork, activeWalletId)
+        }
 
         // Merge: include pending local txs not yet returned by JNI
         val jniTxHashes = items.map { it.txHash }.toSet()

--- a/android/app/src/main/java/com/rjnr/pocketnode/data/wallet/WalletPreferences.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/wallet/WalletPreferences.kt
@@ -254,6 +254,39 @@ class WalletPreferences @Inject constructor(
         prefs.edit().putBoolean(KEY_BG_SYNC_PILL_DISMISSED, true).apply()
     }
 
+    // --- #382 gap-limit signature banner ---
+    // Set when transaction history shows an outgoing tx whose change went to
+    // no script we track (seed also used in Neuron/standard BIP44 wallets).
+    // Sticky per wallet+network; the Tier 2 deep scan clears it.
+
+    fun isGapLimitSignalDetected(network: NetworkType? = null, walletId: String? = null): Boolean {
+        val net = network ?: getSelectedNetwork()
+        val key = if (walletId != null) walletNetworkKey(walletId, net.name, KEY_GAP_LIMIT_SIGNAL)
+                  else networkKey(KEY_GAP_LIMIT_SIGNAL, net)
+        return prefs.getBoolean(key, false)
+    }
+
+    fun setGapLimitSignalDetected(detected: Boolean, network: NetworkType? = null, walletId: String? = null) {
+        val net = network ?: getSelectedNetwork()
+        val key = if (walletId != null) walletNetworkKey(walletId, net.name, KEY_GAP_LIMIT_SIGNAL)
+                  else networkKey(KEY_GAP_LIMIT_SIGNAL, net)
+        prefs.edit().putBoolean(key, detected).apply()
+    }
+
+    fun isGapLimitBannerDismissed(network: NetworkType? = null, walletId: String? = null): Boolean {
+        val net = network ?: getSelectedNetwork()
+        val key = if (walletId != null) walletNetworkKey(walletId, net.name, KEY_GAP_LIMIT_BANNER_DISMISSED)
+                  else networkKey(KEY_GAP_LIMIT_BANNER_DISMISSED, net)
+        return prefs.getBoolean(key, false)
+    }
+
+    fun setGapLimitBannerDismissed(network: NetworkType? = null, walletId: String? = null) {
+        val net = network ?: getSelectedNetwork()
+        val key = if (walletId != null) walletNetworkKey(walletId, net.name, KEY_GAP_LIMIT_BANNER_DISMISSED)
+                  else networkKey(KEY_GAP_LIMIT_BANNER_DISMISSED, net)
+        prefs.edit().putBoolean(key, true).apply()
+    }
+
     // --- Database maintenance ---
 
     fun getLastVacuumAt(): Long = prefs.getLong(KEY_LAST_VACUUM_AT, 0L)
@@ -369,6 +402,8 @@ class WalletPreferences @Inject constructor(
         private const val KEY_BACKGROUND_SYNC = "background_sync_enabled"
         private const val KEY_LAST_SYNCED_AT = "last_synced_at_ms"
         private const val KEY_BG_SYNC_PILL_DISMISSED = "bg_sync_pill_dismissed"
+        private const val KEY_GAP_LIMIT_SIGNAL = "gap_limit_signal"
+        private const val KEY_GAP_LIMIT_BANNER_DISMISSED = "gap_limit_banner_dismissed"
         private const val KEY_LAST_VACUUM_AT = "last_vacuum_at"
         private const val KEY_SYNC_PROGRESS_MIGRATED = "sync_progress_migrated_to_room_v7"
         private const val KEY_SYNC_COACHMARK_SEEN = "sync_coachmark_seen"

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/components/GapLimitBanner.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/components/GapLimitBanner.kt
@@ -1,0 +1,82 @@
+package com.rjnr.pocketnode.ui.components
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Info
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.FilledTonalButton
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import com.rjnr.pocketnode.R
+
+/**
+ * #382: history contains an outgoing transaction whose change went to an
+ * address derived from this seed that Pocket Node does not scan yet (seed
+ * previously used in Neuron or another standard BIP44 wallet). Deliberately
+ * calm — secondaryContainer, Info icon — because the symptom already reads
+ * as fund loss and the message is "your funds are safe".
+ */
+@Composable
+fun GapLimitBanner(
+    onLearnMore: () -> Unit,
+    onDismiss: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Card(
+        modifier = modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.secondaryContainer,
+        ),
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(12.dp),
+            ) {
+                Icon(
+                    imageVector = Icons.Default.Info,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.onSecondaryContainer,
+                )
+                Text(
+                    text = stringResource(R.string.gap_limit_banner_title),
+                    style = MaterialTheme.typography.titleSmall,
+                    color = MaterialTheme.colorScheme.onSecondaryContainer,
+                )
+            }
+            Text(
+                text = stringResource(R.string.gap_limit_banner_body),
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSecondaryContainer,
+            )
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.End,
+            ) {
+                TextButton(onClick = onDismiss) {
+                    Text(stringResource(R.string.gap_limit_banner_action_dismiss))
+                }
+                FilledTonalButton(onClick = onLearnMore) {
+                    Text(stringResource(R.string.gap_limit_banner_action_learn_more))
+                }
+            }
+        }
+    }
+}

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/help/FaqEntry.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/help/FaqEntry.kt
@@ -21,6 +21,7 @@ object FaqEntries {
         FaqEntry("safe_during_sync",  R.string.faq_safe_during_sync_title,  R.string.faq_safe_during_sync_body),
         FaqEntry("close_during_sync", R.string.faq_close_during_sync_title, R.string.faq_close_during_sync_body),
         FaqEntry("internet_required", R.string.faq_internet_required_title, R.string.faq_internet_required_body),
+        FaqEntry("imported_funds",    R.string.faq_imported_funds_title,    R.string.faq_imported_funds_body),
     )
 
     fun byAnchor(anchor: String): FaqEntry? = v1.firstOrNull { it.anchor == anchor }

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/home/HomeScreen.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/home/HomeScreen.kt
@@ -94,6 +94,7 @@ import androidx.compose.ui.res.stringResource
 import com.rjnr.pocketnode.ui.components.SecurityBanner
 import com.rjnr.pocketnode.ui.components.SecurityBannerState
 import com.rjnr.pocketnode.ui.components.BgSyncStaleBanner
+import com.rjnr.pocketnode.ui.components.GapLimitBanner
 import com.rjnr.pocketnode.ui.components.SyncStallBanner
 import com.rjnr.pocketnode.ui.components.SyncOptionsSheet
 import com.rjnr.pocketnode.ui.components.UpdateDialog
@@ -487,6 +488,8 @@ fun HomeScreen(
                     onSyncStallDismiss = { viewModel.dismissSyncStallBanner() },
                     onBgSyncStaleEnable = { viewModel.enableBackgroundSyncFromPill() },
                     onBgSyncStaleDismiss = { viewModel.dismissBgSyncStalePill() },
+                    onGapLimitLearnMore = { onNavigateToFaq("imported_funds") },
+                    onGapLimitDismiss = { viewModel.dismissGapLimitBanner() },
                 )
                 if (uiState.isSwitchingWallet) {
                     LinearProgressIndicator(
@@ -559,6 +562,8 @@ fun HomeScreenUI(
     onSyncStallDismiss: () -> Unit = {},
     onBgSyncStaleEnable: () -> Unit = {},
     onBgSyncStaleDismiss: () -> Unit = {},
+    onGapLimitLearnMore: () -> Unit = {},
+    onGapLimitDismiss: () -> Unit = {},
 ) {
     val homeContentHaptic = LocalHapticFeedback.current
     PullToRefreshBox(
@@ -634,6 +639,18 @@ fun HomeScreenUI(
                         minutesStalled = uiState.syncStallMinutes,
                         onSwitchToRecent = onSyncStallSwitchToRecent,
                         onDismiss = onSyncStallDismiss,
+                    )
+                }
+            }
+
+            // #382: change from this seed left to addresses we never derived
+            // (seed also used in Neuron/standard BIP44 wallets). Calm notice,
+            // links to the FAQ; the Tier 2 deep scan will add a scan action.
+            if (uiState.showGapLimitBanner) {
+                item {
+                    GapLimitBanner(
+                        onLearnMore = onGapLimitLearnMore,
+                        onDismiss = onGapLimitDismiss,
                     )
                 }
             }

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/home/HomeViewModel.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/home/HomeViewModel.kt
@@ -460,8 +460,11 @@ class HomeViewModel @Inject constructor(
                     response.items.forEachIndexed { index, tx ->
                         Log.d(TAG, "  [$index] ${tx.txHash.take(16)}... dir=${tx.direction} amount=${tx.balanceChange} conf=${tx.confirmations}")
                     }
+                    // #382: detection runs inside getTransactions (the only
+                    // place output scripts exist); here we only read the flag.
+                    val showGapLimit = repository.isGapLimitBannerVisible()
                     _uiState.update {
-                        it.copy(transactions = response.items)
+                        it.copy(transactions = response.items, showGapLimitBanner = showGapLimit)
                     }
                 }
                 .onFailure { error ->
@@ -640,7 +643,7 @@ class HomeViewModel @Inject constructor(
             try {
                 syncStallDetector.reset()
                 stallBannerDismissed = false
-                _uiState.update { it.copy(isSwitchingWallet = true, showSyncStallBanner = false, syncStallMinutes = 0L) }
+                _uiState.update { it.copy(isSwitchingWallet = true, showSyncStallBanner = false, syncStallMinutes = 0L, showGapLimitBanner = false) }
                 walletRepository.switchActiveWallet(walletId)
                 val wallet = walletRepository.getById(walletId) ?: return@launch
                 repository.onActiveWalletChanged(wallet)
@@ -838,6 +841,12 @@ class HomeViewModel @Inject constructor(
         _uiState.update { it.copy(showSyncStallBanner = false) }
     }
 
+    /** #382 banner: per-wallet permanent dismissal; the Tier 2 deep scan will re-surface via its own flow. */
+    fun dismissGapLimitBanner() {
+        repository.dismissGapLimitBanner()
+        _uiState.update { it.copy(showGapLimitBanner = false) }
+    }
+
     /** #286 pill: permanent dismissal — informational, not a nag surface. */
     fun dismissBgSyncStalePill() {
         walletPreferences.setBgSyncPillDismissed()
@@ -945,5 +954,7 @@ data class HomeUiState(
     // #286 staleness pill: latched at app open (foreground sync freshens
     // lastSyncedAt within a minute, so a live check would self-hide).
     val showBgSyncStalePill: Boolean = false,
+    // #382: history shows change that left to addresses this app never derived
+    val showGapLimitBanner: Boolean = false,
     val bgSyncEnabledAtOpen: Boolean = false,
 )

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -95,6 +95,9 @@
 
     <string name="faq_internet_required_title">Why does the app need internet?</string>
     <string name="faq_internet_required_body">To check the blockchain itself, your phone has to talk to other CKB nodes around the world. The app does not send your private keys anywhere — those stay on your phone. Without internet, the app can show you your last known balance but cannot send or receive new transactions.</string>
+
+    <string name="faq_imported_funds_title">I imported a phrase from another wallet and my balance looks wrong</string>
+    <string name="faq_imported_funds_body">Wallet apps like Neuron create many addresses from one recovery phrase and quietly rotate between them, including hidden change addresses. Pocket Node currently watches one address per account, so funds sitting on those other addresses do not show up here. That is why your balance can look lower than expected, and why a send can appear as a large negative amount with nothing received back: the change went to a sister address this app does not watch yet.\n\nYour funds are not lost. They are still controlled by your recovery phrase and nothing has left it. Until the deep scan feature arrives, you can open the same phrase in the other wallet app to see and move those funds. An upcoming update will add a deeper scan that finds these addresses, plus an option to gather the funds onto your main address.</string>
     <!-- endregion -->
 
     <!-- region: SyncOptions -->
@@ -485,6 +488,10 @@
     <string name="sync_stall_banner_body">If this wallet has years of history, scanning from that far back is slow. Switch to Recent activity to catch up faster.</string>
     <string name="sync_stall_banner_action_switch_recent">Use Recent</string>
     <string name="sync_stall_banner_action_dismiss">Dismiss</string>
+    <string name="gap_limit_banner_title">Funds may be on other addresses</string>
+    <string name="gap_limit_banner_body">A past transaction sent change to an address from your recovery phrase that this app does not scan yet. This happens when the same phrase was used in another wallet app, such as Neuron. Your funds are safe. A deeper address scan is coming in an upcoming update.</string>
+    <string name="gap_limit_banner_action_learn_more">Learn more</string>
+    <string name="gap_limit_banner_action_dismiss">Dismiss</string>
     <!-- endregion -->
 
 </resources>

--- a/android/app/src/test/java/com/rjnr/pocketnode/data/gateway/GapLimitSignatureTest.kt
+++ b/android/app/src/test/java/com/rjnr/pocketnode/data/gateway/GapLimitSignatureTest.kt
@@ -1,0 +1,174 @@
+package com.rjnr.pocketnode.data.gateway
+
+import com.rjnr.pocketnode.data.gateway.models.CellOutput
+import com.rjnr.pocketnode.data.gateway.models.Script
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * #382: seeds imported from Neuron (or any standard BIP44 wallet) spread funds
+ * across m/44'/309'/0'/{0|1}/{i}, but Pocket Node derives only /N'/0/0. A send
+ * made by the other wallet spends our known cell and pays change to a sibling
+ * address we never derived — Activity shows a huge negative amount with nothing
+ * coming back, which reads as fund loss.
+ *
+ * The signature: an outgoing transaction where NO output returns to any script
+ * we know, and at least one plain (untyped) secp256k1 output exists that could
+ * be that missing change leg. Single-output transactions are excluded — that
+ * shape is a legitimate send-max.
+ */
+class GapLimitSignatureTest {
+
+    private val ckb = 100_000_000L
+
+    private val knownArgs = "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    private val siblingArgs = "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+    private val recipientArgs = "0xcccccccccccccccccccccccccccccccccccccccc"
+
+    private val daoTypeScript = Script(
+        codeHash = "0x82d76d1b75fe2fd9a27dfbaa65a039221a380d76c926f378d3f81cf3e7e13f2e",
+        hashType = "type",
+        args = "0x"
+    )
+
+    private fun secpOutput(capacityCkb: Long, args: String, type: Script? = null) = CellOutput(
+        capacity = "0x${(capacityCkb * ckb).toString(16)}",
+        lock = Script(Script.SECP256K1_CODE_HASH, "type", args),
+        type = type
+    )
+
+    @Test
+    fun `neuron send with sibling change is flagged`() {
+        // Neuron spent our cell: recipient + change both land on scripts we don't know
+        val flagged = isUnknownChangeSignature(
+            netChangeShannons = -1_000 * ckb,
+            outputs = listOf(
+                secpOutput(900, recipientArgs),
+                secpOutput(99, siblingArgs),
+            ),
+            knownLockArgs = setOf(knownArgs),
+        )
+        assertTrue(flagged)
+    }
+
+    @Test
+    fun `our own send with change back to us is not flagged`() {
+        val flagged = isUnknownChangeSignature(
+            netChangeShannons = -900 * ckb,
+            outputs = listOf(
+                secpOutput(900, recipientArgs),
+                secpOutput(99, knownArgs),
+            ),
+            knownLockArgs = setOf(knownArgs),
+        )
+        assertFalse(flagged)
+    }
+
+    @Test
+    fun `send-max single output is not flagged`() {
+        // One output and nothing back is the legitimate send-everything shape
+        val flagged = isUnknownChangeSignature(
+            netChangeShannons = -1_000 * ckb,
+            outputs = listOf(secpOutput(999, recipientArgs)),
+            knownLockArgs = setOf(knownArgs),
+        )
+        assertFalse(flagged)
+    }
+
+    @Test
+    fun `incoming transaction is not flagged`() {
+        val flagged = isUnknownChangeSignature(
+            netChangeShannons = 500 * ckb,
+            outputs = listOf(
+                secpOutput(500, knownArgs),
+                secpOutput(100, siblingArgs),
+            ),
+            knownLockArgs = setOf(knownArgs),
+        )
+        assertFalse(flagged)
+    }
+
+    @Test
+    fun `self consolidation is not flagged`() {
+        val flagged = isUnknownChangeSignature(
+            netChangeShannons = 0L,
+            outputs = listOf(secpOutput(100, knownArgs)),
+            knownLockArgs = setOf(knownArgs),
+        )
+        assertFalse(flagged)
+    }
+
+    @Test
+    fun `dao deposit locked to sibling with sibling change is flagged`() {
+        // knmo's Nervos Talk case: deposit cell + change both on the change chain
+        val flagged = isUnknownChangeSignature(
+            netChangeShannons = -10_300 * ckb,
+            outputs = listOf(
+                secpOutput(10_200, siblingArgs, type = daoTypeScript),
+                secpOutput(99, siblingArgs),
+            ),
+            knownLockArgs = setOf(knownArgs),
+        )
+        assertTrue(flagged)
+    }
+
+    @Test
+    fun `dao deposit with change back to us is not flagged`() {
+        val flagged = isUnknownChangeSignature(
+            netChangeShannons = -10_201 * ckb,
+            outputs = listOf(
+                secpOutput(10_200, siblingArgs, type = daoTypeScript),
+                secpOutput(99, knownArgs),
+            ),
+            knownLockArgs = setOf(knownArgs),
+        )
+        assertFalse(flagged)
+    }
+
+    @Test
+    fun `unknown outputs that are all typed have no plausible change leg and are not flagged`() {
+        // No plain secp output at all — nothing here can be a change cell
+        val flagged = isUnknownChangeSignature(
+            netChangeShannons = -10_300 * ckb,
+            outputs = listOf(
+                secpOutput(10_200, siblingArgs, type = daoTypeScript),
+                secpOutput(100, recipientArgs, type = daoTypeScript),
+            ),
+            knownLockArgs = setOf(knownArgs),
+        )
+        assertFalse(flagged)
+    }
+
+    @Test
+    fun `known-args match is case-insensitive`() {
+        val flagged = isUnknownChangeSignature(
+            netChangeShannons = -900 * ckb,
+            outputs = listOf(
+                secpOutput(900, recipientArgs),
+                secpOutput(99, knownArgs.uppercase().replaceFirst("0X", "0x")),
+            ),
+            knownLockArgs = setOf(knownArgs),
+        )
+        assertFalse(flagged)
+    }
+
+    @Test
+    fun `non-secp unknown lock does not count as the change leg`() {
+        // e.g. omnilock/ACP recipient plus a typed leg — still no plain secp change
+        val exoticLock = Script(
+            codeHash = "0x9b819793a64463aed77c615d6cb226eea5487ccfc0783043a587254cda2b6f26",
+            hashType = "type",
+            args = recipientArgs
+        )
+        val flagged = isUnknownChangeSignature(
+            netChangeShannons = -900 * ckb,
+            outputs = listOf(
+                CellOutput("0x${(900 * ckb).toString(16)}", exoticLock, null),
+                secpOutput(100, recipientArgs, type = daoTypeScript),
+            ),
+            knownLockArgs = setOf(knownArgs),
+        )
+        assertFalse(flagged)
+    }
+}


### PR DESCRIPTION
## Tier 1 of #382 (detection only, no scanning)

Seeds also used in Neuron/standard BIP44 wallets spread funds across `m/44'/309'/0'/{0|1}/{i}`; Pocket Node derives `/N'/0/0` only, so change constructed by the other wallet lands on sibling addresses we never derived and history reads as fund loss (0 CKB + huge negative outflow). knmo's Nervos Talk DAO-deposit case is the same axis gap.

### What this does
- **`isUnknownChangeSignature`** (pure function, TDD, 10 cases): flags a transaction only when ALL hold:
  1. outgoing (negative net change against our scripts)
  2. no output lock args match any script we track (nothing came back)
  3. at least 2 outputs (single-output = legitimate send-max shape, excluded to avoid false positives)
  4. at least one plain untyped secp256k1 output exists (the only shape a change cell can take)
- **Known-scripts set** built at `getTransactions` time: active script + every wallet's address-derived args + every `sub_account_candidates` row's `scriptArgs` (so account-axis discovery candidates don't double-fire). Any failure degrades to active-script-only and never breaks the transaction list.
- **Sticky flag** per wallet+network once detected (a later partial walk can't un-detect); Tier 2's deep scan is what clears it.
- **Calm banner** on Home (secondaryContainer + Info icon, deliberately not the error palette): "Funds may be on other addresses... Your funds are safe." Learn more -> FAQ anchor `imported_funds`; Dismiss is per-wallet permanent.
- **FAQ entry** explaining the derivation gap, that funds are safe, the interim open-in-Neuron workaround, and the upcoming deep scan + consolidation.

### Deliberate scope cuts
- No scan CTA yet: Tier 2 adds the bounded gap-limit scan; the banner copy points at the FAQ and the upcoming update instead of a dead button.
- No per-tx flag persisted to Room (no migration): detection is recomputed on every full history walk, and the wallet-level flag is a pref.

### Testing
- `GapLimitSignatureTest`: 10 pure-function cases (Neuron send, own send, send-max, incoming, self, DAO-deposit-to-sibling, DAO-with-known-change, all-typed outputs, case-insensitivity, non-secp locks)
- Full unit suite green: `./gradlew :app:testDebugUnitTest`

Closes nothing; #382 stays open until Tier 2/3 land.