### PR TITLE
fix(jni): log unresolved input capacity instead of failing silently

### DIFF
--- a/external/ckb-light-client/light-client-lib/src/jni_bridge/query.rs
+++ b/external/ckb-light-client/light-client-lib/src/jni_bridge/query.rs
@@ -810,28 +810,79 @@ pub extern "C" fn Java_com_nervosnetwork_ckblightclient_LightClientNative_native
             };
 
             let io_capacity = if io_type == CellType::Input {
-                // For input, the io_index is the index into the inputs array
+                // For input, io_index indexes into the inputs array; the spent
+                // cell's capacity lives in the output that created it, so we
+                // resolve it from the previous transaction.
                 let input = tx.raw().inputs().get(io_index as usize)?;
                 let out_point = input.previous_output();
-                // We need to look up the capacity of the spent cell from storage
-                swc.storage()
+                let prev_index: u32 = out_point.index().unpack();
+                let prev_hash: H256 = out_point.tx_hash().unpack();
+                let cur_hash: H256 = tx_hash.unpack();
+
+                // On a light client synced from a checkpoint, the tx that
+                // created the spent cell can predate the sync window and simply
+                // not be in storage. Its capacity is then unrecoverable here
+                // (the cell index stores only the tx hash, not the capacity), so
+                // the activity net for this tx is understated and, because the
+                // Kotlin side classifies direction by net sign, an affected send
+                // can even render as a receive. This used to fail silently.
+                // Behavior is unchanged (missing prev tx drops the row, malformed
+                // data reports 0), but each case now logs so windowed-out amounts
+                // are diagnosable in logcat. A correct fix needs the spent
+                // capacity stored in the cell index or resolved on the Kotlin
+                // side, which is a coordinated follow-up.
+                let prev_tx_bytes = match swc
+                    .storage()
                     .get(Key::TxHash(&out_point.tx_hash()).into_vec())
-                    .ok()??
+                {
+                    Ok(Some(bytes)) => bytes,
+                    Ok(None) => {
+                        warn!(
+                            "nativeGetTransactions: spent-cell tx {:#x} outside sync window; \
+                             input {}:{} of tx {:#x} dropped, activity amount understated",
+                            prev_hash, prev_index, io_index, cur_hash
+                        );
+                        return None;
+                    }
+                    Err(e) => {
+                        error!(
+                            "nativeGetTransactions: storage error resolving input capacity \
+                             for tx {:#x}: {}",
+                            cur_hash, e
+                        );
+                        return None;
+                    }
+                };
+                prev_tx_bytes
                     .get(12..) // Skip block number (8) and tx index (4) in Value::Transaction
                     .and_then(|data| {
-                        let tx = packed::Transaction::from_slice(data).ok()?;
-                        let index: u32 = out_point.index().unpack();
-                        tx.raw().outputs().get(index as usize)
+                        let prev_tx = packed::Transaction::from_slice(data).ok()?;
+                        prev_tx.raw().outputs().get(prev_index as usize)
                     })
                     .map(|output: packed::CellOutput| Unpack::<core::Capacity>::unpack(&output.capacity()).as_u64())
-                    .unwrap_or(0)
+                    .unwrap_or_else(|| {
+                        warn!(
+                            "nativeGetTransactions: malformed prev tx {:#x} for input {}:{} \
+                             of tx {:#x}; capacity reported as 0",
+                            prev_hash, prev_index, io_index, cur_hash
+                        );
+                        0
+                    })
             } else {
-                // For output, we can get it directly from the current transaction
+                // For output, read capacity directly from the current transaction.
+                let cur_hash: H256 = tx_hash.unpack();
                 tx.raw()
                     .outputs()
                     .get(io_index as usize)
                     .map(|output: packed::CellOutput| Unpack::<core::Capacity>::unpack(&output.capacity()).as_u64())
-                    .unwrap_or(0)
+                    .unwrap_or_else(|| {
+                        warn!(
+                            "nativeGetTransactions: output io_index {} out of range for tx {:#x}; \
+                             capacity reported as 0",
+                            io_index, cur_hash
+                        );
+                        0
+                    })
             };
 
             last_key = key.to_vec();


### PR DESCRIPTION
Follow-up to #402. I audited the whole JNI Rust surface for the same silent-fallback bug class that hid the cursor cap. One real instance found and made observable; one candidate confirmed a false alarm.

## The real one: input capacity in `nativeGetTransactions`

Resolving an input's capacity means looking up the tx that created the spent cell. Two failures were swallowed silently:

- **`.ok()??`** dropped the whole input row when the previous tx was not in storage. On a checkpoint-synced light client the funding tx can predate the sync window, so the row vanished, the activity net for that tx was understated, and — because the Kotlin side classifies direction purely by net sign (`GatewayRepository.kt:2023`) — an affected send could render as a *receive*.
- **`.unwrap_or(0)`** reported capacity 0 when the stored prev tx was malformed or the output index was out of range.

The capacity is genuinely unrecoverable in Rust here: the cell index stores only the tx hash, not the capacity (`query.rs:638`). So this PR **preserves behavior** (missing prev tx still drops the row, malformed still reports 0) and adds a `warn!`/`error!` at each case with the affected tx hash, previous outpoint and io index. Rust logs survive R8, so these windowed-out amounts become diagnosable in production logcat instead of silently wrong.

A *correct* fix (make the amount right, not just visible) needs either the spent capacity stored in the cell index at write time, or an "unknown capacity" signal resolved on the Kotlin side. That is a coordinated change and is left as a follow-up.

## Confirmed NOT a bug

The `Err(_) => "".to_string()` cursor fallback (`query.rs:591,736`) looked like a silent restart-at-page-1, but it is load-bearing: Kotlin passes a **null** jstring for the first page (`nativeGetCells(..., cursor: String?)`, doc says "null for first page"), which `env.get_string` surfaces as `Err`, and the empty-string fallback is exactly how first page is detected. Left unchanged.

## Also clean (audit notes)
- `nativeGetCellsCapacity` has no pagination — it sums every matching cell, so total-balance was always correct even pre-#402.
- DAO hex/epoch parses return `Option` and every caller handles `None`.
- `iterator_collect` has no SQL `LIMIT` and materializes the remaining prefix range per page (~O(N²/limit) to walk a huge wallet). Perf, not correctness; noted for a future change, not touched here.

## Verification
- `cargo check --features jni-bridge --target aarch64-linux-android` passes.
- No host unit test: the module is `cfg(target_os = "android")` and the change is logging-only (behavior unchanged), so there is no new assertion to make. CI build + smoke compile the real `.so`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved transaction capacity handling for spent inputs.
  * Transactions with missing or out-of-range previous data are now skipped more safely instead of failing.
  * Malformed or undecodable references now fall back to a zero capacity value with a warning, while valid output capacity handling remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->