### PR TITLE
chore: deprecation-warning sweep from the 1.7.7 build log

### DIFF
--- a/android/app/src/main/java/com/rjnr/pocketnode/MainActivity.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/MainActivity.kt
@@ -69,6 +69,9 @@ class MainActivity : FragmentActivity() {
         val startDestination = runBlocking {
             cachedHasWallet = repository.hasWallet()
             when {
+                // Suppressed, not removed: the corruption flag guards the ESP
+                // legacy-key path, which un-migrated installs still read.
+                @Suppress("DEPRECATION")
                 keyManager.wasResetDueToCorruption() -> Screen.Recovery.route
                 !cachedHasWallet -> Screen.Onboarding.route
                 !pinManager.hasPin() -> Screen.InitialPinSetup.route

--- a/android/app/src/main/java/com/rjnr/pocketnode/data/gateway/GatewayRepository.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/gateway/GatewayRepository.kt
@@ -628,6 +628,10 @@ class GatewayRepository @Inject constructor(
             && !hasMnemonicBackupForActiveWallet()
     }
 
+    // Retires together with KeyManager's ESP fallback — that path is still the
+    // legacy-key read for un-migrated installs, so its removal needs its own
+    // issue, not a warning sweep.
+    @Suppress("DEPRECATION")
     fun wasResetDueToCorruption(): Boolean = keyManager.wasResetDueToCorruption()
 
     fun getWalletType(): String = activeWalletType

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/MainScreen.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/MainScreen.kt
@@ -29,7 +29,7 @@ import com.composables.icons.lucide.Wallet
 import com.rjnr.pocketnode.ui.components.UpdateProgressBanner
 import com.rjnr.pocketnode.ui.navigation.BottomTab
 import com.rjnr.pocketnode.ui.screens.activity.ActivityScreen
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import com.rjnr.pocketnode.ui.screens.dao.DaoScreen
 import com.rjnr.pocketnode.ui.screens.home.HomeScreen
 import com.rjnr.pocketnode.ui.screens.settings.SettingsScreen

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/components/MnemonicWordInput.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/components/MnemonicWordInput.kt
@@ -5,7 +5,7 @@ import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExposedDropdownMenuBox
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.MenuAnchorType
+import androidx.compose.material3.ExposedDropdownMenuAnchorType
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -47,7 +47,7 @@ fun MnemonicWordInput(
             label = { Text(stringResource(R.string.mnemonic_word_index_label, index + 1)) },
             modifier = Modifier
                 .fillMaxWidth()
-                .menuAnchor(MenuAnchorType.PrimaryEditable),
+                .menuAnchor(ExposedDropdownMenuAnchorType.PrimaryEditable),
             singleLine = true,
             isError = isError,
             textStyle = MaterialTheme.typography.bodyMedium

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/navigation/NavGraph.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/navigation/NavGraph.kt
@@ -10,7 +10,7 @@ import androidx.navigation.NavType
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.navArgument
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import com.rjnr.pocketnode.data.auth.PinManager
 import com.rjnr.pocketnode.ui.MainScreen
 import com.rjnr.pocketnode.ui.screens.auth.AuthScreen

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/activity/ActivityScreen.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/activity/ActivityScreen.kt
@@ -63,7 +63,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.paging.LoadState
 import androidx.paging.compose.collectAsLazyPagingItems
 import com.composables.icons.lucide.*

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/auth/AuthScreen.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/auth/AuthScreen.kt
@@ -36,7 +36,7 @@ import androidx.compose.ui.unit.dp
 import com.rjnr.pocketnode.R
 import androidx.core.content.ContextCompat
 import androidx.fragment.app.FragmentActivity
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 
 @Composable
 fun AuthScreen(

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/auth/ForgotPinScreen.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/auth/ForgotPinScreen.kt
@@ -29,7 +29,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import com.composables.icons.lucide.ArrowLeft
 import com.composables.icons.lucide.Lucide
 import com.rjnr.pocketnode.R

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/auth/PinEntryScreen.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/auth/PinEntryScreen.kt
@@ -41,7 +41,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import com.rjnr.pocketnode.data.auth.PinManager
 import com.rjnr.pocketnode.ui.util.uaTestTag
 

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/contacts/AddContactScreen.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/contacts/AddContactScreen.kt
@@ -31,7 +31,7 @@ import androidx.compose.ui.platform.LocalClipboardManager
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import com.rjnr.pocketnode.R
 import com.rjnr.pocketnode.ui.util.resolveString
 import com.composables.icons.lucide.ArrowLeft

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/contacts/ContactDetailScreen.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/contacts/ContactDetailScreen.kt
@@ -47,7 +47,7 @@ import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import com.rjnr.pocketnode.R
 import com.rjnr.pocketnode.ui.util.resolveString
 import com.composables.icons.lucide.ArrowLeft

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/contacts/ContactsScreen.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/contacts/ContactsScreen.kt
@@ -35,7 +35,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import com.rjnr.pocketnode.R
 import com.composables.icons.lucide.ArrowLeft
 import com.composables.icons.lucide.Lucide

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/contacts/EditContactScreen.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/contacts/EditContactScreen.kt
@@ -28,7 +28,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import com.rjnr.pocketnode.R
 import com.rjnr.pocketnode.ui.util.resolveString
 import com.composables.icons.lucide.ArrowLeft

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/help/FaqScreen.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/help/FaqScreen.kt
@@ -33,7 +33,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import com.rjnr.pocketnode.R
 
 @OptIn(ExperimentalMaterial3Api::class)

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/home/HomeScreen.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/home/HomeScreen.kt
@@ -74,7 +74,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import com.composables.icons.lucide.CircleHelp
 import com.composables.icons.lucide.Copy
 import com.composables.icons.lucide.ExternalLink

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/onboarding/BackgroundSyncOptInScreen.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/onboarding/BackgroundSyncOptInScreen.kt
@@ -30,7 +30,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.core.content.ContextCompat
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.ViewModel
 import com.composables.icons.lucide.Lucide
 import com.composables.icons.lucide.RefreshCw

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/onboarding/MnemonicBackupScreen.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/onboarding/MnemonicBackupScreen.kt
@@ -19,7 +19,7 @@ import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.compose.ui.res.stringResource
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/onboarding/MnemonicImportScreen.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/onboarding/MnemonicImportScreen.kt
@@ -16,7 +16,7 @@ import com.rjnr.pocketnode.ui.util.uaTestTag
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.fragment.app.FragmentActivity
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import android.util.Log

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/onboarding/OnboardingScreen.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/onboarding/OnboardingScreen.kt
@@ -13,7 +13,7 @@ import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import com.rjnr.pocketnode.ui.util.resolveString
 import com.rjnr.pocketnode.ui.util.uaTestTag
 

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/receive/ReceiveScreen.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/receive/ReceiveScreen.kt
@@ -30,7 +30,7 @@ import com.rjnr.pocketnode.R
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import com.google.zxing.BarcodeFormat
 import com.google.zxing.qrcode.QRCodeWriter
 import com.rjnr.pocketnode.data.gateway.models.NetworkType

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/recovery/RecoveryScreen.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/recovery/RecoveryScreen.kt
@@ -32,7 +32,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.unit.dp
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import com.rjnr.pocketnode.R
 
 @OptIn(ExperimentalMaterial3Api::class)

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/scanner/QrScannerScreen.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/scanner/QrScannerScreen.kt
@@ -23,7 +23,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.platform.LocalLifecycleOwner
+import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/send/SendScreen.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/send/SendScreen.kt
@@ -69,7 +69,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import com.composables.icons.lucide.BookUser
 import com.composables.icons.lucide.Check
 import com.composables.icons.lucide.ChevronLeft

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/settings/SecuritySettingsScreen.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/settings/SecuritySettingsScreen.kt
@@ -39,7 +39,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import com.rjnr.pocketnode.R
 import com.rjnr.pocketnode.ui.util.resolveString
 

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/settings/SettingsScreen.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/settings/SettingsScreen.kt
@@ -59,7 +59,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.core.content.ContextCompat
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import com.composables.icons.lucide.ChevronRight
 import com.composables.icons.lucide.CircleHelp
 import com.composables.icons.lucide.Download

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/status/NodeStatusScreen.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/status/NodeStatusScreen.kt
@@ -35,8 +35,8 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Surface
+import androidx.compose.material3.PrimaryTabRow
 import androidx.compose.material3.Tab
-import androidx.compose.material3.TabRow
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
@@ -59,8 +59,9 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.rjnr.pocketnode.R
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.navigation.NavController
+import kotlinx.coroutines.launch
 import com.composables.icons.lucide.ChevronLeft
 import com.composables.icons.lucide.Lucide
 import com.rjnr.pocketnode.data.gateway.models.JniHeaderView
@@ -94,7 +95,7 @@ fun NodeStatusScreen(
         }
     ) { padding ->
         Column(modifier = Modifier.padding(padding)) {
-            TabRow(selectedTabIndex = selectedTab) {
+            PrimaryTabRow(selectedTabIndex = selectedTab) {
                 tabs.forEachIndexed { index, title ->
                     Tab(
                         selected = selectedTab == index,
@@ -126,7 +127,8 @@ fun StatusTab(
     onClearErrors: () -> Unit = {},
 ) {
     var rpcMethod by remember { mutableStateOf("get_peers") }
-    val clipboard = androidx.compose.ui.platform.LocalClipboardManager.current
+    val clipboard = androidx.compose.ui.platform.LocalClipboard.current
+    val copyScope = androidx.compose.runtime.rememberCoroutineScope()
     val tipHeader = uiState.tipHeader
     val peers = uiState.peers
 
@@ -163,11 +165,16 @@ fun StatusTab(
                         Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
                             androidx.compose.material3.TextButton(onClick = {
                                 val fmt = java.text.SimpleDateFormat("yyyy-MM-dd HH:mm:ss", java.util.Locale.US)
-                                clipboard.setText(androidx.compose.ui.text.AnnotatedString(
-                                    uiState.appErrors.joinToString("\n") { e ->
-                                        "[${fmt.format(java.util.Date(e.atMs))}] ${e.tag}: ${e.message}"
-                                    }
-                                ))
+                                val text = uiState.appErrors.joinToString("\n") { e ->
+                                    "[${fmt.format(java.util.Date(e.atMs))}] ${e.tag}: ${e.message}"
+                                }
+                                copyScope.launch {
+                                    clipboard.setClipEntry(
+                                        androidx.compose.ui.platform.ClipEntry(
+                                            android.content.ClipData.newPlainText("App errors", text)
+                                        )
+                                    )
+                                }
                             }) { Text("Copy all") }
                             androidx.compose.material3.TextButton(onClick = onClearErrors) { Text("Clear") }
                         }

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/wallet/AddWalletScreen.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/wallet/AddWalletScreen.kt
@@ -29,7 +29,7 @@ import androidx.compose.material3.ExposedDropdownMenuDefaults
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.MenuAnchorType
+import androidx.compose.material3.ExposedDropdownMenuAnchorType
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHost
@@ -51,7 +51,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalClipboardManager
 import androidx.compose.ui.unit.dp
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import com.composables.icons.lucide.ArrowLeft
 import com.composables.icons.lucide.ClipboardPaste
 import com.composables.icons.lucide.Key
@@ -368,7 +368,7 @@ private fun SubAccountForm(
             placeholder = { Text(stringResource(R.string.add_wallet_parent_placeholder)) },
             trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = dropdownExpanded) },
             modifier = Modifier
-                .menuAnchor(MenuAnchorType.PrimaryNotEditable)
+                .menuAnchor(ExposedDropdownMenuAnchorType.PrimaryNotEditable)
                 .fillMaxWidth()
         )
         ExposedDropdownMenu(

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/wallet/WalletManagerScreen.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/wallet/WalletManagerScreen.kt
@@ -37,7 +37,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import com.composables.icons.lucide.ArrowLeft
 import androidx.compose.ui.res.stringResource
 import com.composables.icons.lucide.ChevronRight

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/wallet/WalletSettingsScreen.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/wallet/WalletSettingsScreen.kt
@@ -46,7 +46,7 @@ import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import com.composables.icons.lucide.ArrowLeft
 import com.composables.icons.lucide.ChevronRight
 import com.composables.icons.lucide.Lucide


### PR DESCRIPTION
Mechanical warning sweep, no behavior changes intended.

## Fixed
- **hiltViewModel package move** (hilt-navigation-compose 1.3.0): `androidx.hilt.navigation.compose` -> `androidx.hilt.lifecycle.viewmodel.compose`, all 25 usages (the build log flagged Send/Settings/NodeStatus; the rest are the same one-line change)
- **TabRow -> PrimaryTabRow** in NodeStatusScreen
- **LocalClipboardManager -> LocalClipboard** in the NodeStatusScreen App-errors "Copy all" (new suspend `setClipEntry` API via `rememberCoroutineScope`)
- **MenuAnchorType -> ExposedDropdownMenuAnchorType** (MnemonicWordInput, AddWalletScreen)
- **LocalLifecycleOwner** moved import (QrScannerScreen)
- **wasResetDueToCorruption** call sites: `@Suppress("DEPRECATION")` + pointer comment. NOT removed: the flag guards KeyManager's ESP fallback, which is still the legacy-key read path for un-migrated installs. Retiring the whole ESP fallback deserves its own issue.

## Deliberately left
- ESP/MasterKey deprecations inside KeyManager/PinManager (androidx.security.crypto is deprecated wholesale; goes away with the ESP-fallback retirement)
- Remaining 11 `LocalClipboardManager` sites: `ClipboardManager` is threaded through HomeScreen's composable parameters, so this is an API refactor, not a sweep line-item
- `Theme.kt` `statusBarColor` (edge-to-edge migration)

## Testing
- `./gradlew :app:compileDebugKotlin` clean of all swept warning classes
- Full unit suite green: `./gradlew :app:testDebugUnitTest`