### PR TITLE
fix(382): explicit gap-limit scan re-arms EMPTY chain slots

### DIFF
--- a/android/app/src/main/java/com/rjnr/pocketnode/data/database/dao/SubAccountCandidateDao.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/database/dao/SubAccountCandidateDao.kt
@@ -44,6 +44,20 @@ interface SubAccountCandidateDao {
     )
     suspend fun updateRegisteredFrom(parentId: String, derivationPath: String, fromBlock: Long)
 
+    /**
+     * Re-arm retired chain-axis slots for an explicit re-scan (#382). EMPTY
+     * is a verdict about a PAST scan; a user-triggered "Scan Other Addresses"
+     * must look again (funds may have arrived since, or the verdict came from
+     * a different network's scan). Account-axis slots (accountIndex > 0) are
+     * left alone — their EMPTY still gates the restore banner.
+     * Returns rows re-armed.
+     */
+    @Query(
+        "UPDATE sub_account_candidates SET state = 'PENDING' " +
+            "WHERE parentWalletId = :parentId AND accountIndex = 0 AND state = 'EMPTY'"
+    )
+    suspend fun reArmEmptyChainSlots(parentId: String): Int
+
     @Query("DELETE FROM sub_account_candidates WHERE parentWalletId = :parentId")
     suspend fun deleteForParent(parentId: String)
 }

--- a/android/app/src/main/java/com/rjnr/pocketnode/data/gateway/GatewayRepository.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/gateway/GatewayRepository.kt
@@ -947,6 +947,15 @@ class GatewayRepository @Inject constructor(
                     )
                 }
             )
+            // An explicit scan means "look AGAIN": re-arm chain slots a past
+            // pass retired as EMPTY. Without this the action was a silent
+            // no-op after any completed scan — funds arriving later (or on a
+            // different network than the pass that retired them) were
+            // undiscoverable forever (device-verification, 2026-07). The
+            // reconciler's probe re-judges them: activity -> FOUND, still
+            // nothing -> EMPTY again shortly.
+            val reArmed = dao.reArmEmptyChainSlots(wId)
+            if (reArmed > 0) Log.i(TAG, "gap-limit scan: re-armed $reArmed retired slot(s)")
             // Fresh registration pass so new candidate scripts join the filter.
             registerAccountWithStrategy(
                 getSavedSyncMode(), getSavedCustomBlockHeight(), savePreference = false

--- a/android/app/src/test/java/com/rjnr/pocketnode/data/wallet/SubAccountReconcilerTest.kt
+++ b/android/app/src/test/java/com/rjnr/pocketnode/data/wallet/SubAccountReconcilerTest.kt
@@ -116,6 +116,47 @@ class SubAccountReconcilerTest {
         assertEquals(SubAccountCandidateEntity.STATE_PENDING, stateOf(2))
     }
 
+    /**
+     * #382 explicit re-scan: EMPTY chain slots (accountIndex 0) re-arm to
+     * PENDING; account-axis EMPTY stays retired (still gates the restore
+     * banner). Without re-arm, "Scan Other Addresses" was a silent no-op
+     * after any completed pass (device-verification, 2026-07).
+     */
+    @Test
+    fun `explicit re-scan re-arms EMPTY chain slots only`() = runTest {
+        dao.insertAll(
+            listOf(
+                SubAccountCandidateEntity(
+                    parentWalletId = parent,
+                    derivationPath = "m/44'/309'/0'/1/3",
+                    accountIndex = 0,
+                    scriptArgs = "0xchain",
+                    state = SubAccountCandidateEntity.STATE_EMPTY,
+                    createdAt = 1L,
+                ),
+                SubAccountCandidateEntity(
+                    parentWalletId = parent,
+                    derivationPath = SubAccountDiscovery.accountPath(2),
+                    accountIndex = 2,
+                    scriptArgs = "0xacct",
+                    state = SubAccountCandidateEntity.STATE_EMPTY,
+                    createdAt = 1L,
+                ),
+            )
+        )
+        val reArmed = dao.reArmEmptyChainSlots(parent)
+        assertEquals(1, reArmed)
+        val rows = dao.getForParent(parent)
+        assertEquals(
+            SubAccountCandidateEntity.STATE_PENDING,
+            rows.first { it.accountIndex == 0 }.state,
+        )
+        assertEquals(
+            SubAccountCandidateEntity.STATE_EMPTY,
+            rows.first { it.accountIndex == 2 }.state,
+        )
+    }
+
     @Test
     fun `FOUND survives later empty-looking passes`() = runTest {
         seed(1, "0xaa", registeredFrom = 100_000L)


### PR DESCRIPTION
Found during the pre-release device verification of the #382 Tier 2 scan.

## Bug
Once any scan pass retires the chain candidates as EMPTY, **Settings → Scan Other Addresses becomes a silent no-op**: the IGNORE-insert preserves retired rows, `selectCandidatesForRegistration` finds nothing PENDING, and the registration shrinks to just the parent script (observed live: 47 scripts at import → 6 → 1, while the scan snackbar claimed success). Real-world consequence: a user who scans before their funds arrive — or whose slots were retired by a pass on the other network — can never discover those funds.

## Fix
The explicit scan flips the parent's EMPTY **chain-axis** slots back to PENDING before re-registering (`reArmEmptyChainSlots`). The reconciler's probe re-judges them: activity → FOUND; still nothing → EMPTY again shortly (coverage gate unchanged). Account-axis EMPTY stays retired — it still gates the sub-account restore banner.

## Verification
- Unit: re-arm flips chain EMPTY only, account-axis EMPTY untouched (in-memory Room).
- Emulator (testnet, faucet-funded `/0/0/1` + `/0/1/0` from a seed whose slots were retired by a mainnet pass): fixed build logs `re-armed 41 retired slot(s)` → `Registering 42 wallet scripts`; filter scan in progress toward FOUND.

Full unit suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Explicit deep scans can now re-enable previously retired chain slots, helping discover funds that may have been missed after an earlier scan.

* **Bug Fixes**
  * Improved scan behavior so only eligible empty chain slots are re-armed, preventing unintended changes to other slots.

* **Tests**
  * Added regression coverage to verify the re-scan behavior works as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->