### PR TITLE
feat(#382): Tier 2 sub-PR 3 — found-funds surface, explicit scan, Tier 1 signal retirement

### DIFF
--- a/android/app/src/main/java/com/rjnr/pocketnode/data/database/dao/TransactionDao.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/database/dao/TransactionDao.kt
@@ -13,6 +13,10 @@ interface TransactionDao {
     @Query("SELECT * FROM transactions WHERE network = :network AND status = 'PENDING'")
     suspend fun getPending(network: String): List<TransactionEntity>
 
+    /** #382: hex block numbers of every cached tx for a wallet — anchors the gap-limit candidate scan depth. */
+    @Query("SELECT blockNumber FROM transactions WHERE walletId = :walletId AND network = :network")
+    suspend fun getBlockNumbers(walletId: String, network: String): List<String>
+
     @Query("SELECT * FROM transactions WHERE txHash = :txHash")
     suspend fun getByTxHash(txHash: String): TransactionEntity?
 

--- a/android/app/src/main/java/com/rjnr/pocketnode/data/gateway/GatewayRepository.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/gateway/GatewayRepository.kt
@@ -17,8 +17,13 @@ import com.rjnr.pocketnode.data.sync.SyncForegroundService
 import com.rjnr.pocketnode.data.sync.SyncProgressTracker
 import com.rjnr.pocketnode.data.migration.WalletMigrationHelper
 import com.rjnr.pocketnode.data.transaction.TransactionBuilder
+import com.rjnr.pocketnode.data.database.entity.SubAccountCandidateEntity
 import com.rjnr.pocketnode.data.wallet.AddressUtils
+import com.rjnr.pocketnode.data.wallet.GapLimitResolution
+import com.rjnr.pocketnode.data.wallet.GapLimitStatus
 import com.rjnr.pocketnode.data.wallet.KeyManager
+import com.rjnr.pocketnode.data.wallet.gapLimitResolution
+import com.rjnr.pocketnode.data.wallet.nextScanWindow
 import com.rjnr.pocketnode.data.wallet.WalletInfo
 import com.rjnr.pocketnode.data.wallet.WalletPreferences
 import com.rjnr.pocketnode.data.wallet.SyncStrategy
@@ -110,6 +115,7 @@ class GatewayRepository @Inject constructor(
     private val daoDepositReader: DaoDepositReader,
     private val lightClient: LightClientReadOnly,
     private val subAccountReconciler: com.rjnr.pocketnode.data.wallet.SubAccountReconciler,
+    private val subAccountDiscovery: com.rjnr.pocketnode.data.wallet.SubAccountDiscovery,
 ) : TipSource {
     private val sendMutex = Mutex()
 
@@ -851,6 +857,106 @@ class GatewayRepository @Inject constructor(
     fun dismissGapLimitBanner() {
         if (activeWalletId.isEmpty()) return
         walletPreferences.setGapLimitBannerDismissed(currentNetwork, activeWalletId)
+    }
+
+    /**
+     * #382 Tier 2: what the chain-axis candidate set means for the active
+     * wallet, plus the live capacity sitting on FOUND slots. Side effect:
+     * a CLEAR resolution (scan finished, nothing anywhere) retires the
+     * Tier 1 signal so the banner stops firing on stale evidence.
+     */
+    suspend fun getGapLimitStatus(): GapLimitStatus {
+        val wId = activeWalletId
+        if (wId.isEmpty()) return GapLimitStatus(GapLimitResolution.NOT_SCANNED, 0, 0L)
+        val chain = runCatching {
+            appDatabase.subAccountCandidateDao().getForParent(wId).filter { it.accountIndex == 0 }
+        }.getOrDefault(emptyList())
+        val resolution = gapLimitResolution(chain)
+        if (resolution == GapLimitResolution.CLEAR &&
+            walletPreferences.isGapLimitSignalDetected(currentNetwork, wId)
+        ) {
+            Log.i(TAG, "gap-limit scan completed clean — retiring Tier 1 signal for $wId")
+            walletPreferences.setGapLimitSignalDetected(false, currentNetwork, wId)
+        }
+        if (resolution != GapLimitResolution.FOUND) return GapLimitStatus(resolution, 0, 0L)
+
+        val myScript = _walletInfo.value?.script
+            ?: return GapLimitStatus(resolution, chain.count { it.state == SubAccountCandidateEntity.STATE_FOUND }, 0L)
+        var total = 0L
+        var count = 0
+        chain.filter { it.state == SubAccountCandidateEntity.STATE_FOUND }.forEach { cand ->
+            runCatching {
+                val cap = liveUntypedCapacityFor(JniSearchKey(script = myScript.copy(args = cand.scriptArgs)))
+                if (cap > 0L) {
+                    total += cap
+                    count++
+                }
+            }.onFailure { Log.w(TAG, "gap-limit capacity read failed for ${cand.derivationPath}: ${it.message}") }
+        }
+        return GapLimitStatus(resolution, count, total)
+    }
+
+    /**
+     * #382 Tier 2: explicit deep scan. Covers wallets imported before the
+     * auto-scan shipped, and extends the window (20 -> 40 -> 60) when the
+     * current boundary slot shows activity. Needs the mnemonic (session-auth
+     * gated by [getMnemonic]); inserts are IGNORE so already-resolved slots
+     * keep their state, then scripts re-register so the new ones enter the
+     * light-client filter. Returns the window that is now covered.
+     */
+    suspend fun runGapLimitScan(): Result<Int> = runCatching {
+        val wId = activeWalletId
+        if (wId.isEmpty()) throw Exception("No active wallet")
+        val words = getMnemonic() ?: throw Exception("Recovery phrase unavailable for this wallet")
+        val dao = appDatabase.subAccountCandidateDao()
+        val existing = dao.getForParent(wId).filter { it.accountIndex == 0 }
+        val window = nextScanWindow(existing)
+        val now = System.currentTimeMillis()
+        dao.insertAll(
+            subAccountDiscovery.deriveChainCandidates(words, window = window).map {
+                SubAccountCandidateEntity(
+                    parentWalletId = wId,
+                    derivationPath = it.derivationPath,
+                    accountIndex = it.accountIndex,
+                    scriptArgs = it.scriptArgs,
+                    createdAt = now,
+                )
+            }
+        )
+        // Fresh registration pass so new candidate scripts join the filter.
+        registerAccountWithStrategy(
+            getSavedSyncMode(), getSavedCustomBlockHeight(), savePreference = false
+        ).getOrThrow()
+        window
+    }
+
+    /**
+     * Live spendable capacity for one script: cells walked to the end, spent
+     * outpoints subtracted, typed cells excluded — the same read-path rules
+     * as refreshBalance (nativeGetCellsCapacity alone can overstate; an
+     * inflated "found funds" number would re-create the exact panic #382 is
+     * meant to end).
+     */
+    private suspend fun liveUntypedCapacityFor(searchKey: JniSearchKey): Long {
+        val searchKeyJson = json.encodeToString(searchKey)
+        val spent = fetchAllSpentOutpoints(searchKeyJson)
+        var live = 0L
+        var cursor: String? = null
+        var pages = 0
+        while (pages < MAX_CELL_PAGES) {
+            val pageJson = LightClientNative.nativeGetCells(searchKeyJson, "desc", 100, cursor) ?: break
+            val page = json.decodeFromString<JniPagination<JniCell>>(pageJson)
+            page.objects.forEach { cell ->
+                val key = "${cell.outPoint.txHash}:${cell.outPoint.index}"
+                if (key !in spent && cell.output.type == null) {
+                    live += cell.output.capacity.removePrefix("0x").toLongOrNull(16) ?: 0L
+                }
+            }
+            pages++
+            if (page.objects.isEmpty() || page.objects.size < 100 || page.lastCursor.isNullOrEmpty()) break
+            cursor = page.lastCursor
+        }
+        return live
     }
     
     suspend fun forceResetSync(): Result<Unit> = runCatching {

--- a/android/app/src/main/java/com/rjnr/pocketnode/data/gateway/GatewayRepository.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/gateway/GatewayRepository.kt
@@ -119,6 +119,10 @@ class GatewayRepository @Inject constructor(
 ) : TipSource {
     private val sendMutex = Mutex()
 
+    // #382: single-flight for the explicit gap-limit scan (Home banner and
+    // Settings both trigger it).
+    private val gapLimitScanMutex = Mutex()
+
     private val _tipFlow = MutableStateFlow(0L)
     override val tipFlow: StateFlow<Long> = _tipFlow.asStateFlow()
 
@@ -878,6 +882,8 @@ class GatewayRepository @Inject constructor(
         if (wId.isEmpty()) return GapLimitStatus(GapLimitResolution.NOT_SCANNED, 0, 0L)
         val chain = runCatching {
             appDatabase.subAccountCandidateDao().getForParent(wId).filter { it.accountIndex == 0 }
+        }.onFailure {
+            Log.w(TAG, "getGapLimitStatus: candidate read failed, treating as not scanned: ${it.message}")
         }.getOrDefault(emptyList())
         val resolution = gapLimitResolution(chain)
         if (resolution == GapLimitResolution.CLEAR &&
@@ -913,29 +919,42 @@ class GatewayRepository @Inject constructor(
      * light-client filter. Returns the window that is now covered.
      */
     suspend fun runGapLimitScan(): Result<Int> = runCatching {
-        val wId = activeWalletId
-        if (wId.isEmpty()) throw Exception("No active wallet")
-        val words = getMnemonic() ?: throw Exception("Recovery phrase unavailable for this wallet")
-        val dao = appDatabase.subAccountCandidateDao()
-        val existing = dao.getForParent(wId).filter { it.accountIndex == 0 }
-        val window = nextScanWindow(existing)
-        val now = System.currentTimeMillis()
-        dao.insertAll(
-            subAccountDiscovery.deriveChainCandidates(words, window = window).map {
-                SubAccountCandidateEntity(
-                    parentWalletId = wId,
-                    derivationPath = it.derivationPath,
-                    accountIndex = it.accountIndex,
-                    scriptArgs = it.scriptArgs,
-                    createdAt = now,
-                )
-            }
-        )
-        // Fresh registration pass so new candidate scripts join the filter.
-        registerAccountWithStrategy(
-            getSavedSyncMode(), getSavedCustomBlockHeight(), savePreference = false
-        ).getOrThrow()
-        window
+        // Single-flight: the Home banner and Settings both trigger this, and
+        // a second concurrent pass would double the derivation work and
+        // interleave two CMD_SET_SCRIPTS_ALL registrations.
+        if (!gapLimitScanMutex.tryLock()) throw Exception("A scan is already running")
+        try {
+            val wId = activeWalletId
+            if (wId.isEmpty()) throw Exception("No active wallet")
+            val words = getMnemonic() ?: throw Exception("Recovery phrase unavailable for this wallet")
+            val dao = appDatabase.subAccountCandidateDao()
+            val existing = dao.getForParent(wId).filter { it.accountIndex == 0 }
+            val window = nextScanWindow(existing)
+            val now = System.currentTimeMillis()
+            val candidates = subAccountDiscovery.deriveChainCandidates(words, window = window)
+            // The mnemonic read and derivation are slow; if the user switched
+            // wallets meanwhile, inserting rows for the OLD wallet and then
+            // registering the NEW one would corrupt the scan. Abort instead.
+            if (activeWalletId != wId) throw Exception("Wallet changed during the scan; try again")
+            dao.insertAll(
+                candidates.map {
+                    SubAccountCandidateEntity(
+                        parentWalletId = wId,
+                        derivationPath = it.derivationPath,
+                        accountIndex = it.accountIndex,
+                        scriptArgs = it.scriptArgs,
+                        createdAt = now,
+                    )
+                }
+            )
+            // Fresh registration pass so new candidate scripts join the filter.
+            registerAccountWithStrategy(
+                getSavedSyncMode(), getSavedCustomBlockHeight(), savePreference = false
+            ).getOrThrow()
+            window
+        } finally {
+            gapLimitScanMutex.unlock()
+        }
     }
 
     /**

--- a/android/app/src/main/java/com/rjnr/pocketnode/data/gateway/GatewayRepository.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/gateway/GatewayRepository.kt
@@ -788,8 +788,16 @@ class GatewayRepository @Inject constructor(
         // candidates registered at import were wiped 40s later and discovery
         // never ran (#82, device-test 2026-07). Empty walletIds keep them out
         // of per-wallet progress, same contract as registerAllWalletScripts.
+        // #382 P1: candidates register from their own HISTORICAL start, not
+        // this wallet's resume height — a tip-synced wallet resuming from
+        // ~tip would register candidates where a scan can find nothing.
+        val candidateHex = "0x" + candidateScanStart(
+            historicalStartBlock(syncMode, customBlockHeight, tipHeight, currentNetwork),
+            syncCoordinator.earliestCachedTxBlock(activeWalletId, currentNetwork.name),
+            tipHeight,
+        ).toString(16)
         val candidateRegistrations = syncCoordinator.pendingCandidateStatuses(
-            activeWalletId, info.script, blockNumberHex
+            activeWalletId, info.script, candidateHex
         )
         val result = setScriptsAndRecord(
             scriptStatuses + candidateRegistrations.map { it.status },

--- a/android/app/src/main/java/com/rjnr/pocketnode/data/gateway/SyncCoordinator.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/gateway/SyncCoordinator.kt
@@ -108,6 +108,51 @@ internal fun clampPartialRewinds(
 }
 
 /**
+ * #382: the mode-derived historical sync start for a wallet — what a fresh
+ * registration would use — ignoring any saved resume progress. Mirrors the
+ * guards both registration paths apply: a future block resets to the RECENT
+ * window, and a zero resolution outside FULL_HISTORY falls back to the
+ * network checkpoint.
+ */
+fun historicalStartBlock(
+    syncMode: SyncMode,
+    customHeight: Long?,
+    tipHeight: Long,
+    network: NetworkType,
+): Long {
+    val calculated = syncMode.toFromBlock(
+        if (syncMode == SyncMode.CUSTOM) customHeight else null, tipHeight, network
+    ).toLongOrNull() ?: 0L
+    val checkpoint = getCheckpoint(network)
+    return when {
+        calculated > tipHeight && tipHeight > 0 -> (tipHeight - 200_000L).coerceAtLeast(0L)
+        calculated == 0L && syncMode != SyncMode.FULL_HISTORY && checkpoint > 0 -> checkpoint
+        else -> calculated
+    }
+}
+
+/**
+ * #382 (sub-PR 3 review P1): the block gap-limit candidates register from.
+ * Candidates must scan HISTORY — inheriting the parent's resume height meant
+ * a tip-synced wallet registered them at ~tip, where the Neuron change can
+ * never be found. Deepest reasonable start wins:
+ *  - the mode-derived historical start ([historicalStartBlock]),
+ *  - the earliest cached transaction's block minus a small margin (sibling
+ *    change left DURING those transactions),
+ *  - and never shallower than the RECENT window when the tip is known.
+ */
+fun candidateScanStart(
+    modeDerivedStart: Long,
+    earliestKnownTxBlock: Long?,
+    tipHeight: Long,
+): Long {
+    val recentFloor = if (tipHeight > 0) (tipHeight - 200_000L).coerceAtLeast(0L) else modeDerivedStart
+    var start = minOf(modeDerivedStart, recentFloor)
+    earliestKnownTxBlock?.let { start = minOf(start, (it - 1_000L).coerceAtLeast(0L)) }
+    return start.coerceAtLeast(0L)
+}
+
+/**
  * #382 Tier 2 registration policy, pure for unit-test directness.
  * Account-axis candidates (restorable sub-account slots) trickle at most
  * [accountAxisCap] per cycle, lowest indices first — each batch is a fresh
@@ -158,6 +203,7 @@ class SyncCoordinator @Inject constructor(
     private val json: Json,
     private val lightClient: LightClientBridge,
     private val subAccountCandidateDao: com.rjnr.pocketnode.data.database.dao.SubAccountCandidateDao,
+    private val transactionDao: com.rjnr.pocketnode.data.database.dao.TransactionDao,
 ) {
 
     /**
@@ -316,6 +362,18 @@ class SyncCoordinator @Inject constructor(
             )
         }
     }.getOrDefault(emptyList())
+
+    /**
+     * Earliest cached transaction block for a wallet, or null when the cache
+     * is empty or unreadable. Anchors [candidateScanStart].
+     */
+    suspend fun earliestCachedTxBlock(walletId: String, network: String): Long? =
+        runCatching {
+            transactionDao.getBlockNumbers(walletId, network)
+                .mapNotNull { it.removePrefix("0x").toLongOrNull(16) }
+                .filter { it > 0L }
+                .minOrNull()
+        }.getOrNull()
 
     /**
      * A candidate paired with the script status it registers as — identity
@@ -547,8 +605,18 @@ class SyncCoordinator @Inject constructor(
                     // #82 phase 2: register PENDING sub-account discovery
                     // candidates alongside their parent so the filter sync
                     // covers them. See [pendingCandidateStatuses].
+                    // #382 P1: candidates get their own HISTORICAL start —
+                    // inheriting the parent's resume height registered them
+                    // at ~tip on synced wallets, where a scan finds nothing.
+                    val syncModeForWallet = walletPreferences.getSyncMode(walletId = wallet.walletId)
+                    val customForWallet = walletPreferences.getCustomBlockHeight(walletId = wallet.walletId)
+                    val candidateHex = "0x" + candidateScanStart(
+                        historicalStartBlock(syncModeForWallet, customForWallet, tipHeight, ctx.network),
+                        earliestCachedTxBlock(wallet.walletId, ctx.network.name),
+                        tipHeight,
+                    ).toString(16)
                     val candidates =
-                        pendingCandidateStatuses(wallet.walletId, lockScript, blockNumberHex)
+                        pendingCandidateStatuses(wallet.walletId, lockScript, candidateHex)
                     Triple(wallet.walletId, own, candidates)
                 }
             }.awaitAll().filterNotNull()

--- a/android/app/src/main/java/com/rjnr/pocketnode/data/wallet/GapLimitScanState.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/wallet/GapLimitScanState.kt
@@ -1,0 +1,46 @@
+package com.rjnr.pocketnode.data.wallet
+
+import com.rjnr.pocketnode.data.database.entity.SubAccountCandidateEntity
+
+/**
+ * What the chain-axis candidate set means for the active wallet (#382 Tier 2).
+ * Drives the Home surface: NOT_SCANNED offers "Scan now" on the Tier 1 banner
+ * (wallet imported before Tier 2 shipped), SCANNING shows progress copy,
+ * FOUND switches to the found-funds card, CLEAR retires the Tier 1 signal.
+ */
+enum class GapLimitResolution { NOT_SCANNED, SCANNING, FOUND, CLEAR }
+
+/** Resolution plus the live capacity found on chain-axis slots (FOUND only). */
+data class GapLimitStatus(
+    val resolution: GapLimitResolution,
+    val foundAddressCount: Int,
+    val foundShannons: Long,
+)
+
+fun gapLimitResolution(chainCandidates: List<SubAccountCandidateEntity>): GapLimitResolution = when {
+    chainCandidates.isEmpty() -> GapLimitResolution.NOT_SCANNED
+    chainCandidates.any { it.state == SubAccountCandidateEntity.STATE_PENDING } -> GapLimitResolution.SCANNING
+    chainCandidates.any { it.state == SubAccountCandidateEntity.STATE_FOUND } -> GapLimitResolution.FOUND
+    else -> GapLimitResolution.CLEAR
+}
+
+/**
+ * The gap-limit window a new scan should derive. A used slot AT the current
+ * boundary means the other wallet may have rotated past it, so extend by 20;
+ * capped at 60 (three windows — beyond that is not a realistic BIP44 wallet
+ * and every slot costs light-client sync time).
+ */
+fun nextScanWindow(chainCandidates: List<SubAccountCandidateEntity>): Int {
+    if (chainCandidates.isEmpty()) return SubAccountDiscovery.CHAIN_GAP_WINDOW
+    val boundary = chainCandidates.maxOf { addressIndexOf(it.derivationPath) }
+    val boundaryActive = chainCandidates.any {
+        it.state == SubAccountCandidateEntity.STATE_FOUND && addressIndexOf(it.derivationPath) == boundary
+    }
+    return if (boundaryActive) minOf(boundary + 20, MAX_CHAIN_GAP_WINDOW) else boundary
+}
+
+/** Last path segment of m/44'/309'/0'/{chain}/{index}; -1 if malformed. */
+private fun addressIndexOf(derivationPath: String): Int =
+    derivationPath.substringAfterLast('/').toIntOrNull() ?: -1
+
+const val MAX_CHAIN_GAP_WINDOW = 60

--- a/android/app/src/main/java/com/rjnr/pocketnode/di/AppModule.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/di/AppModule.kt
@@ -265,7 +265,8 @@ object AppModule {
         daoDepositReader: com.rjnr.pocketnode.data.gateway.DaoDepositReader,
         lightClient: com.rjnr.pocketnode.data.gateway.LightClientReadOnly,
         subAccountReconciler: com.rjnr.pocketnode.data.wallet.SubAccountReconciler,
-    ): GatewayRepository = GatewayRepository(context, keyManager, walletPreferences, json, transactionBuilder, cacheManager, daoSyncManager, walletMigrationHelper, walletDao, appDatabase, headerCacheDao, syncProgressDao, pendingBroadcastDao, broadcastClient, syncCoordinator, daoHeaderResolver, daoDepositReader, lightClient, subAccountReconciler)
+        subAccountDiscovery: com.rjnr.pocketnode.data.wallet.SubAccountDiscovery,
+    ): GatewayRepository = GatewayRepository(context, keyManager, walletPreferences, json, transactionBuilder, cacheManager, daoSyncManager, walletMigrationHelper, walletDao, appDatabase, headerCacheDao, syncProgressDao, pendingBroadcastDao, broadcastClient, syncCoordinator, daoHeaderResolver, daoDepositReader, lightClient, subAccountReconciler, subAccountDiscovery)
 
     /**
      * Production activity probe for sub-account discovery (#82 phase 2):

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/components/FoundFundsCard.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/components/FoundFundsCard.kt
@@ -1,0 +1,85 @@
+package com.rjnr.pocketnode.ui.components
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.CheckCircle
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.FilledTonalButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.pluralStringResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import com.rjnr.pocketnode.R
+import java.util.Locale
+
+/**
+ * #382 Tier 2: the gap-limit scan found live funds on receiving/change-chain
+ * addresses derived from this seed (paths another BIP44 wallet used). Shown
+ * instead of the Tier 1 GapLimitBanner once the scan resolves FOUND. Reads as
+ * good news; Tier 3 replaces the FAQ pointer with a one-tap sweep.
+ */
+@Composable
+fun FoundFundsCard(
+    foundCkb: Double,
+    addressCount: Int,
+    onLearnMore: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Card(
+        modifier = modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.tertiaryContainer,
+        ),
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(12.dp),
+            ) {
+                Icon(
+                    imageVector = Icons.Default.CheckCircle,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.onTertiaryContainer,
+                )
+                Text(
+                    text = stringResource(
+                        R.string.found_funds_title,
+                        String.format(Locale.US, "%,.2f", foundCkb),
+                    ),
+                    style = MaterialTheme.typography.titleSmall,
+                    color = MaterialTheme.colorScheme.onTertiaryContainer,
+                )
+            }
+            Text(
+                text = pluralStringResource(
+                    R.plurals.found_funds_body, addressCount, addressCount
+                ),
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onTertiaryContainer,
+            )
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.End,
+            ) {
+                FilledTonalButton(onClick = onLearnMore) {
+                    Text(stringResource(R.string.gap_limit_banner_action_learn_more))
+                }
+            }
+        }
+    }
+}

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/components/GapLimitBanner.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/components/GapLimitBanner.kt
@@ -33,6 +33,10 @@ fun GapLimitBanner(
     onLearnMore: () -> Unit,
     onDismiss: () -> Unit,
     modifier: Modifier = Modifier,
+    /** Non-null when the explicit deep scan is available (#382 Tier 2 — wallet imported before auto-scan shipped). */
+    onScanNow: (() -> Unit)? = null,
+    /** True while chain-axis candidates are still resolving — scan in progress. */
+    scanning: Boolean = false,
 ) {
     Card(
         modifier = modifier.fillMaxWidth(),
@@ -62,7 +66,10 @@ fun GapLimitBanner(
                 )
             }
             Text(
-                text = stringResource(R.string.gap_limit_banner_body),
+                text = stringResource(
+                    if (scanning) R.string.gap_limit_banner_body_scanning
+                    else R.string.gap_limit_banner_body
+                ),
                 style = MaterialTheme.typography.bodyMedium,
                 color = MaterialTheme.colorScheme.onSecondaryContainer,
             )
@@ -73,8 +80,17 @@ fun GapLimitBanner(
                 TextButton(onClick = onDismiss) {
                     Text(stringResource(R.string.gap_limit_banner_action_dismiss))
                 }
-                FilledTonalButton(onClick = onLearnMore) {
-                    Text(stringResource(R.string.gap_limit_banner_action_learn_more))
+                if (onScanNow != null && !scanning) {
+                    TextButton(onClick = onLearnMore) {
+                        Text(stringResource(R.string.gap_limit_banner_action_learn_more))
+                    }
+                    FilledTonalButton(onClick = onScanNow) {
+                        Text(stringResource(R.string.gap_limit_banner_action_scan_now))
+                    }
+                } else {
+                    FilledTonalButton(onClick = onLearnMore) {
+                        Text(stringResource(R.string.gap_limit_banner_action_learn_more))
+                    }
                 }
             }
         }

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/home/HomeScreen.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/home/HomeScreen.kt
@@ -94,6 +94,7 @@ import androidx.compose.ui.res.stringResource
 import com.rjnr.pocketnode.ui.components.SecurityBanner
 import com.rjnr.pocketnode.ui.components.SecurityBannerState
 import com.rjnr.pocketnode.ui.components.BgSyncStaleBanner
+import com.rjnr.pocketnode.ui.components.FoundFundsCard
 import com.rjnr.pocketnode.ui.components.GapLimitBanner
 import com.rjnr.pocketnode.ui.components.SyncStallBanner
 import com.rjnr.pocketnode.ui.components.SyncOptionsSheet
@@ -490,6 +491,7 @@ fun HomeScreen(
                     onBgSyncStaleDismiss = { viewModel.dismissBgSyncStalePill() },
                     onGapLimitLearnMore = { onNavigateToFaq("imported_funds") },
                     onGapLimitDismiss = { viewModel.dismissGapLimitBanner() },
+                    onGapLimitScanNow = { viewModel.runGapLimitScan() },
                 )
                 if (uiState.isSwitchingWallet) {
                     LinearProgressIndicator(
@@ -564,6 +566,7 @@ fun HomeScreenUI(
     onBgSyncStaleDismiss: () -> Unit = {},
     onGapLimitLearnMore: () -> Unit = {},
     onGapLimitDismiss: () -> Unit = {},
+    onGapLimitScanNow: () -> Unit = {},
 ) {
     val homeContentHaptic = LocalHapticFeedback.current
     PullToRefreshBox(
@@ -644,13 +647,24 @@ fun HomeScreenUI(
             }
 
             // #382: change from this seed left to addresses we never derived
-            // (seed also used in Neuron/standard BIP44 wallets). Calm notice,
-            // links to the FAQ; the Tier 2 deep scan will add a scan action.
-            if (uiState.showGapLimitBanner) {
+            // (seed also used in Neuron/standard BIP44 wallets). Calm notice
+            // with the Tier 2 deep-scan action; switches to the found-funds
+            // card once the scan resolves FOUND.
+            if (uiState.foundFundsAddressCount > 0) {
+                item {
+                    FoundFundsCard(
+                        foundCkb = uiState.foundFundsShannons / 100_000_000.0,
+                        addressCount = uiState.foundFundsAddressCount,
+                        onLearnMore = onGapLimitLearnMore,
+                    )
+                }
+            } else if (uiState.showGapLimitBanner) {
                 item {
                     GapLimitBanner(
                         onLearnMore = onGapLimitLearnMore,
                         onDismiss = onGapLimitDismiss,
+                        onScanNow = if (uiState.gapLimitScanAvailable) onGapLimitScanNow else null,
+                        scanning = uiState.gapLimitScanning,
                     )
                 }
             }

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/home/HomeViewModel.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/home/HomeViewModel.kt
@@ -8,6 +8,7 @@ import com.rjnr.pocketnode.data.gateway.CacheManager
 import com.rjnr.pocketnode.data.gateway.GatewayRepository
 import com.rjnr.pocketnode.data.gateway.SyncProgress
 import com.rjnr.pocketnode.data.sync.SyncStallDetector
+import com.rjnr.pocketnode.data.wallet.GapLimitResolution
 import com.rjnr.pocketnode.data.gateway.models.NetworkType
 import com.rjnr.pocketnode.data.gateway.models.SyncMode
 import com.rjnr.pocketnode.data.gateway.models.TransactionRecord
@@ -461,10 +462,24 @@ class HomeViewModel @Inject constructor(
                         Log.d(TAG, "  [$index] ${tx.txHash.take(16)}... dir=${tx.direction} amount=${tx.balanceChange} conf=${tx.confirmations}")
                     }
                     // #382: detection runs inside getTransactions (the only
-                    // place output scripts exist); here we only read the flag.
-                    val showGapLimit = repository.isGapLimitBannerVisible()
+                    // place output scripts exist); here we read the flag and
+                    // resolve what the chain-axis scan concluded. The status
+                    // call also retires the Tier 1 signal after a clean scan.
+                    val gapStatus = repository.getGapLimitStatus()
+                    val showGapLimit = repository.isGapLimitBannerVisible() &&
+                        (gapStatus.resolution == GapLimitResolution.NOT_SCANNED ||
+                            gapStatus.resolution == GapLimitResolution.SCANNING)
                     _uiState.update {
-                        it.copy(transactions = response.items, showGapLimitBanner = showGapLimit)
+                        it.copy(
+                            transactions = response.items,
+                            showGapLimitBanner = showGapLimit,
+                            gapLimitScanAvailable = gapStatus.resolution == GapLimitResolution.NOT_SCANNED,
+                            gapLimitScanning = gapStatus.resolution == GapLimitResolution.SCANNING,
+                            foundFundsAddressCount = if (gapStatus.resolution == GapLimitResolution.FOUND)
+                                gapStatus.foundAddressCount else 0,
+                            foundFundsShannons = if (gapStatus.resolution == GapLimitResolution.FOUND)
+                                gapStatus.foundShannons else 0L,
+                        )
                     }
                 }
                 .onFailure { error ->
@@ -847,6 +862,35 @@ class HomeViewModel @Inject constructor(
         _uiState.update { it.copy(showGapLimitBanner = false) }
     }
 
+    /**
+     * #382 Tier 2: explicit deep scan from the banner (wallets imported
+     * before auto-scan shipped, or window extension). Session-auth gated
+     * inside the repository via getMnemonic().
+     */
+    fun runGapLimitScan() {
+        viewModelScope.launch {
+            _uiState.update { it.copy(gapLimitScanning = true, gapLimitScanAvailable = false) }
+            repository.runGapLimitScan()
+                .onSuccess {
+                    Log.i(TAG, "gap-limit scan started (window $it)")
+                    refreshTransactionsOnly(silent = true)
+                }
+                .onFailure { e ->
+                    Log.e(TAG, "gap-limit scan failed", e)
+                    _uiState.update {
+                        it.copy(
+                            gapLimitScanning = false,
+                            gapLimitScanAvailable = true,
+                            error = com.rjnr.pocketnode.ui.util.UiMessage.Resource(
+                                com.rjnr.pocketnode.R.string.gap_limit_scan_failed,
+                                listOf(e.message ?: "")
+                            ),
+                        )
+                    }
+                }
+        }
+    }
+
     /** #286 pill: permanent dismissal — informational, not a nag surface. */
     fun dismissBgSyncStalePill() {
         walletPreferences.setBgSyncPillDismissed()
@@ -956,5 +1000,10 @@ data class HomeUiState(
     val showBgSyncStalePill: Boolean = false,
     // #382: history shows change that left to addresses this app never derived
     val showGapLimitBanner: Boolean = false,
+    // #382 Tier 2: chain-axis scan state for the active wallet
+    val gapLimitScanAvailable: Boolean = false,
+    val gapLimitScanning: Boolean = false,
+    val foundFundsAddressCount: Int = 0,
+    val foundFundsShannons: Long = 0L,
     val bgSyncEnabledAtOpen: Boolean = false,
 )

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/settings/SettingsScreen.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/settings/SettingsScreen.kt
@@ -364,6 +364,7 @@ fun SettingsScreen(
         },
         showThemeDialog = { viewModel.showThemeDialog() },
         onCheckForUpdate = { viewModel.checkForUpdate() },
+        onScanOtherAddresses = { viewModel.runGapLimitScan() },
         onToggleBackgroundSync = { enabled ->
             if (enabled && Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
                 val hasPermission = ContextCompat.checkSelfPermission(
@@ -397,6 +398,7 @@ private fun SettingsScreenUI(
     requestNetworkSwitch: (NetworkType) -> Unit,
     showThemeDialog: () -> Unit,
     onCheckForUpdate: () -> Unit = {},
+    onScanOtherAddresses: () -> Unit = {},
     onToggleBackgroundSync: (Boolean) -> Unit = {}
 ) {
     Scaffold(
@@ -471,6 +473,17 @@ private fun SettingsScreenUI(
                     title = "Sync Options",
                     badgeText = syncModeLabel(uiState.syncMode),
                     onClick = { showSyncDialog() }
+                )
+            }
+
+            // #382 Tier 2: explicit gap-limit scan. Recovery path for wallets
+            // whose Home banner was dismissed, and the window-extension entry
+            // (20 -> 40 -> 60) when the boundary slot showed activity.
+            item {
+                SettingsLinkRow(
+                    icon = Lucide.Wallet,
+                    title = stringResource(R.string.settings_scan_other_addresses),
+                    onClick = onScanOtherAddresses
                 )
             }
 

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/settings/SettingsViewModel.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/settings/SettingsViewModel.kt
@@ -171,6 +171,36 @@ class SettingsViewModel @Inject constructor(
         }
     }
 
+    /**
+     * #382 Tier 2: explicit gap-limit scan from Settings — the recovery path
+     * when the Home banner was dismissed, and the window-extension entry.
+     * Feedback rides the same snackbar channel as other Settings actions.
+     */
+    fun runGapLimitScan() {
+        viewModelScope.launch {
+            repository.runGapLimitScan()
+                .onSuccess {
+                    _uiState.update {
+                        it.copy(
+                            error = com.rjnr.pocketnode.ui.util.UiMessage.Resource(
+                                com.rjnr.pocketnode.R.string.gap_limit_scan_started,
+                            ),
+                        )
+                    }
+                }
+                .onFailure { e ->
+                    _uiState.update {
+                        it.copy(
+                            error = com.rjnr.pocketnode.ui.util.UiMessage.Resource(
+                                com.rjnr.pocketnode.R.string.gap_limit_scan_failed,
+                                listOf(e.message ?: ""),
+                            ),
+                        )
+                    }
+                }
+        }
+    }
+
     fun requestNetworkSwitch(target: NetworkType) {
         if (target == _uiState.value.currentNetwork) return
         _uiState.update {

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -97,7 +97,7 @@
     <string name="faq_internet_required_body">To check the blockchain itself, your phone has to talk to other CKB nodes around the world. The app does not send your private keys anywhere — those stay on your phone. Without internet, the app can show you your last known balance but cannot send or receive new transactions.</string>
 
     <string name="faq_imported_funds_title">I imported a phrase from another wallet and my balance looks wrong</string>
-    <string name="faq_imported_funds_body">Wallet apps like Neuron create many addresses from one recovery phrase and quietly rotate between them, including hidden change addresses. Pocket Node currently watches one address per account, so funds sitting on those other addresses do not show up here. That is why your balance can look lower than expected, and why a send can appear as a large negative amount with nothing received back: the change went to a sister address this app does not watch yet.\n\nYour funds are not lost. They are still controlled by your recovery phrase and nothing has left it. Until the deep scan feature arrives, you can open the same phrase in the other wallet app to see and move those funds. An upcoming update will add a deeper scan that finds these addresses, plus an option to gather the funds onto your main address.</string>
+    <string name="faq_imported_funds_body">Wallet apps like Neuron create many addresses from one recovery phrase and quietly rotate between them, including hidden change addresses. Pocket Node currently watches one address per account, so funds sitting on those other addresses do not show up here. That is why your balance can look lower than expected, and why a send can appear as a large negative amount with nothing received back: the change went to a sister address this app does not watch yet.\n\nYour funds are not lost. They are still controlled by your recovery phrase and nothing has left it. Pocket Node can now scan these extra addresses: newly imported wallets are scanned automatically, and you can start a scan any time from the notice on the home screen or from Settings, Scan Other Addresses. Funds the scan finds are shown on the home screen. An upcoming update adds a one-tap way to move them to your main address; until then you can also open the same phrase in the other wallet app to move them.</string>
     <!-- endregion -->
 
     <!-- region: SyncOptions -->
@@ -489,9 +489,19 @@
     <string name="sync_stall_banner_action_switch_recent">Use Recent</string>
     <string name="sync_stall_banner_action_dismiss">Dismiss</string>
     <string name="gap_limit_banner_title">Funds may be on other addresses</string>
-    <string name="gap_limit_banner_body">A past transaction sent change to an address from your recovery phrase that this app does not scan yet. This happens when the same phrase was used in another wallet app, such as Neuron. Your funds are safe. A deeper address scan is coming in an upcoming update.</string>
+    <string name="gap_limit_banner_body">A past transaction sent change to an address from your recovery phrase that this app does not scan yet. This happens when the same phrase was used in another wallet app, such as Neuron. Your funds are safe. Run a deeper scan to find them.</string>
+    <string name="gap_limit_banner_body_scanning">Scanning the extra addresses from your recovery phrase. This runs with normal sync and can take a few minutes. Your funds are safe.</string>
     <string name="gap_limit_banner_action_learn_more">Learn more</string>
     <string name="gap_limit_banner_action_dismiss">Dismiss</string>
+    <string name="gap_limit_banner_action_scan_now">Scan now</string>
+    <string name="gap_limit_scan_failed">Could not start the address scan: %1$s</string>
+    <string name="gap_limit_scan_started">Scanning extra addresses from your recovery phrase. Results appear on the home screen.</string>
+    <string name="settings_scan_other_addresses">Scan Other Addresses</string>
+    <string name="found_funds_title">Found %1$s CKB on other addresses</string>
+    <plurals name="found_funds_body">
+        <item quantity="one">These funds sit on %d extra address created from your recovery phrase by another wallet app. They belong to you and are safe. An upcoming update adds a one-tap way to move them to your main address.</item>
+        <item quantity="other">These funds sit on %d extra addresses created from your recovery phrase by another wallet app. They belong to you and are safe. An upcoming update adds a one-tap way to move them to your main address.</item>
+    </plurals>
     <!-- endregion -->
 
 </resources>

--- a/android/app/src/test/java/com/rjnr/pocketnode/data/gateway/CandidateRegistrationRecordingTest.kt
+++ b/android/app/src/test/java/com/rjnr/pocketnode/data/gateway/CandidateRegistrationRecordingTest.kt
@@ -57,6 +57,7 @@ class CandidateRegistrationRecordingTest {
             Json { ignoreUnknownKeys = true },
             fakeBridge,
             db.subAccountCandidateDao(),
+            db.transactionDao(),
         )
     }
 

--- a/android/app/src/test/java/com/rjnr/pocketnode/data/gateway/CandidateScanStartTest.kt
+++ b/android/app/src/test/java/com/rjnr/pocketnode/data/gateway/CandidateScanStartTest.kt
@@ -1,0 +1,88 @@
+package com.rjnr.pocketnode.data.gateway
+
+import com.rjnr.pocketnode.data.gateway.models.NetworkType
+import com.rjnr.pocketnode.data.gateway.models.SyncMode
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * #382 (Codex P1 on the sub-PR 3 review): candidate scripts must scan
+ * HISTORY. Registration inherited the parent's RESUME height, so a wallet
+ * already synced to tip registered its gap-limit candidates at ~tip and the
+ * scan could never see the blocks where the Neuron change actually lives.
+ *
+ * candidateScanStart picks the deepest reasonable start:
+ *  - the wallet's mode-derived historical start (what a fresh sync would use)
+ *  - the earliest cached transaction's block minus a margin (the sibling
+ *    change left DURING those transactions, so history starts there)
+ *  - never shallower than the RECENT window (tip - 200k) when tip is known
+ */
+class CandidateScanStartTest {
+
+    private val tip = 1_000_000L
+
+    @Test
+    fun `synced new-wallet mode still scans at least the recent window`() {
+        // mode-derived start for NEW_WALLET is the tip — useless for a scan.
+        assertEquals(800_000L, candidateScanStart(tip, null, tip))
+    }
+
+    @Test
+    fun `full history scans from genesis`() {
+        assertEquals(0L, candidateScanStart(0L, null, tip))
+    }
+
+    @Test
+    fun `earliest cached transaction anchors deeper than the floor`() {
+        assertEquals(499_000L, candidateScanStart(tip, 500_000L, tip))
+    }
+
+    @Test
+    fun `anchor near genesis clamps to zero`() {
+        assertEquals(0L, candidateScanStart(tip, 500L, tip))
+    }
+
+    @Test
+    fun `unknown tip falls back to the mode-derived start`() {
+        assertEquals(18_300_000L, candidateScanStart(18_300_000L, null, 0L))
+    }
+
+    @Test
+    fun `unknown tip still honors the transaction anchor`() {
+        assertEquals(299_000L, candidateScanStart(18_300_000L, 300_000L, 0L))
+    }
+
+    // --- historicalStartBlock: the mode-derived start, resume ignored ---
+
+    @Test
+    fun `recent mode derives tip minus window`() {
+        assertEquals(
+            800_000L,
+            historicalStartBlock(SyncMode.RECENT, null, tip, NetworkType.MAINNET),
+        )
+    }
+
+    @Test
+    fun `full history derives zero`() {
+        assertEquals(
+            0L,
+            historicalStartBlock(SyncMode.FULL_HISTORY, null, tip, NetworkType.MAINNET),
+        )
+    }
+
+    @Test
+    fun `future custom height resets to the recent window`() {
+        assertEquals(
+            800_000L,
+            historicalStartBlock(SyncMode.CUSTOM, 2_000_000L, tip, NetworkType.MAINNET),
+        )
+    }
+
+    @Test
+    fun `zero resolution outside full history falls back to checkpoint`() {
+        assertEquals(
+            18_300_000L,
+            historicalStartBlock(SyncMode.CUSTOM, null, 20_000_000L, NetworkType.MAINNET),
+        )
+    }
+}

--- a/android/app/src/test/java/com/rjnr/pocketnode/data/gateway/SyncCoordinatorCustomBlockTest.kt
+++ b/android/app/src/test/java/com/rjnr/pocketnode/data/gateway/SyncCoordinatorCustomBlockTest.kt
@@ -108,6 +108,7 @@ class SyncCoordinatorCustomBlockTest {
             json = json,
             lightClient = fakeBridge,
             subAccountCandidateDao = db.subAccountCandidateDao(),
+            transactionDao = db.transactionDao(),
         )
     }
 

--- a/android/app/src/test/java/com/rjnr/pocketnode/data/wallet/GapLimitScanStateTest.kt
+++ b/android/app/src/test/java/com/rjnr/pocketnode/data/wallet/GapLimitScanStateTest.kt
@@ -1,0 +1,92 @@
+package com.rjnr.pocketnode.data.wallet
+
+import com.rjnr.pocketnode.data.database.entity.SubAccountCandidateEntity
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * #382 Tier 2 sub-PR 3: pure decisions driving the Home surface and the
+ * explicit scan action.
+ *
+ * Resolution: what the chain-axis candidate set means for the active wallet.
+ *  - no candidates  -> NOT_SCANNED (imported before Tier 2; offer Scan now)
+ *  - any PENDING    -> SCANNING (registration/reconcile still working)
+ *  - any FOUND      -> FOUND (show found-funds surface)
+ *  - all EMPTY      -> CLEAR (scan finished clean; Tier 1 signal can clear)
+ *
+ * Window: the gap-limit window a new scan should derive. Extends by 20 when
+ * the current boundary index shows activity (a used slot at the edge means
+ * the wallet may have rotated past it), capped at 60.
+ */
+class GapLimitScanStateTest {
+
+    private fun chain(chainIdx: Int, addrIdx: Int, state: String) =
+        SubAccountCandidateEntity(
+            parentWalletId = "p",
+            derivationPath = SubAccountDiscovery.chainPath(chainIdx, addrIdx),
+            accountIndex = 0,
+            scriptArgs = "0x$chainIdx$addrIdx",
+            state = state,
+            createdAt = 1L,
+        )
+
+    private val pending = SubAccountCandidateEntity.STATE_PENDING
+    private val found = SubAccountCandidateEntity.STATE_FOUND
+    private val empty = SubAccountCandidateEntity.STATE_EMPTY
+
+    // --- resolution ---
+
+    @Test
+    fun `no chain candidates means not scanned`() {
+        assertEquals(GapLimitResolution.NOT_SCANNED, gapLimitResolution(emptyList()))
+    }
+
+    @Test
+    fun `any pending means still scanning`() {
+        assertEquals(
+            GapLimitResolution.SCANNING,
+            gapLimitResolution(listOf(chain(0, 1, empty), chain(1, 0, pending), chain(1, 1, found))),
+        )
+    }
+
+    @Test
+    fun `found wins once nothing is pending`() {
+        assertEquals(
+            GapLimitResolution.FOUND,
+            gapLimitResolution(listOf(chain(0, 1, empty), chain(1, 3, found))),
+        )
+    }
+
+    @Test
+    fun `all empty means clear`() {
+        assertEquals(
+            GapLimitResolution.CLEAR,
+            gapLimitResolution(listOf(chain(0, 1, empty), chain(1, 0, empty))),
+        )
+    }
+
+    // --- window ---
+
+    @Test
+    fun `no candidates scans the default window`() {
+        assertEquals(SubAccountDiscovery.CHAIN_GAP_WINDOW, nextScanWindow(emptyList()))
+    }
+
+    @Test
+    fun `quiet boundary keeps the current window`() {
+        val candidates = listOf(chain(0, 20, empty), chain(1, 20, empty), chain(1, 5, found))
+        assertEquals(20, nextScanWindow(candidates))
+    }
+
+    @Test
+    fun `active boundary extends by twenty`() {
+        val candidates = listOf(chain(0, 20, found), chain(1, 20, empty))
+        assertEquals(40, nextScanWindow(candidates))
+    }
+
+    @Test
+    fun `extension caps at sixty`() {
+        val candidates = listOf(chain(0, 60, found), chain(1, 60, found))
+        assertEquals(60, nextScanWindow(candidates))
+    }
+}


### PR DESCRIPTION
Last Tier 2 sub-PR. The scan machinery from #391/#393 gets its user-facing surface.

## What changes
- **Pure scan-state logic** (`GapLimitScanState.kt`, TDD, 8 cases): `gapLimitResolution` maps the chain-axis candidate set to NOT_SCANNED / SCANNING / FOUND / CLEAR; `nextScanWindow` extends 20 -> 40 -> 60 only when the boundary slot itself showed activity.
- **`getGapLimitStatus`**: resolution + live capacity on FOUND slots. Capacity is computed per script with a full cell walk, spent-set subtraction, and typed-cell exclusion — the same read-path rules as refreshBalance, because `nativeGetCellsCapacity` alone can overstate and an inflated "Found X CKB" would re-create the exact panic this issue is about. A CLEAR resolution retires the Tier 1 signal pref.
- **`runGapLimitScan`**: explicit deep scan. Mnemonic via the session-auth-gated `getMnemonic`, derivation at `nextScanWindow`, IGNORE-insert so resolved slots keep their state, then `registerAccountWithStrategy` so the new scripts join the light-client filter.
- **UI** (all surfaces from the approved design):
  - `FoundFundsCard` (tertiary palette, CheckCircle — deliberately reads as good news): "Found X CKB on other addresses", replaces the Tier 1 banner once FOUND.
  - `GapLimitBanner` gains **Scan now** when the wallet predates auto-scan (NOT_SCANNED) and switches to scanning copy while candidates are PENDING.
  - **Settings > Scan Other Addresses**: recovery path when the Home banner was dismissed, and the window-extension entry. Snackbar feedback.
  - FAQ body updated now that the scan exists.

## Testing
- `GapLimitScanStateTest` — RED verified before implementation
- Full unit suite green
- Device verification with a real Neuron-used seed is the next step before Tier 3 (sweep) — testnet plan: Neuron testnet wallet, spread funds across /0/{i} and /1/{i}, import into Pocket Node, confirm auto-scan finds them and amounts match the explorer.

Part of #382; Tier 3 (single signed sweep transaction to the main address) is the remaining tier.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for scanning additional wallet addresses and showing discovered funds in the app.
  * Introduced a new “Scan other addresses” action in Settings and a scan-now option in the gap-limit banner.
  * Added a new card to highlight found funds on the home screen.

* **Bug Fixes**
  * Improved gap-limit detection and scan status handling so the app can better reflect whether extra funds are available, still scanning, or cleared.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->