### PR TITLE
fix(dao): page-cap DaoDepositReader walks + document the sync-invariant decision

### DIFF
--- a/android/app/src/main/java/com/rjnr/pocketnode/data/gateway/DaoDepositReader.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/gateway/DaoDepositReader.kt
@@ -76,16 +76,24 @@ class DaoDepositReader @Inject constructor(
         )
         val searchKeyJson = json.encodeToString(searchKey)
 
-        // Paginate all cells by lock script
+        // Paginate all cells by lock script. Cap is a runaway guard only
+        // (logged when hit), matching the read-path convention in
+        // GatewayRepository — never a functional limit that could truncate
+        // real history and undercount deposits.
         val allCellObjects = mutableListOf<JniCell>()
         var cellsCursor: String? = null
+        var cellPages = 0
         do {
             val pageJson = LightClientNative.nativeGetCells(searchKeyJson, "desc", 100, cellsCursor)
                 ?: break
             val page = json.decodeFromString<JniPagination<JniCell>>(pageJson)
             allCellObjects += page.objects
             cellsCursor = page.lastCursor?.takeUnless { it == cellsCursor }
-        } while (cellsCursor != null)
+            cellPages++
+        } while (cellsCursor != null && cellPages < MAX_PAGES)
+        if (cellPages >= MAX_PAGES) {
+            Log.w(TAG, "list: hit $MAX_PAGES-page cap walking DAO cells — list may be incomplete")
+        }
 
         // Filter locally: only cells whose type script matches DAO code hash
         val daoCells = allCellObjects.filter { cell ->
@@ -93,9 +101,10 @@ class DaoDepositReader @Inject constructor(
         }
         Log.d(TAG, "📋 getDaoDeposits: ${daoCells.size} DAO cells out of ${allCellObjects.size} total")
 
-        // Paginate transactions to find spent outpoints
+        // Paginate transactions to find spent outpoints (same runaway guard).
         val spentOutpoints = mutableSetOf<String>()
         var txCursor: String? = null
+        var txPages = 0
         do {
             val txJson = LightClientNative.nativeGetTransactions(searchKeyJson, "desc", 100, txCursor)
                 ?: break
@@ -106,7 +115,11 @@ class DaoDepositReader @Inject constructor(
                 }
             }
             txCursor = txPag.lastCursor?.takeUnless { it == txCursor }
-        } while (txCursor != null)
+            txPages++
+        } while (txCursor != null && txPages < MAX_PAGES)
+        if (txPages >= MAX_PAGES) {
+            Log.w(TAG, "list: hit $MAX_PAGES-page cap walking DAO spent-set — result may be incomplete")
+        }
 
         val liveDaoCells = daoCells.filter { cell ->
             val key = "${cell.outPoint.txHash}:${cell.outPoint.index}"
@@ -328,5 +341,11 @@ class DaoDepositReader @Inject constructor(
 
     companion object {
         private const val TAG = "DaoDepositReader"
+
+        // Runaway guard for the cell / spent-set walks (100 items per page).
+        // Generous — a real wallet's DAO history is far smaller; this only
+        // bounds a pathological/looping cursor, and it logs when hit so a
+        // genuine truncation is visible rather than silent.
+        private const val MAX_PAGES = 200
     }
 }

--- a/android/app/src/main/java/com/rjnr/pocketnode/data/gateway/GatewayRepository.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/gateway/GatewayRepository.kt
@@ -1376,8 +1376,21 @@ class GatewayRepository @Inject constructor(
             0.0
         }
         
-        val isSynced = tipNumber > 0 && 
-                scriptBlockNumber >= tipNumber - 10 && 
+        // isSynced tracks the ACTIVE WALLET'S PRIMARY script only — deliberately
+        // NOT a MIN across its #382 gap-limit candidate scripts. This looks like
+        // Neuron's #2992 ("light client sync miss some tx"), but that was a real
+        // miss: Neuron advanced a SHARED fetch cursor past lagging scripts, so
+        // their range never got refetched. Our embedded light client scans each
+        // registered script INDEPENDENTLY to tip, and candidates re-register from
+        // their own historical start (candidateScanStart), so a lagging candidate
+        // is never abandoned — it keeps catching up and its cells get indexed.
+        // Gating isSynced on candidates would instead show "syncing" for the
+        // entire background discovery deep-scan while the user's own funds are
+        // already synced and spendable — strictly worse UX. The candidate
+        // lifecycle (FOUND/EMPTY/found-funds) is gated separately and correctly
+        // by SubAccountReconciler's coverage rule. Do not "fix" this into a MIN.
+        val isSynced = tipNumber > 0 &&
+                scriptBlockNumber >= tipNumber - 10 &&
                 scriptBlockNumber <= tipNumber + 10 // Handle slight mismatches safely
         
         Log.d(TAG, "📊 SYNC PROGRESS: ${(progress * 100).toInt()}% synced, isSynced=$isSynced")


### PR DESCRIPTION
Two small hardening items from the Neuron-research read-path/sync audit.

## 1. DaoDepositReader runaway page-cap
`DaoDepositReader.list` had the only two computation-feeding cursor walks without a runaway page cap; every other walk (`getTransactions`, `getCells`, `refreshBalance`, `fetchAllSpentOutpoints`) guards with `MAX_*_PAGES` + a warning log. Not a live bug (DAO history is sparse), but a looping cursor would spin unbounded. Cap at 200 pages with a warning when hit.

## 2. Document the sync-invariant decision (no behavior change)
The audit flagged that `isSynced` tracks the active wallet's primary script only, ignoring its #382 gap-limit candidate scripts — the shape of Neuron's #2992. Traced it: in our architecture that's correct, not a bug. Neuron's #2992 was a real miss because they advanced a shared fetch cursor past lagging scripts; our embedded light client scans each script independently to tip and candidates re-register from their own historical start, so nothing is abandoned. Gating `isSynced` on candidates would show "syncing" through the whole background discovery scan while the user's funds are already synced — worse UX. Candidate lifecycle is gated correctly by SubAccountReconciler's coverage rule. Comment added so a future audit doesn't 'fix' it into the worse behavior. Full suite green.