### PR TITLE
docs(sync): amount accuracy vs sync coverage; correct the query.rs note

### DIFF
--- a/docs/SYNC_COVERAGE_AND_AMOUNTS.md
+++ b/docs/SYNC_COVERAGE_AND_AMOUNTS.md
@@ -1,0 +1,103 @@
+# Sync coverage and amount accuracy
+
+## TL;DR
+
+Balances and activity amounts are correct **for wallets synced from at or before
+their first funding block**. The only way an amount can be wrong is a wallet
+synced from a checkpoint *after* some of its funds arrived, which leaves
+"pre-window" cells the light client can never see. The fix is coverage, not
+computation: choose a **Custom** sync height at or before the wallet's first
+transaction. This matters mainly for **imported** wallets, whose funding history
+is unknown to us.
+
+This document exists so we stop re-diagnosing this as a read-path or
+computation bug. It is neither. It is an inherent property of a light client
+that syncs from a checkpoint.
+
+## How the light client indexes a wallet's history
+
+The embedded CKB light client (`external/ckb-light-client`) processes each
+matched block in `Storage::filter_block` (`storage/db/native.rs`). For each
+transaction it:
+
+- **Outputs:** for every output whose lock/type matches a registered script,
+  writes a `CellLockScript`/`CellTypeScript` cell entry and a `TxLockScript`
+  Output history entry, and stores the full transaction under `TxHash`.
+- **Inputs:** for every input, it looks up the **previous** transaction that
+  created the spent cell:
+
+  ```rust
+  if let Some((.., previous_tx)) = self.get_transaction(&previous_tx_hash) {
+      let previous_output = previous_tx.raw().outputs().get(prev_index);
+      if scripts.contains(&(previous_output.lock(), Lock)) {
+          // delete the cell entry, write a TxLockScript Input history entry
+      }
+  }
+  ```
+
+  The input's lock is not carried in the transaction (a CKB input is just an
+  `OutPoint`), so the client can only decide the input is *ours* by resolving
+  the previous output from **its own storage**.
+
+Two consequences follow, and they are the whole story:
+
+1. **An input is indexed only if its previous transaction is already stored.**
+2. **Stored transactions are never pruned.** The only deletion is
+   `rollback_to_block`, used for reorgs.
+
+## Why "wrong amounts" happen, and why only under checkpoint sync
+
+If a cell was funded **before** the sync start block, its creating transaction
+is never stored. When that cell is later spent in an in-window block,
+`filter_block`'s `get_transaction(prev_hash)` misses, so the input is **never
+matched and never indexed**. The pre-window cell is invisible everywhere:
+balance, cells, and activity.
+
+The visible symptom appears on a *mixed* transaction, one that spends a
+pre-window cell **and** has an in-window output back to the wallet (change, or a
+received output). Only the output is indexed, so:
+
+- `netShannonsByTx` (Kotlin, `TransactionWalk.kt`) sees `+output` with no
+  matching input, so the net looks positive.
+- `GatewayRepository` classifies direction by net sign
+  (`netChangeShannons > 0 -> "in"`), so a **send can render as a receive**, with
+  an understated amount.
+
+The spent cell's lock and capacity are genuinely absent from local data, so **no
+read-path computation can recover them.** In particular:
+
+- The JNI `get_transactions` handler (`jni_bridge/query.rs`) computes each
+  input's `io_capacity` by looking up the previous transaction. Because of
+  consequence (1) + (2) above, that lookup **always resolves for a legitimately
+  indexed input** — the previous tx is in storage permanently. The `Ok(None)`
+  branch there is a defensive guard for DB corruption or a mid-read reorg, not
+  the source of wrong amounts. It logs and drops the row.
+
+## The remedy: coverage
+
+For a wallet synced from at/before its first funding block, no cell is ever
+pre-window: every input's previous tx is stored, every capacity resolves, and
+every balance and amount is correct by construction.
+
+- **New wallets** start at the current tip, so they have no pre-window history
+  and are always correct.
+- **Imported wallets** have unknown funding history. If funds may have arrived
+  long ago (e.g. a mining wallet, or a seed previously used in Neuron), pick a
+  **Custom** sync height at or before the first transaction. Full history
+  (genesis) is always safe; a known earlier height is faster.
+
+This is already the guidance given to users ("sync from your first height") and
+is available in the app via the Custom sync height option. We rely on that plus
+the diagnostic logging in `query.rs` rather than attempting to reconstruct
+unknowable pre-window data locally, which would require fetching historical
+transactions from a full node and cuts against the light, self-custodial design.
+
+## What we deliberately did NOT build
+
+- **On-demand pre-window fetch** from a peer/full node to value missing inputs:
+  most complete, but heaviest and most against the no-remote-server design.
+- **A history probe** that asks a full node whether an address has pre-sync
+  activity: reveals the address to a server, same objection.
+- **Storing capacity in the cell index** so inputs could be valued without the
+  previous tx: does not help, because the pre-window input is never indexed in
+  the first place (consequence 1), so there is no row to attach capacity to.

--- a/external/ckb-light-client/light-client-lib/src/jni_bridge/query.rs
+++ b/external/ckb-light-client/light-client-lib/src/jni_bridge/query.rs
@@ -819,18 +819,34 @@ pub extern "C" fn Java_com_nervosnetwork_ckblightclient_LightClientNative_native
                 let prev_hash: H256 = out_point.tx_hash().unpack();
                 let cur_hash: H256 = tx_hash.unpack();
 
-                // On a light client synced from a checkpoint, the tx that
-                // created the spent cell can predate the sync window and simply
-                // not be in storage. Its capacity is then unrecoverable here
-                // (the cell index stores only the tx hash, not the capacity), so
-                // the activity net for this tx is understated and, because the
-                // Kotlin side classifies direction by net sign, an affected send
-                // can even render as a receive. This used to fail silently.
-                // Behavior is unchanged (missing prev tx drops the row, malformed
-                // data reports 0), but each case now logs so windowed-out amounts
-                // are diagnosable in logcat. A correct fix needs the spent
-                // capacity stored in the cell index or resolved on the Kotlin
-                // side, which is a coordinated follow-up.
+                // The Ok(None) arm below is a near-unreachable defensive guard,
+                // NOT the source of wrong activity amounts. `filter_block`
+                // (storage/db/native.rs) only writes an input's index entry
+                // inside `if let Some(prev_tx) = self.get_transaction(prev_hash)`
+                // — it resolves the spent cell's lock from the locally-stored
+                // previous tx to decide the input is ours — and nothing prunes
+                // stored txs (the only delete is reorg rollback_to_block). So
+                // whenever an input IS indexed, its previous tx is in storage
+                // permanently, and this lookup resolves. Ok(None) can therefore
+                // only happen on DB corruption or a mid-read reorg; we log and
+                // drop that row rather than trust a bogus capacity.
+                //
+                // The genuine amount error lives at the WRITE layer, upstream of
+                // this code and unfixable here: a cell funded BEFORE the sync
+                // start block is never in storage, so filter_block never matches
+                // or indexes the input that spends it. A tx mixing such a
+                // pre-window input with an in-window output to us then shows only
+                // the output, so its net looks positive and — because the Kotlin
+                // side classifies direction by net sign — a send can render as a
+                // receive. The spent cell's lock is genuinely unknowable from
+                // local data, so no computation here recovers it. The remedy is
+                // sync COVERAGE: sync from at/before the wallet's first funding
+                // block (the Custom height option) so no cell is ever pre-window
+                // and every amount is correct by construction. See
+                // docs/SYNC_COVERAGE_AND_AMOUNTS.md.
+                //
+                // The malformed-data arm reports 0 (behavior preserved); both
+                // arms log so anything unexpected is diagnosable in logcat.
                 let prev_tx_bytes = match swc
                     .storage()
                     .get(Key::TxHash(&out_point.tx_hash()).into_vec())
@@ -838,8 +854,10 @@ pub extern "C" fn Java_com_nervosnetwork_ckblightclient_LightClientNative_native
                     Ok(Some(bytes)) => bytes,
                     Ok(None) => {
                         warn!(
-                            "nativeGetTransactions: spent-cell tx {:#x} outside sync window; \
-                             input {}:{} of tx {:#x} dropped, activity amount understated",
+                            "nativeGetTransactions: indexed input references prev tx {:#x} \
+                             not in storage (unexpected: DB corruption or mid-read reorg, since \
+                             filter_block only indexes inputs whose prev tx it stored); \
+                             input {}:{} of tx {:#x} dropped",
                             prev_hash, prev_index, io_index, cur_hash
                         );
                         return None;


### PR DESCRIPTION
Closes the "real amount correctness" investigation. Conclusion: the wrong-amount / send-looks-like-receive class is **not** a read-path or computation bug and cannot be fixed locally. It is a property of checkpoint sync.

## Why (evidence)

`filter_block` (`storage/db/native.rs`) indexes an input only inside `if let Some(prev_tx) = self.get_transaction(prev_hash)` — it resolves the spent cell's lock from the locally-stored previous tx to decide the input is ours — and nothing prunes stored txs (only reorg `rollback_to_block` deletes). Therefore:

- Any input that **is** indexed has its previous tx in storage permanently, so `query.rs` `get_transactions` always resolves its `io_capacity`. The `Ok(None)` drop added in #403 is a defensive guard for DB corruption / mid-read reorg, **not** the amount bug.
- The genuine error is at the **write layer**: a cell funded before the sync-start block is never stored, so filter_block never matches the input that spends it. A tx mixing such a pre-window input with an in-window output shows only the output, so its net looks positive and — since direction is net-sign — a send can render as a receive. The spent lock/capacity are unknowable from local data.

## Decision

Fix by **coverage, not code**: sync from at/before the wallet's first funding block (the Custom height option) so no cell is ever pre-window. Already available in-app, already the guidance we give imported-wallet users ("sync from your first height"). We rely on that plus the `query.rs` diagnostic logging rather than fetching historical txs from a full node, which would cut against the light, self-custodial design.

## Changes
- `docs/SYNC_COVERAGE_AND_AMOUNTS.md`: full mechanism, symptom, remedy, and the options we deliberately did not build.
- `query.rs`: rewrites the misleading comment (it implied the `Ok(None)` drop was the windowing culprit) and its `warn!` text to match the real cause.

No behavior change. `cargo check --features jni-bridge --target aarch64-linux-android` passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance explaining when wallet balances and transaction amounts can appear incorrect after syncing from a later checkpoint.
  * Clarified how to choose a sync height so imported wallets show accurate history and balances.

* **Bug Fixes**
  * Improved handling of missing transaction history during sync by adding clearer warnings and context.
  * Preserved existing safeguards for incomplete transaction data while keeping current wallet behavior unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->