### PR TITLE
feat(#382): Tier 2 sub-PR 1 — path-keyed candidates (DB v15) + chain derivation

### DIFF
--- a/android/app/src/main/java/com/rjnr/pocketnode/data/database/AppDatabase.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/database/AppDatabase.kt
@@ -66,7 +66,12 @@ import com.rjnr.pocketnode.data.database.entity.WalletEntity
     //
     // Bumped from 13 to 14: sub_account_candidates gains registeredFromBlock
     // (#82 coverage gate). MIGRATION_13_14 is a single ALTER TABLE.
-    version = 14,
+    //
+    // Bumped from 14 to 15 for #382 Tier 2: sub_account_candidates re-keyed
+    // on (parentWalletId, derivationPath) so chain-axis gap-limit slots can
+    // coexist with account-axis slots. MIGRATION_14_15 recreates the table
+    // and backfills derivationPath from accountIndex.
+    version = 15,
     // Schema export deliberately OFF until the Room 2.8.4 / kotlinx-serialization
     // 1.8.0 binary incompatibility is resolved (tracked in #149). Enabling it
     // crashes KSP with AbstractMethodError in Room's bundled

--- a/android/app/src/main/java/com/rjnr/pocketnode/data/database/Migrations.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/database/Migrations.kt
@@ -506,3 +506,44 @@ val MIGRATION_13_14 = object : Migration(13, 14) {
         )
     }
 }
+
+/**
+ * v15 (#382 Tier 2): re-key `sub_account_candidates` on
+ * (parentWalletId, derivationPath) so gap-limit candidates along account 0's
+ * receiving/change chains (m/44'/309'/0'/{0|1}/{i}) can coexist with the
+ * account-axis slots (m/44'/309'/N'/0/0). Recreate-and-copy: the PK change
+ * cannot be expressed with ALTER, and recreating to the exact entity shape
+ * converges upgraders and fresh installs onto one schema (the v9 lesson).
+ * Existing rows are all account-axis; their path is backfilled from
+ * accountIndex.
+ */
+val MIGRATION_14_15 = object : Migration(14, 15) {
+    override fun migrate(db: SupportSQLiteDatabase) {
+        db.execSQL(
+            """
+            CREATE TABLE IF NOT EXISTS `sub_account_candidates_new` (
+                `parentWalletId` TEXT NOT NULL,
+                `derivationPath` TEXT NOT NULL,
+                `accountIndex` INTEGER NOT NULL,
+                `scriptArgs` TEXT NOT NULL,
+                `state` TEXT NOT NULL,
+                `createdAt` INTEGER NOT NULL,
+                `registeredFromBlock` INTEGER NOT NULL,
+                PRIMARY KEY(`parentWalletId`, `derivationPath`)
+            )
+            """.trimIndent()
+        )
+        db.execSQL(
+            """
+            INSERT INTO `sub_account_candidates_new`
+                (parentWalletId, derivationPath, accountIndex, scriptArgs, state, createdAt, registeredFromBlock)
+            SELECT parentWalletId,
+                   'm/44''/309''/' || accountIndex || '''/0/0',
+                   accountIndex, scriptArgs, state, createdAt, registeredFromBlock
+            FROM `sub_account_candidates`
+            """.trimIndent()
+        )
+        db.execSQL("DROP TABLE `sub_account_candidates`")
+        db.execSQL("ALTER TABLE `sub_account_candidates_new` RENAME TO `sub_account_candidates`")
+    }
+}

--- a/android/app/src/main/java/com/rjnr/pocketnode/data/database/dao/SubAccountCandidateDao.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/database/dao/SubAccountCandidateDao.kt
@@ -25,9 +25,9 @@ interface SubAccountCandidateDao {
 
     @Query(
         "UPDATE sub_account_candidates SET state = :state " +
-            "WHERE parentWalletId = :parentId AND accountIndex = :accountIndex"
+            "WHERE parentWalletId = :parentId AND derivationPath = :derivationPath"
     )
-    suspend fun updateState(parentId: String, accountIndex: Int, state: String)
+    suspend fun updateState(parentId: String, derivationPath: String, state: String)
 
     /**
      * Record the scan start for a registration, keeping the LOWEST block ever
@@ -35,10 +35,10 @@ interface SubAccountCandidateDao {
      */
     @Query(
         "UPDATE sub_account_candidates SET registeredFromBlock = :fromBlock " +
-            "WHERE parentWalletId = :parentId AND accountIndex = :accountIndex " +
+            "WHERE parentWalletId = :parentId AND derivationPath = :derivationPath " +
             "AND (registeredFromBlock = 0 OR registeredFromBlock > :fromBlock)"
     )
-    suspend fun updateRegisteredFrom(parentId: String, accountIndex: Int, fromBlock: Long)
+    suspend fun updateRegisteredFrom(parentId: String, derivationPath: String, fromBlock: Long)
 
     @Query("DELETE FROM sub_account_candidates WHERE parentWalletId = :parentId")
     suspend fun deleteForParent(parentId: String)

--- a/android/app/src/main/java/com/rjnr/pocketnode/data/database/entity/SubAccountCandidateEntity.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/database/entity/SubAccountCandidateEntity.kt
@@ -3,23 +3,33 @@ package com.rjnr.pocketnode.data.database.entity
 import androidx.room.Entity
 
 /**
- * A derivable-but-not-yet-restored sub-account slot recorded at parent
- * mnemonic import (#82 / #371 phase 1). Holds ONLY the public lock-script
- * args for m/44'/309'/{accountIndex}'/0/0 — never key material; keys are
- * re-derived from the parent mnemonic if the user restores the slot.
+ * A derivable-but-not-yet-restored slot recorded at parent mnemonic import
+ * (#82 / #371 phase 1; generalized for #382 Tier 2). Holds ONLY the public
+ * lock-script args for the path — never key material; keys are re-derived
+ * from the parent mnemonic when needed.
+ *
+ * Two candidate axes share this table, distinguished by [derivationPath]:
+ *  - account axis (#82):  m/44'/309'/{accountIndex}'/0/0 — restorable as a
+ *    sub-account wallet; [accountIndex] carries the restore index.
+ *  - chain axis (#382):   m/44'/309'/0'/{0|1}/{addressIndex} — gap-limit
+ *    slots other BIP44 wallets (Neuron) spread funds across; accountIndex
+ *    is 0 and these are NEVER restored as wallets (Tier 3 sweeps instead).
  *
  * Lifecycle (phase 2 consumes these):
  *  PENDING  -> registered for sync, activity unknown
- *  FOUND    -> on-chain activity seen; offer one-tap restore
- *  RESTORED -> user restored it (wallet row exists now)
+ *  FOUND    -> on-chain activity seen; offer one-tap restore (account axis)
+ *              or count toward the gap-limit found-funds surface (chain axis)
+ *  RESTORED -> user restored it (wallet row exists now; account axis only)
  *  EMPTY    -> sync completed with no activity; candidate retired
  */
 @Entity(
     tableName = "sub_account_candidates",
-    primaryKeys = ["parentWalletId", "accountIndex"],
+    primaryKeys = ["parentWalletId", "derivationPath"],
 )
 data class SubAccountCandidateEntity(
     val parentWalletId: String,
+    /** Full BIP44 path this slot derives at — the candidate's identity. */
+    val derivationPath: String,
     val accountIndex: Int,
     val scriptArgs: String,
     val state: String = STATE_PENDING,

--- a/android/app/src/main/java/com/rjnr/pocketnode/data/wallet/MnemonicManager.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/wallet/MnemonicManager.kt
@@ -64,11 +64,16 @@ class MnemonicManager @Inject constructor() {
 
     /**
      * Derive a 32-byte secp256k1 private key from a BIP39 seed using BIP32/BIP44.
-     * Derivation path: m/44'/309'/{accountIndex}'/0/{addressIndex}
+     * Derivation path: m/44'/309'/{accountIndex}'/{chainIndex}/{addressIndex}
+     *
+     * [chainIndex] is BIP44's change level: 0 = receiving chain, 1 = change
+     * chain. Everything shipped before #382 Tier 2 used chain 0 only; the
+     * default keeps those call sites byte-identical.
      */
     fun derivePrivateKey(
         seed: ByteArray,
         accountIndex: Int = 0,
+        chainIndex: Int = 0,
         addressIndex: Int = 0
     ): ByteArray {
         require(seed.size == 64) { "Seed must be 64 bytes" }
@@ -78,8 +83,8 @@ class MnemonicManager @Inject constructor() {
         key = deriveHardenedChild(key, 44)
         key = deriveHardenedChild(key, 309)
         key = deriveHardenedChild(key, accountIndex)
-        // m/44'/309'/accountIndex'/0 -> m/44'/309'/accountIndex'/0/addressIndex
-        key = deriveNormalChild(key, 0)
+        // m/44'/309'/accountIndex'/chainIndex -> .../chainIndex/addressIndex
+        key = deriveNormalChild(key, chainIndex)
         key = deriveNormalChild(key, addressIndex)
 
         return key.key

--- a/android/app/src/main/java/com/rjnr/pocketnode/data/wallet/SubAccountDiscovery.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/wallet/SubAccountDiscovery.kt
@@ -31,8 +31,16 @@ class SubAccountDiscovery @Inject constructor(
     private val keyManager: KeyManager,
 ) {
 
-    /** A derivable sub-account slot: its BIP44 account index + lock args. */
-    data class Candidate(val accountIndex: Int, val scriptArgs: String)
+    /**
+     * A derivable-but-not-owned slot: full BIP44 path + lock args. Account-
+     * axis candidates (m/44'/309'/N'/0/0) keep their account index for the
+     * restore flow; chain-axis candidates (#382 Tier 2) live on account 0.
+     */
+    data class Candidate(
+        val accountIndex: Int,
+        val scriptArgs: String,
+        val derivationPath: String,
+    )
 
     /**
      * Derive the candidate lock-script args for [window] sub-account indices
@@ -47,14 +55,50 @@ class SubAccountDiscovery @Inject constructor(
         require(window > 0) { "window must be positive" }
         val seed = mnemonicManager.mnemonicToSeed(words, passphrase)
         return (1..window).map { index ->
-            val privateKey = mnemonicManager.derivePrivateKey(seed, accountIndex = index)
-            val publicKey = keyManager.derivePublicKey(privateKey)
-            privateKey.fill(0) // wipe: args are public, the key must not linger
             Candidate(
                 accountIndex = index,
-                scriptArgs = keyManager.deriveLockScript(publicKey).args,
+                scriptArgs = argsFor(seed, accountIndex = index, chainIndex = 0, addressIndex = 0),
+                derivationPath = accountPath(index),
             )
         }
+    }
+
+    /**
+     * #382 Tier 2: derive gap-limit candidates along account 0's receiving
+     * and change chains — m/44'/309'/0'/{0|1}/{0..window} — the paths Neuron
+     * and standard BIP44 wallets actually spread funds across. Chain 0 /
+     * index 0 is the parent itself and is skipped. Args only, keys wiped.
+     */
+    fun deriveChainCandidates(
+        words: List<String>,
+        passphrase: String = "",
+        window: Int = CHAIN_GAP_WINDOW,
+    ): List<Candidate> {
+        require(window > 0) { "window must be positive" }
+        val seed = mnemonicManager.mnemonicToSeed(words, passphrase)
+        return buildList {
+            for (chain in 0..1) {
+                for (index in 0..window) {
+                    if (chain == 0 && index == 0) continue // the parent's own slot
+                    add(
+                        Candidate(
+                            accountIndex = 0,
+                            scriptArgs = argsFor(seed, 0, chain, index),
+                            derivationPath = chainPath(chain, index),
+                        )
+                    )
+                }
+            }
+        }
+    }
+
+    private fun argsFor(seed: ByteArray, accountIndex: Int, chainIndex: Int, addressIndex: Int): String {
+        val privateKey = mnemonicManager.derivePrivateKey(
+            seed, accountIndex = accountIndex, chainIndex = chainIndex, addressIndex = addressIndex
+        )
+        val publicKey = keyManager.derivePublicKey(privateKey)
+        privateKey.fill(0) // wipe: args are public, the key must not linger
+        return keyManager.deriveLockScript(publicKey).args
     }
 
     companion object {
@@ -64,5 +108,16 @@ class SubAccountDiscovery @Inject constructor(
          * window when the highest index in it turns out active.
          */
         const val CANDIDATE_WINDOW = 10
+
+        /**
+         * Address indices scanned per chain for the #382 gap-limit scan
+         * (0..window inclusive per chain). BIP44's standard gap limit is 20
+         * consecutive unused; a fixed 0..20 window covers real Neuron usage,
+         * and the reconciler can extend when index 20 turns out active.
+         */
+        const val CHAIN_GAP_WINDOW = 20
+
+        fun accountPath(accountIndex: Int) = "m/44'/309'/$accountIndex'/0/0"
+        fun chainPath(chainIndex: Int, addressIndex: Int) = "m/44'/309'/0'/$chainIndex/$addressIndex"
     }
 }

--- a/android/app/src/main/java/com/rjnr/pocketnode/data/wallet/SubAccountReconciler.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/wallet/SubAccountReconciler.kt
@@ -64,11 +64,11 @@ class SubAccountReconciler @Inject constructor(
                     Log.i(
                         TAG,
                         "Candidate found: parent=${candidate.parentWalletId} " +
-                            "index=${candidate.accountIndex} has on-chain history"
+                            "path=${candidate.derivationPath} has on-chain history"
                     )
                     candidateDao.updateState(
                         candidate.parentWalletId,
-                        candidate.accountIndex,
+                        candidate.derivationPath,
                         SubAccountCandidateEntity.STATE_FOUND,
                     )
                 }
@@ -77,7 +77,7 @@ class SubAccountReconciler @Inject constructor(
                     scanned - candidate.registeredFromBlock >= MIN_COVERED_BLOCKS -> {
                     candidateDao.updateState(
                         candidate.parentWalletId,
-                        candidate.accountIndex,
+                        candidate.derivationPath,
                         SubAccountCandidateEntity.STATE_EMPTY,
                     )
                 }

--- a/android/app/src/main/java/com/rjnr/pocketnode/data/wallet/WalletRepository.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/wallet/WalletRepository.kt
@@ -221,6 +221,7 @@ class WalletRepository @Inject constructor(
                 subAccountDiscovery.deriveCandidates(words, passphrase).map {
                     com.rjnr.pocketnode.data.database.entity.SubAccountCandidateEntity(
                         parentWalletId = walletId,
+                        derivationPath = it.derivationPath,
                         accountIndex = it.accountIndex,
                         scriptArgs = it.scriptArgs,
                         createdAt = now2,
@@ -408,7 +409,7 @@ class WalletRepository @Inject constructor(
         // means a plain no-candidate create is a harmless 0-row update).
         runCatching {
             subAccountCandidateDao.updateState(
-                parentWalletId, nextIndex,
+                parentWalletId, SubAccountDiscovery.accountPath(nextIndex),
                 com.rjnr.pocketnode.data.database.entity.SubAccountCandidateEntity.STATE_RESTORED,
             )
         }

--- a/android/app/src/main/java/com/rjnr/pocketnode/di/AppModule.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/di/AppModule.kt
@@ -21,6 +21,7 @@ import com.rjnr.pocketnode.data.database.MIGRATION_10_11
 import com.rjnr.pocketnode.data.database.MIGRATION_11_12
 import com.rjnr.pocketnode.data.database.MIGRATION_12_13
 import com.rjnr.pocketnode.data.database.MIGRATION_13_14
+import com.rjnr.pocketnode.data.database.MIGRATION_14_15
 import com.rjnr.pocketnode.data.database.dao.BalanceCacheDao
 import com.rjnr.pocketnode.data.database.dao.ContactDao
 import com.rjnr.pocketnode.data.database.dao.DaoCellDao
@@ -132,7 +133,7 @@ object AppModule {
     fun provideAppDatabase(@ApplicationContext context: Context): AppDatabase =
         Room.databaseBuilder(context, AppDatabase::class.java, "pocket_node.db")
             .setJournalMode(RoomDatabase.JournalMode.WRITE_AHEAD_LOGGING)
-            .addMigrations(MIGRATION_1_2, MIGRATION_2_3, MIGRATION_3_4, MIGRATION_4_5, MIGRATION_5_6, MIGRATION_6_7, MIGRATION_7_8, MIGRATION_8_9, MIGRATION_9_10, MIGRATION_10_11, MIGRATION_11_12, MIGRATION_12_13, MIGRATION_13_14)
+            .addMigrations(MIGRATION_1_2, MIGRATION_2_3, MIGRATION_3_4, MIGRATION_4_5, MIGRATION_5_6, MIGRATION_6_7, MIGRATION_7_8, MIGRATION_8_9, MIGRATION_9_10, MIGRATION_10_11, MIGRATION_11_12, MIGRATION_12_13, MIGRATION_13_14, MIGRATION_14_15)
             .build()
 
     @Provides

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/wallet/WalletManagerViewModel.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/wallet/WalletManagerViewModel.kt
@@ -43,13 +43,16 @@ class WalletManagerViewModel @Inject constructor(
         }
         // Discovery restore banner (#82 phase 2): sub-account slots whose
         // scripts showed on-chain history after a parent seed import.
+        // Account-axis only — chain-axis gap-limit slots (#382, accountIndex
+        // 0) are never restorable as wallets; they surface via the Tier 2
+        // found-funds flow instead.
         viewModelScope.launch {
             subAccountCandidateDao
                 .observeByState(
                     com.rjnr.pocketnode.data.database.entity.SubAccountCandidateEntity.STATE_FOUND
                 )
                 .collect { found ->
-                    _uiState.update { it.copy(foundCandidates = found) }
+                    _uiState.update { st -> st.copy(foundCandidates = found.filter { it.accountIndex >= 1 }) }
                 }
         }
     }

--- a/android/app/src/test/java/com/rjnr/pocketnode/data/database/WalkingMigrationTest.kt
+++ b/android/app/src/test/java/com/rjnr/pocketnode/data/database/WalkingMigrationTest.kt
@@ -146,6 +146,31 @@ class WalkingMigrationTest {
     }
 
     /**
+     * #382 Tier 2: a v14 file with existing account-axis candidates walked
+     * to v15 must re-key `sub_account_candidates` on
+     * (parentWalletId, derivationPath), backfilling each old row's path as
+     * m/44'/309'/{accountIndex}'/0/0 and preserving every other column.
+     */
+    @Test
+    fun `v14 candidates walk to v15 with derivationPath backfilled`() {
+        bootstrapV14WithCandidate()
+        openViaRoomAndValidate()
+        val db = openedRoomDb!!.openHelper.readableDatabase
+        db.query(
+            "SELECT derivationPath, accountIndex, scriptArgs, state, registeredFromBlock " +
+                "FROM sub_account_candidates WHERE parentWalletId = 'parent-1'"
+        ).use { c ->
+            assertTrue("candidate row lost by MIGRATION_14_15", c.moveToNext())
+            org.junit.Assert.assertEquals("m/44'/309'/3'/0/0", c.getString(0))
+            org.junit.Assert.assertEquals(3, c.getInt(1))
+            org.junit.Assert.assertEquals("0xabcdef", c.getString(2))
+            org.junit.Assert.assertEquals("FOUND", c.getString(3))
+            org.junit.Assert.assertEquals(123456L, c.getLong(4))
+            org.junit.Assert.assertFalse("unexpected extra candidate row", c.moveToNext())
+        }
+    }
+
+    /**
      * v1.6.x → v1.7.0 path: bootstrap a v9 SQLite file (no `kdfVersion`
      * column on `key_material`) and confirm MIGRATION_9_10 adds the
      * column with default 1, then Room schema validation passes.
@@ -190,7 +215,7 @@ class WalkingMigrationTest {
                 .addMigrations(
                     MIGRATION_1_2, MIGRATION_2_3, MIGRATION_3_4, MIGRATION_4_5,
                     MIGRATION_5_6, MIGRATION_6_7, MIGRATION_7_8, noOpMigration8To9,
-                    MIGRATION_9_10, MIGRATION_10_11, MIGRATION_11_12, MIGRATION_12_13, MIGRATION_13_14,
+                    MIGRATION_9_10, MIGRATION_10_11, MIGRATION_11_12, MIGRATION_12_13, MIGRATION_13_14, MIGRATION_14_15,
                 )
                 .build()
             openedRoomDb = db
@@ -220,7 +245,7 @@ class WalkingMigrationTest {
             .addMigrations(
                 MIGRATION_1_2, MIGRATION_2_3, MIGRATION_3_4, MIGRATION_4_5,
                 MIGRATION_5_6, MIGRATION_6_7, MIGRATION_7_8, MIGRATION_8_9,
-                MIGRATION_9_10, MIGRATION_10_11, MIGRATION_11_12, MIGRATION_12_13, MIGRATION_13_14,
+                MIGRATION_9_10, MIGRATION_10_11, MIGRATION_11_12, MIGRATION_12_13, MIGRATION_13_14, MIGRATION_14_15,
             )
             .build()
         openedRoomDb = db
@@ -278,6 +303,41 @@ class WalkingMigrationTest {
                 MIGRATION_8_9.migrate(db)
                 db.execSQL("CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)")
                 db.execSQL("INSERT OR REPLACE INTO room_master_table VALUES(42, 'bootstrap-v9')")
+            }
+            override fun onUpgrade(db: SupportSQLiteDatabase, oldV: Int, newV: Int) = Unit
+        }
+        val config = SupportSQLiteOpenHelper.Configuration.builder(ctx)
+            .name(dbName)
+            .callback(callback)
+            .build()
+        val helper = factory.create(config)
+        helper.writableDatabase.close()
+        helper.close()
+    }
+
+    /**
+     * Bootstrap a v14 SQLite file (full migration chain applied over the v8
+     * shape) holding one account-axis candidate row, so MIGRATION_14_15's
+     * backfill has something real to transform.
+     */
+    private fun bootstrapV14WithCandidate() {
+        val factory = FrameworkSQLiteOpenHelperFactory()
+        val callback = object : SupportSQLiteOpenHelper.Callback(14) {
+            override fun onCreate(db: SupportSQLiteDatabase) {
+                createV8Tables(db, pathA = true)
+                MIGRATION_8_9.migrate(db)
+                MIGRATION_9_10.migrate(db)
+                MIGRATION_10_11.migrate(db)
+                MIGRATION_11_12.migrate(db)
+                MIGRATION_12_13.migrate(db)
+                MIGRATION_13_14.migrate(db)
+                db.execSQL(
+                    "INSERT INTO sub_account_candidates " +
+                        "(parentWalletId, accountIndex, scriptArgs, state, createdAt, registeredFromBlock) " +
+                        "VALUES ('parent-1', 3, '0xabcdef', 'FOUND', 1000, 123456)"
+                )
+                db.execSQL("CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)")
+                db.execSQL("INSERT OR REPLACE INTO room_master_table VALUES(42, 'bootstrap-v14')")
             }
             override fun onUpgrade(db: SupportSQLiteDatabase, oldV: Int, newV: Int) = Unit
         }

--- a/android/app/src/test/java/com/rjnr/pocketnode/data/wallet/ChainDerivationTest.kt
+++ b/android/app/src/test/java/com/rjnr/pocketnode/data/wallet/ChainDerivationTest.kt
@@ -1,0 +1,61 @@
+package com.rjnr.pocketnode.data.wallet
+
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Test
+
+/**
+ * #382 Tier 2: gap-limit discovery needs keys along the receiving AND change
+ * chains — m/44'/309'/0'/{chain}/{index} — while everything shipped so far
+ * hardcodes chain 0. The chain segment is a normal (non-hardened) BIP32
+ * child, exactly like the address index.
+ *
+ * Contracts: chain 0 must be byte-identical to the legacy two-axis call
+ * (a change here would re-derive every existing wallet to a different key),
+ * chain 1 must differ, and derivation must be deterministic.
+ */
+class ChainDerivationTest {
+
+    private val manager = MnemonicManager()
+
+    private val words =
+        "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about"
+            .split(" ")
+
+    private val seed by lazy { manager.mnemonicToSeed(words) }
+
+    @Test
+    fun `chain 0 matches the legacy derivation for every address index`() {
+        for (i in 0..3) {
+            val legacy = manager.derivePrivateKey(seed, accountIndex = 0, addressIndex = i)
+            val explicit = manager.derivePrivateKey(
+                seed, accountIndex = 0, chainIndex = 0, addressIndex = i
+            )
+            assertArrayEquals("index $i", legacy, explicit)
+        }
+    }
+
+    @Test
+    fun `change chain derives a different key than the receiving chain`() {
+        val receiving = manager.derivePrivateKey(seed, accountIndex = 0, chainIndex = 0, addressIndex = 0)
+        val change = manager.derivePrivateKey(seed, accountIndex = 0, chainIndex = 1, addressIndex = 0)
+        assertFalse(receiving.contentEquals(change))
+    }
+
+    @Test
+    fun `change-chain derivation is deterministic`() {
+        val a = manager.derivePrivateKey(seed, accountIndex = 0, chainIndex = 1, addressIndex = 7)
+        val b = manager.derivePrivateKey(seed, accountIndex = 0, chainIndex = 1, addressIndex = 7)
+        assertArrayEquals(a, b)
+    }
+
+    @Test
+    fun `distinct change-chain indices derive distinct keys`() {
+        val keys = (0..5).map {
+            manager.derivePrivateKey(seed, accountIndex = 0, chainIndex = 1, addressIndex = it)
+                .joinToString("") { b -> "%02x".format(b) }
+        }
+        assertEquals(6, keys.toSet().size)
+    }
+}

--- a/android/app/src/test/java/com/rjnr/pocketnode/data/wallet/SubAccountDiscoveryTest.kt
+++ b/android/app/src/test/java/com/rjnr/pocketnode/data/wallet/SubAccountDiscoveryTest.kt
@@ -64,6 +64,68 @@ class SubAccountDiscoveryTest {
     }
 
     @Test
+    fun `account candidates carry their derivation path`() {
+        val candidate = discovery.deriveCandidates(words).first { it.accountIndex == 2 }
+        assertEquals("m/44'/309'/2'/0/0", candidate.derivationPath)
+    }
+
+    // --- #382 Tier 2: receiving/change-chain candidates -------------------
+
+    @Test
+    fun `chain candidates cover both chains through the window, excluding the parent slot`() {
+        val candidates = discovery.deriveChainCandidates(words, window = 20)
+        // chains {0,1} x indices {0..20} minus chain0/index0 (the parent) = 41
+        assertEquals(41, candidates.size)
+        assertEquals(41, candidates.map { it.scriptArgs }.toSet().size)
+        assertTrue(candidates.any { it.derivationPath == "m/44'/309'/0'/0/1" })
+        assertTrue(candidates.any { it.derivationPath == "m/44'/309'/0'/1/0" })
+        assertTrue(candidates.any { it.derivationPath == "m/44'/309'/0'/1/20" })
+        assertTrue(candidates.none { it.derivationPath == "m/44'/309'/0'/0/0" })
+        candidates.forEach {
+            assertEquals(0, it.accountIndex)
+            assertTrue(it.scriptArgs.startsWith("0x"))
+        }
+    }
+
+    @Test
+    fun `chain candidates are deterministic across calls`() {
+        assertEquals(
+            discovery.deriveChainCandidates(words),
+            discovery.deriveChainCandidates(words),
+        )
+    }
+
+    @Test
+    fun `chain candidates exclude the parent args`() {
+        val parentArgs = keyManager
+            .deriveLockScript(
+                keyManager.derivePublicKey(mnemonicManager.mnemonicToPrivateKey(words))
+            )
+            .args
+        discovery.deriveChainCandidates(words).forEach {
+            assertNotEquals(parentArgs, it.scriptArgs)
+        }
+    }
+
+    @Test
+    fun `chain candidate args match direct chain derivation`() {
+        // A mismatch means discovery would scan scripts the seed never owned.
+        val seed = mnemonicManager.mnemonicToSeed(words)
+        val expected = keyManager
+            .deriveLockScript(
+                keyManager.derivePublicKey(
+                    mnemonicManager.derivePrivateKey(
+                        seed, accountIndex = 0, chainIndex = 1, addressIndex = 3
+                    )
+                )
+            )
+            .args
+        val candidate = discovery.deriveChainCandidates(words)
+            .first { it.derivationPath == "m/44'/309'/0'/1/3" }
+        assertEquals(expected, candidate.scriptArgs)
+    }
+
+    @Test
     fun `candidate args match createSubAccount derivation for the same index`() {
         // Mirror WalletRepository.createSubAccount's exact derivation for
         // index 2; a mismatch means discovery scans scripts no restored

--- a/android/app/src/test/java/com/rjnr/pocketnode/data/wallet/SubAccountReconcilerTest.kt
+++ b/android/app/src/test/java/com/rjnr/pocketnode/data/wallet/SubAccountReconcilerTest.kt
@@ -45,6 +45,7 @@ class SubAccountReconcilerTest {
             listOf(
                 SubAccountCandidateEntity(
                     parentWalletId = parent,
+                    derivationPath = SubAccountDiscovery.accountPath(index),
                     accountIndex = index,
                     scriptArgs = args,
                     createdAt = 1L,


### PR DESCRIPTION
First of three Tier 2 sub-PRs for the gap-limit scan (design approved on the issue thread). Schema + derivation machinery only — no new candidates are created and no registration behavior changes; this PR ships dormant capability that sub-PR 2 wires up.

## What changes
- **`MnemonicManager.derivePrivateKey` gains `chainIndex`** (BIP44 change level). Default 0, so every existing call site derives byte-identical keys — TDD'd: chain 0 asserted equal to the legacy two-axis derivation across indices, chain 1 asserted different and deterministic (`ChainDerivationTest`).
- **`SubAccountDiscovery.deriveChainCandidates`**: derives `m/44'/309'/0'/{0|1}/{0..20}` minus the parent slot = 41 candidates, script args only, private keys wiped after use. `Candidate` now carries its full `derivationPath`; account-axis candidates get `m/44'/309'/N'/0/0`.
- **DB v15**: `sub_account_candidates` re-keyed on `(parentWalletId, derivationPath)` so chain-axis slots can coexist with the #82 account-axis slots. `MIGRATION_14_15` recreates the table (PK changes can't ALTER) and backfills each existing row's path from `accountIndex`. Fresh v15 migration, nothing amended in place (#384 lesson).
- **DAO re-key**: `updateState` / `updateRegisteredFrom` now keyed on `derivationPath`; `SubAccountReconciler` and the sub-account restore flow updated.
- **Guard**: the WalletManager "Found N sub-accounts" restore banner filters to account-axis candidates (`accountIndex >= 1`). Chain-axis slots are never restorable as wallets — Tier 2 surfaces them as found funds, Tier 3 sweeps them.

## Testing
- `ChainDerivationTest` (new, 4 cases) — RED verified before implementation
- `SubAccountDiscoveryTest` +5 cases: window shape (41, both chains, no parent slot), determinism, parent exclusion, args cross-checked against direct chain derivation — RED verified
- `WalkingMigrationTest`: new `v14 candidates walk to v15 with derivationPath backfilled` — bootstraps a real v14 SQLite file with a FOUND candidate row, walks it through MIGRATION_14_15, asserts path backfill + column preservation + Room schema validation — RED verified
- Full unit suite green

## Next
- Sub-PR 2: chain-candidate creation on import (auto-scan per issue thread), single-batch registration (the 5-per-cycle candidate cap would rewind-thrash for 41 scripts), wiring `updateRegisteredFrom` (currently never called — coverage gate can never retire candidates), reconciler window extension at index 20.
- Sub-PR 3: found-funds surface + banner Scan action + Tier 1 signal clearing.

Part of #382; issue stays open.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Sub-account candidates now track full derivation paths, enabling more reliable restore and discovery flows.
  * Added support for discovering both account-level and change-chain candidates.

* **Bug Fixes**
  * Updated stored candidate matching so updates and restore states use derivation paths instead of only account numbers.
  * Existing data is migrated automatically, with prior records backfilled to preserve current candidate information.

* **Tests**
  * Added migration and derivation coverage to validate the new candidate path behavior and key derivation results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->