### PR TITLE
feat(#382): Tier 2 sub-PR 2 — auto-scan wiring (creation, batched registration, coverage recording)

### DIFF
--- a/android/app/src/main/java/com/rjnr/pocketnode/data/gateway/GatewayRepository.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/gateway/GatewayRepository.kt
@@ -782,15 +782,19 @@ class GatewayRepository @Inject constructor(
         // candidates registered at import were wiped 40s later and discovery
         // never ran (#82, device-test 2026-07). Empty walletIds keep them out
         // of per-wallet progress, same contract as registerAllWalletScripts.
-        val candidateStatuses = syncCoordinator.pendingCandidateStatuses(
+        val candidateRegistrations = syncCoordinator.pendingCandidateStatuses(
             activeWalletId, info.script, blockNumberHex
         )
         val result = setScriptsAndRecord(
-            scriptStatuses + candidateStatuses,
-            listOf(activeWalletId) + candidateStatuses.map { "" },
+            scriptStatuses + candidateRegistrations.map { it.status },
+            listOf(activeWalletId) + candidateRegistrations.map { "" },
             LightClientNative.CMD_SET_SCRIPTS_ALL
         )
         if (!result) throw Exception("Failed to set scripts")
+
+        // #382: record each candidate's scan-from block — the reconciler's
+        // EMPTY coverage gate stays inert while registeredFromBlock is 0.
+        syncCoordinator.recordCandidateRegistrations(candidateRegistrations)
 
         _isRegistered.value = true
         if (savePreference) {

--- a/android/app/src/main/java/com/rjnr/pocketnode/data/gateway/SyncCoordinator.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/gateway/SyncCoordinator.kt
@@ -108,6 +108,25 @@ internal fun clampPartialRewinds(
 }
 
 /**
+ * #382 Tier 2 registration policy, pure for unit-test directness.
+ * Account-axis candidates (restorable sub-account slots) trickle at most
+ * [accountAxisCap] per cycle, lowest indices first — each batch is a fresh
+ * filter rewind and they resolve one wallet at a time. Chain-axis gap-limit
+ * candidates (accountIndex 0) register as ONE batch: 41 scripts through a
+ * capped pipe would rewind-and-rescan the window once per batch.
+ */
+fun selectCandidatesForRegistration(
+    candidates: List<com.rjnr.pocketnode.data.database.entity.SubAccountCandidateEntity>,
+    accountAxisCap: Int,
+): List<com.rjnr.pocketnode.data.database.entity.SubAccountCandidateEntity> {
+    val pending = candidates.filter {
+        it.state == com.rjnr.pocketnode.data.database.entity.SubAccountCandidateEntity.STATE_PENDING
+    }
+    val (chainAxis, accountAxis) = pending.partition { it.accountIndex == 0 }
+    return accountAxis.sortedBy { it.accountIndex }.take(accountAxisCap) + chainAxis
+}
+
+/**
  * Thin indirection over the two static JNI methods [SyncCoordinator]
  * touches. Exists so unit tests can fake the JNI surface without
  * forcing `System.loadLibrary` on the JVM — `external` methods can't
@@ -282,18 +301,52 @@ class SyncCoordinator @Inject constructor(
         walletId: String,
         lockScript: com.rjnr.pocketnode.data.gateway.models.Script,
         blockNumberHex: String,
-    ): List<JniScriptStatus> = runCatching {
-        subAccountCandidateDao.getForParent(walletId)
-            .filter { it.state == com.rjnr.pocketnode.data.database.entity.SubAccountCandidateEntity.STATE_PENDING }
-            .take(MAX_CANDIDATE_SCRIPTS_PER_PARENT)
-            .map { candidate ->
-                JniScriptStatus(
+    ): List<CandidateRegistration> = runCatching {
+        selectCandidatesForRegistration(
+            subAccountCandidateDao.getForParent(walletId),
+            accountAxisCap = MAX_CANDIDATE_SCRIPTS_PER_PARENT,
+        ).map { candidate ->
+            CandidateRegistration(
+                candidate = candidate,
+                status = JniScriptStatus(
                     script = lockScript.copy(args = candidate.scriptArgs),
                     scriptType = "lock",
                     blockNumber = blockNumberHex,
-                )
-            }
+                ),
+            )
+        }
     }.getOrDefault(emptyList())
+
+    /**
+     * A candidate paired with the script status it registers as — identity
+     * kept so a successful registration can be recorded back into
+     * `registeredFromBlock` (the reconciler's EMPTY coverage gate is inert
+     * while that column stays 0).
+     */
+    data class CandidateRegistration(
+        val candidate: com.rjnr.pocketnode.data.database.entity.SubAccountCandidateEntity,
+        val status: JniScriptStatus,
+    )
+
+    /**
+     * Persist the fromBlock each candidate was just registered to scan from
+     * (keep-min semantics live in the DAO query). Call ONLY after the
+     * CMD_SET_SCRIPTS_ALL that included these candidates succeeded.
+     */
+    suspend fun recordCandidateRegistrations(registrations: List<CandidateRegistration>) {
+        registrations.forEach { reg ->
+            val fromBlock = reg.status.blockNumber.removePrefix("0x").toLongOrNull(16) ?: return@forEach
+            runCatching {
+                subAccountCandidateDao.updateRegisteredFrom(
+                    reg.candidate.parentWalletId,
+                    reg.candidate.derivationPath,
+                    fromBlock,
+                )
+            }.onFailure {
+                Log.w(TAG, "recordCandidateRegistrations failed for ${reg.candidate.derivationPath}: ${it.message}")
+            }
+        }
+    }
 
     /**
      * BALANCED strategy filter: drop wallets whose `localSavedBlockNumber`
@@ -449,7 +502,7 @@ class SyncCoordinator @Inject constructor(
         // boot without a BiometricPrompt (#213 sub-PR 5). The cached
         // WalletEntity already has the address; AddressUtils.decode
         // round-trips to the exact same Script.
-        val pairs = coroutineScope {
+        val perWallet = coroutineScope {
             wallets.map { wallet ->
                 async(Dispatchers.IO) {
                     val lockScript = try {
@@ -496,10 +549,14 @@ class SyncCoordinator @Inject constructor(
                     // covers them. See [pendingCandidateStatuses].
                     val candidates =
                         pendingCandidateStatuses(wallet.walletId, lockScript, blockNumberHex)
-                            .map { "" to it }
-                    listOf(own) + candidates
+                    Triple(wallet.walletId, own, candidates)
                 }
-            }.awaitAll().filterNotNull().flatten()
+            }.awaitAll().filterNotNull()
+        }
+
+        val registrations = perWallet.flatMap { it.third }
+        val pairs = perWallet.flatMap { (_, own, candidates) ->
+            listOf(own) + candidates.map { "" to it.status }
         }
 
         if (pairs.isEmpty()) {
@@ -512,6 +569,10 @@ class SyncCoordinator @Inject constructor(
         Log.d(TAG, "Registering ${scriptStatuses.size} wallet scripts with light client")
         val result = setScriptsAndRecord(scriptStatuses, walletIds, LightClientNative.CMD_SET_SCRIPTS_ALL, ctx.network)
         if (!result) throw Exception("Failed to set scripts for all wallets")
+
+        // #382: persist each candidate's scan-from block so the reconciler's
+        // EMPTY coverage gate can actually pass (it is inert at 0).
+        recordCandidateRegistrations(registrations)
 
         ctx.onScriptsRegistered()
     }

--- a/android/app/src/main/java/com/rjnr/pocketnode/data/wallet/WalletRepository.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/wallet/WalletRepository.kt
@@ -215,10 +215,15 @@ class WalletRepository @Inject constructor(
         // #82 phase 1: record derivable sub-account slots while the mnemonic
         // is in memory. Args only, no keys. Never allowed to fail the import —
         // discovery is an enhancement, the wallet row above is the product.
+        // #382 Tier 2 adds the gap-limit slots along account 0's receiving
+        // and change chains: an imported seed may have been used in Neuron or
+        // any standard BIP44 wallet, which spread funds across those paths.
         runCatching {
             val now2 = System.currentTimeMillis()
+            val candidates = subAccountDiscovery.deriveCandidates(words, passphrase) +
+                subAccountDiscovery.deriveChainCandidates(words, passphrase)
             subAccountCandidateDao.insertAll(
-                subAccountDiscovery.deriveCandidates(words, passphrase).map {
+                candidates.map {
                     com.rjnr.pocketnode.data.database.entity.SubAccountCandidateEntity(
                         parentWalletId = walletId,
                         derivationPath = it.derivationPath,

--- a/android/app/src/test/java/com/rjnr/pocketnode/data/gateway/CandidateRegistrationRecordingTest.kt
+++ b/android/app/src/test/java/com/rjnr/pocketnode/data/gateway/CandidateRegistrationRecordingTest.kt
@@ -1,0 +1,121 @@
+package com.rjnr.pocketnode.data.gateway
+
+import android.content.Context
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import com.rjnr.pocketnode.data.database.AppDatabase
+import com.rjnr.pocketnode.data.database.entity.SubAccountCandidateEntity
+import com.rjnr.pocketnode.data.gateway.models.JniScriptStatus
+import com.rjnr.pocketnode.data.gateway.models.Script
+import com.rjnr.pocketnode.data.wallet.KeyManager
+import com.rjnr.pocketnode.data.wallet.MnemonicManager
+import com.rjnr.pocketnode.data.wallet.SubAccountDiscovery
+import com.rjnr.pocketnode.data.wallet.WalletPreferences
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+/**
+ * #382: `registeredFromBlock` powers the reconciler's EMPTY coverage gate
+ * but was never written by any production path — every candidate sat at 0
+ * and could never retire. [SyncCoordinator.recordCandidateRegistrations]
+ * closes that: after a successful CMD_SET_SCRIPTS_ALL, each included
+ * candidate records the block it scans from, keep-min so a later shallower
+ * registration never erases deeper coverage.
+ */
+@RunWith(RobolectricTestRunner::class)
+class CandidateRegistrationRecordingTest {
+
+    private lateinit var db: AppDatabase
+    private lateinit var coordinator: SyncCoordinator
+
+    private val parent = "parent-1"
+    private val path = SubAccountDiscovery.chainPath(1, 4)
+
+    @Before
+    fun setUp() {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        db = Room.inMemoryDatabaseBuilder(context, AppDatabase::class.java)
+            .allowMainThreadQueries()
+            .build()
+        val mnemonicManager = MnemonicManager()
+        val fakeBridge = object : LightClientBridge {
+            override suspend fun setScripts(scriptsJson: String, command: Int) = true
+            override suspend fun getTipHeaderRaw(): String? = null
+            override suspend fun getScriptsRaw(): String? = null
+        }
+        coordinator = SyncCoordinator(
+            db.walletDao(),
+            db.syncProgressDao(),
+            WalletPreferences(context),
+            KeyManager(context, mnemonicManager),
+            Json { ignoreUnknownKeys = true },
+            fakeBridge,
+            db.subAccountCandidateDao(),
+        )
+    }
+
+    @After
+    fun tearDown() = db.close()
+
+    private suspend fun seedCandidate() {
+        db.subAccountCandidateDao().insertAll(
+            listOf(
+                SubAccountCandidateEntity(
+                    parentWalletId = parent,
+                    derivationPath = path,
+                    accountIndex = 0,
+                    scriptArgs = "0xcc",
+                    createdAt = 1L,
+                )
+            )
+        )
+    }
+
+    private fun registration(fromBlockHex: String) = SyncCoordinator.CandidateRegistration(
+        candidate = SubAccountCandidateEntity(
+            parentWalletId = parent,
+            derivationPath = path,
+            accountIndex = 0,
+            scriptArgs = "0xcc",
+            createdAt = 1L,
+        ),
+        status = JniScriptStatus(
+            script = Script(Script.SECP256K1_CODE_HASH, "type", "0xcc"),
+            scriptType = "lock",
+            blockNumber = fromBlockHex,
+        ),
+    )
+
+    private suspend fun storedFromBlock(): Long =
+        db.subAccountCandidateDao().getForParent(parent).single().registeredFromBlock
+
+    @Test
+    fun `recording persists the scan-from block`() = runTest {
+        seedCandidate()
+        coordinator.recordCandidateRegistrations(listOf(registration("0x100")))
+        assertEquals(256L, storedFromBlock())
+    }
+
+    @Test
+    fun `keep-min - a shallower later registration never erases deeper coverage`() = runTest {
+        seedCandidate()
+        coordinator.recordCandidateRegistrations(listOf(registration("0x100")))
+        coordinator.recordCandidateRegistrations(listOf(registration("0x9000")))
+        assertEquals(256L, storedFromBlock())
+        coordinator.recordCandidateRegistrations(listOf(registration("0x80")))
+        assertEquals(128L, storedFromBlock())
+    }
+
+    @Test
+    fun `unparseable block hex is skipped without touching the row`() = runTest {
+        seedCandidate()
+        coordinator.recordCandidateRegistrations(listOf(registration("not-hex")))
+        assertEquals(0L, storedFromBlock())
+    }
+}

--- a/android/app/src/test/java/com/rjnr/pocketnode/data/gateway/CandidateSelectionTest.kt
+++ b/android/app/src/test/java/com/rjnr/pocketnode/data/gateway/CandidateSelectionTest.kt
@@ -1,0 +1,78 @@
+package com.rjnr.pocketnode.data.gateway
+
+import com.rjnr.pocketnode.data.database.entity.SubAccountCandidateEntity
+import com.rjnr.pocketnode.data.wallet.SubAccountDiscovery
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * #382 Tier 2 registration policy. Account-axis candidates trickle at most
+ * [SyncCoordinator.MAX_CANDIDATE_SCRIPTS_PER_PARENT] per cycle (each batch
+ * is a fresh filter rewind, and account slots resolve one wallet at a time).
+ * Chain-axis candidates must register as ONE batch: 41 scripts through a
+ * 5-slot pipe means ~9 rewinds, each re-scanning the whole window — one
+ * batch costs a single scan pass.
+ */
+class CandidateSelectionTest {
+
+    private fun account(index: Int, state: String = SubAccountCandidateEntity.STATE_PENDING) =
+        SubAccountCandidateEntity(
+            parentWalletId = "p",
+            derivationPath = SubAccountDiscovery.accountPath(index),
+            accountIndex = index,
+            scriptArgs = "0xa$index",
+            state = state,
+            createdAt = 1L,
+        )
+
+    private fun chain(chainIdx: Int, addrIdx: Int, state: String = SubAccountCandidateEntity.STATE_PENDING) =
+        SubAccountCandidateEntity(
+            parentWalletId = "p",
+            derivationPath = SubAccountDiscovery.chainPath(chainIdx, addrIdx),
+            accountIndex = 0,
+            scriptArgs = "0xc$chainIdx$addrIdx",
+            state = state,
+            createdAt = 1L,
+        )
+
+    @Test
+    fun `account axis is capped, chain axis registers whole`() {
+        val pending = (1..10).map { account(it) } +
+            (0..20).flatMap { i -> listOf(0, 1).map { c -> chain(c, i) } }
+                .filter { it.derivationPath != SubAccountDiscovery.chainPath(0, 0) }
+        val selected = selectCandidatesForRegistration(pending, accountAxisCap = 5)
+        assertEquals(5, selected.count { it.accountIndex >= 1 })
+        assertEquals(41, selected.count { it.accountIndex == 0 })
+    }
+
+    @Test
+    fun `account axis selects lowest indices first`() {
+        val selected = selectCandidatesForRegistration(
+            listOf(account(9), account(2), account(7), account(1), account(5), account(3)),
+            accountAxisCap = 3,
+        )
+        assertEquals(listOf(1, 2, 3), selected.map { it.accountIndex })
+    }
+
+    @Test
+    fun `non-pending candidates are never selected`() {
+        val selected = selectCandidatesForRegistration(
+            listOf(
+                account(1, SubAccountCandidateEntity.STATE_FOUND),
+                account(2, SubAccountCandidateEntity.STATE_EMPTY),
+                account(3, SubAccountCandidateEntity.STATE_RESTORED),
+                chain(1, 0, SubAccountCandidateEntity.STATE_FOUND),
+                chain(1, 1),
+            ),
+            accountAxisCap = 5,
+        )
+        assertEquals(1, selected.size)
+        assertEquals(SubAccountDiscovery.chainPath(1, 1), selected.single().derivationPath)
+    }
+
+    @Test
+    fun `empty input selects nothing`() {
+        assertTrue(selectCandidatesForRegistration(emptyList(), accountAxisCap = 5).isEmpty())
+    }
+}

--- a/android/app/src/test/java/com/rjnr/pocketnode/data/wallet/WalletRepositoryTest.kt
+++ b/android/app/src/test/java/com/rjnr/pocketnode/data/wallet/WalletRepositoryTest.kt
@@ -251,6 +251,55 @@ class WalletRepositoryTest {
         assertEquals(4, sub4.accountIndex)
     }
 
+    /**
+     * #382 Tier 2: importing a seed must also record gap-limit candidates
+     * along account 0's receiving/change chains — the paths Neuron spreads
+     * funds across — so the auto-scan can register them for sync.
+     */
+    @Test
+    fun `importFromMnemonic records chain-axis gap-limit candidates`() = runTest {
+        val words = mnemonicManager.generateMnemonic(MnemonicManager.WordCount.TWELVE)
+        val parent = repo.importFromMnemonic(
+            words = words,
+            name = "Neuron Import",
+            persistKeys = { walletId, bundle -> fakePersistV2(walletId, bundle) },
+        ).getOrThrow()
+
+        val candidates = db.subAccountCandidateDao().getForParent(parent.walletId)
+        val chain = candidates.filter { it.accountIndex == 0 }
+        val account = candidates.filter { it.accountIndex >= 1 }
+
+        // chains {0,1} x {0..20} minus the parent's own 0/0 slot
+        assertEquals(41, chain.size)
+        assertTrue(chain.all { it.state == com.rjnr.pocketnode.data.database.entity.SubAccountCandidateEntity.STATE_PENDING })
+        assertTrue(chain.any { it.derivationPath == "m/44'/309'/0'/1/0" })
+        assertTrue(chain.any { it.derivationPath == "m/44'/309'/0'/0/20" })
+        assertTrue(chain.none { it.derivationPath == "m/44'/309'/0'/0/0" })
+
+        // the parent's own args never appear as a candidate
+        val parentArgs = keyManager.deriveLockScriptFromAddress(parent.testnetAddress).args
+        assertTrue(chain.none { it.scriptArgs == parentArgs })
+
+        // account-axis discovery (#82) is untouched
+        assertEquals(SubAccountDiscovery.CANDIDATE_WINDOW, account.size)
+    }
+
+    /**
+     * Chain-axis slots are scan targets, not wallets. createWallet (a fresh
+     * seed that never existed elsewhere) must NOT record them — auto-scan is
+     * an import-time behavior.
+     */
+    @Test
+    fun `createWallet does not record chain-axis candidates`() = runTest {
+        val wallet = repo.createWallet(
+            name = "Fresh",
+            persistKeys = { walletId, bundle -> fakePersistV2(walletId, bundle) },
+        ).getOrThrow()
+        val chain = db.subAccountCandidateDao().getForParent(wallet.walletId)
+            .filter { it.accountIndex == 0 }
+        assertEquals(0, chain.size)
+    }
+
     @Test
     fun `deleteWallet refuses to delete active wallet`() = runTest {
         val wallet1 = repo.createWallet(


### PR DESCRIPTION
Re-opened #392 after the stack base merged (#391 squash closed it un-retargetable). Same content, rebased onto main; original description and RED-verified test list on #392.

TLDR: importFromMnemonic records the 41 chain-axis gap-limit candidates; registration policy = account-axis capped at 5/cycle, chain-axis one batch (avoids ~9 filter rewinds); pendingCandidateStatuses returns candidate+status pairs so recordCandidateRegistrations can persist registeredFromBlock after CMD_SET_SCRIPTS_ALL succeeds — that column was never written before, leaving the reconciler's EMPTY coverage gate permanently inert (latent #82 bug). Both ALL paths record.

Tests: WalletRepositoryTest +2, CandidateSelectionTest (4), CandidateRegistrationRecordingTest (3, in-memory Room + fake bridge). Full suite green.

Part of #382; sub-PR 3 (found-funds UI + Scan action + Tier 1 signal clearing) follows.