### PR TITLE
fix(tx): smallest-first, change-aware cell selection (learned from Neuron)

### DIFF
--- a/android/app/src/main/java/com/rjnr/pocketnode/data/transaction/TransactionBuilder.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/transaction/TransactionBuilder.kt
@@ -632,20 +632,41 @@ class TransactionBuilder @Inject constructor(
         }
     }
 
-    private fun selectCells(cells: List<Cell>, requiredCapacity: Long): Pair<List<Cell>, Long> {
+    // internal for CellSelectionOrderTest — selection order is behavioural and
+    // deserves direct coverage rather than only through buildTransfer.
+    internal fun selectCells(
+        cells: List<Cell>,
+        requiredCapacity: Long,
+        minChange: Long = MIN_CELL_CAPACITY,
+    ): Pair<List<Cell>, Long> {
         val sortedCells = cells
             .filter { it.type == null }
             // Malformed capacity hex from the node: skip the cell rather than
             // abort the whole selection — same treatment as
             // calculateMaxSendable (#321).
             .mapNotNull { cell -> parseCapacity(cell.capacity)?.let { cell to it } }
-            .sortedByDescending { (_, capacity) -> capacity }
+            // Smallest-first (Neuron's cells.ts does the same). Largest-first
+            // kept txs small but never spent dust, so a frequently-funded
+            // wallet fragmented until a send needed 100+ inputs and hit the
+            // fee/size edge (Alex, #395). Smallest-first sweeps dust into
+            // every send, bounding fragmentation. Cost: slightly larger txs,
+            // now priced correctly by the #395 fee fix.
+            .sortedBy { (_, capacity) -> capacity }
 
         val selected = mutableListOf<Cell>()
         var total = 0L
 
         for ((cell, capacity) in sortedCells) {
-            if (total >= requiredCapacity) break
+            // Stop once the amount+fee is covered AND the leftover change is
+            // viable — either exact (no change output) or at least a whole
+            // min-capacity cell. Stopping the instant `total >= required`
+            // (the old behaviour) could strand the remainder in the dust zone
+            // (0, 61 CKB), which buildTransfer then refuses as dust change —
+            // a send that would have succeeded. Smallest-first makes that
+            // overshoot common, so selection has to keep going one more cell
+            // to escape the zone. Mirrors Neuron's gatherInputs stop rule.
+            val change = total - requiredCapacity
+            if (total >= requiredCapacity && (change == 0L || change >= minChange)) break
             selected.add(cell)
             total += capacity
         }

--- a/android/app/src/test/java/com/rjnr/pocketnode/data/transaction/CellSelectionOrderTest.kt
+++ b/android/app/src/test/java/com/rjnr/pocketnode/data/transaction/CellSelectionOrderTest.kt
@@ -1,0 +1,107 @@
+package com.rjnr.pocketnode.data.transaction
+
+import com.rjnr.pocketnode.data.gateway.models.Cell
+import com.rjnr.pocketnode.data.gateway.models.OutPoint
+import com.rjnr.pocketnode.data.gateway.models.Script
+import com.rjnr.pocketnode.data.validation.NetworkValidator
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+/**
+ * Cell selection order (learned from Neuron's cells.ts, which sorts ascending
+ * and stops only when change is viable). Pocket Node selected LARGEST-first,
+ * which keeps transactions small but never spends dust — so a frequently
+ * funded wallet (mining payouts, many receives) fragments until a send needs
+ * 100+ inputs and tips over the fee/size edge (Alex, Telegram 2026-07).
+ *
+ * Smallest-first sweeps dust into every send; the change-viability stop keeps
+ * that from stranding the remainder below the 61 CKB minimum (which would be
+ * refused as dust change — a regression a naive smallest-first would cause).
+ */
+@RunWith(RobolectricTestRunner::class)
+class CellSelectionOrderTest {
+
+    private val builder = TransactionBuilder(NetworkValidator())
+    private val ckb = 100_000_000L
+    private val minChange = 61 * ckb
+
+    private fun cell(capacityCkb: Long, tag: String) = Cell(
+        outPoint = OutPoint(txHash = "0x" + tag.repeat(64).take(64), index = "0x0"),
+        capacity = "0x${(capacityCkb * ckb).toString(16)}",
+        blockNumber = "0x100",
+        lock = Script(Script.SECP256K1_CODE_HASH, "type", "0x" + "ab".repeat(20)),
+        type = null,
+        data = "0x",
+    )
+
+    private fun caps(cells: List<Cell>) =
+        cells.map { it.capacity.removePrefix("0x").toLong(16) / ckb }
+
+    @Test
+    fun `dust is consumed before large cells`() {
+        // Enough dust to fund the send AND leave viable change, so the big
+        // cell is never touched — the opposite of largest-first.
+        val cells = listOf(cell(200_000, "a"), cell(61, "b"), cell(62, "c"), cell(63, "d"), cell(64, "e"))
+        val (selected, _) = builder.selectCells(cells, requiredCapacity = 100 * ckb, minChange = minChange)
+        assertTrue("big cell must not be spent", caps(selected).none { it == 200_000L })
+        assertTrue("dust is swept in", caps(selected).containsAll(listOf(61L, 62L, 63L)))
+    }
+
+    @Test
+    fun `selection stops once change is viable, not the instant it is covered`() {
+        // 61+62 = 123 covers 100 but leaves 23 CKB change (dust); must add one
+        // more to lift change over the 61 CKB minimum, then stop.
+        val cells = listOf(cell(61, "a"), cell(62, "b"), cell(63, "c"), cell(64, "d"))
+        val (selected, total) = builder.selectCells(cells, requiredCapacity = 100 * ckb, minChange = minChange)
+        assertEquals(listOf(61L, 62L, 63L), caps(selected).sorted())
+        assertTrue("change must clear the min-capacity floor", total - 100 * ckb >= minChange)
+    }
+
+    @Test
+    fun `keeps selecting to escape the dust-change zone when a rescue cell exists`() {
+        // 61+62+63 = 186 covers 150 but change is 36 (dust); the 100 cell is
+        // pulled in to make change viable rather than refusing the send.
+        val cells = listOf(cell(61, "a"), cell(62, "b"), cell(63, "c"), cell(100, "d"))
+        val (selected, total) = builder.selectCells(cells, requiredCapacity = 150 * ckb, minChange = minChange)
+        assertTrue("rescue cell included", caps(selected).contains(100L))
+        assertTrue(total - 150 * ckb >= minChange)
+    }
+
+    @Test
+    fun `normal wallet with one big cell selects just it`() {
+        val cells = listOf(cell(10_000, "a"))
+        val (selected, _) = builder.selectCells(cells, requiredCapacity = 100 * ckb, minChange = minChange)
+        assertEquals(listOf(10_000L), caps(selected))
+    }
+
+    @Test
+    fun `large send reaches into big cells after exhausting dust`() {
+        val cells = listOf(cell(200_000, "a"), cell(61, "b"), cell(62, "c"))
+        val (selected, total) = builder.selectCells(cells, requiredCapacity = 1_000 * ckb, minChange = minChange)
+        assertTrue("must include the big cell", caps(selected).any { it == 200_000L })
+        assertTrue("dust swept in first", caps(selected).containsAll(listOf(61L, 62L)))
+        assertTrue(total >= 1_000 * ckb)
+    }
+
+    @Test
+    fun `exhausting all cells returns them even if change would be dust`() {
+        // No rescue cell — selection returns everything and buildTransfer's own
+        // dust-change guard decides. Selection must not loop forever.
+        val cells = listOf(cell(61, "a"), cell(62, "b"), cell(63, "c"))
+        val (selected, total) = builder.selectCells(cells, requiredCapacity = 150 * ckb, minChange = minChange)
+        assertEquals(3, selected.size)
+        assertEquals(186 * ckb, total)
+    }
+
+    @Test
+    fun `typed cells are never selected`() {
+        val typed = cell(500, "e").copy(
+            type = Script("0x82d76d1b75fe2fd9a27dfbaa65a039221a380d76c926f378d3f81cf3e7e13f2e", "type", "0x")
+        )
+        val (selected, _) = builder.selectCells(listOf(typed, cell(61, "f"), cell(62, "g"), cell(63, "h")), 100 * ckb, minChange)
+        assertTrue(caps(selected).none { it == 500L })
+    }
+}


### PR DESCRIPTION
Learned from a research pass on Neuron (official CKB wallet). Neuron sorts candidate cells ascending (smallest-first) and stops selecting only when change is viable; Pocket Node sorted largest-first and stopped the instant the amount was covered.

## Why
Largest-first keeps individual transactions small but **never spends dust**. A frequently-funded wallet (mining payouts, many receives — Alex's wallet) accumulates small cells until a send needs 100+ inputs and tips over the fee/size edge (the #395 low-fee-rejection). Smallest-first sweeps dust into every send, so fragmentation stays bounded on its own.

## The subtlety (why it's not a one-line sort flip)
A naive smallest-first regresses sends: the accumulated dust often overshoots the amount by **less than the 61 CKB minimum cell capacity**, leaving change in the dust zone that our guard then refuses (#287) — a send that largest-first would have completed. Neuron's `gatherInputs` avoids this by continuing until change is exact or ≥ a min cell. So `selectCells` now:
- sorts **ascending**;
- stops only when `total ≥ amount+fee` **and** change is `0` or `≥ minChange` (default `MIN_CELL_CAPACITY`), pulling in one more cell to escape the dust zone when a rescue cell exists;
- returns everything if cells exhaust (no infinite loop; buildTransfer's dust guard still decides).

`minChange` defaults to `MIN_CELL_CAPACITY`, so `buildTransfer` and the DAO callers get the behaviour for free.

## Tradeoff
Slightly larger average transactions (more inputs). That's now priced correctly by the #395 fee fix, and it's the deliberate cost of self-consolidation.

## Testing
- `CellSelectionOrderTest` (new, 7 cases, RED-verified): dust-before-big, viable-change stop, dust-zone rescue, single-big-cell normal wallet, large-send reaches big cells, cells-exhausted, typed-excluded.
- Full unit suite green.

Part of the Neuron-research follow-ups. Companion findings (read-path audit = clean; a sync-progress invariant gap) reported separately.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved transfer handling so smaller spendable inputs are used first, helping avoid unusable leftover amounts.
  - Added safer selection behavior that continues gathering inputs until the remaining change is actually usable or exactly zero.
  - Prevented cases where transfers could stop too early and leave “dust” change behind.
  - Strengthened validation with coverage for edge cases, including mixed input sizes and non-spendable inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->