### PR TITLE
fix(scan): V2-aware gap-limit scan and sweep via BiometricPrompt (#408)

### DIFF
--- a/android/app/src/main/java/com/rjnr/pocketnode/data/gateway/GatewayRepository.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/gateway/GatewayRepository.kt
@@ -920,15 +920,30 @@ class GatewayRepository @Inject constructor(
      * keep their state, then scripts re-register so the new ones enter the
      * light-client filter. Returns the window that is now covered.
      */
+    /**
+     * V1 / session-auth entry: reads the seed via [getMnemonic] (which has an
+     * EncryptedSharedPreferences fallback). V2 (kdfVersion=2) wallets cannot
+     * decrypt without an authenticated Cipher, so their ViewModels unlock the
+     * seed via a BiometricPrompt and call [runGapLimitScan] with words (#408).
+     */
     suspend fun runGapLimitScan(): Result<Int> = runCatching {
+        val words = getMnemonic() ?: throw Exception("Recovery phrase unavailable for this wallet")
+        runGapLimitScanInner(words)
+    }
+
+    /** V2 entry: [words] were already unlocked by the caller's BiometricPrompt (#408). */
+    suspend fun runGapLimitScan(words: List<String>): Result<Int> = runCatching {
+        runGapLimitScanInner(words)
+    }
+
+    private suspend fun runGapLimitScanInner(words: List<String>): Int {
         // Single-flight: the Home banner and Settings both trigger this, and
         // a second concurrent pass would double the derivation work and
         // interleave two CMD_SET_SCRIPTS_ALL registrations.
         if (!gapLimitScanMutex.tryLock()) throw Exception("A scan is already running")
-        try {
+        return try {
             val wId = activeWalletId
             if (wId.isEmpty()) throw Exception("No active wallet")
-            val words = getMnemonic() ?: throw Exception("Recovery phrase unavailable for this wallet")
             val dao = appDatabase.subAccountCandidateDao()
             val existing = dao.getForParent(wId).filter { it.accountIndex == 0 }
             val window = nextScanWindow(existing)
@@ -1068,13 +1083,26 @@ class GatewayRepository @Inject constructor(
      * transaction and hands it to the idempotent sendTransaction path
      * (pending row + watchdog). Keys and seed are zeroed after signing.
      */
+    /**
+     * V1 / session-auth entry: reads the seed via [getMnemonic]. V2 wallets
+     * unlock the seed via a BiometricPrompt and call the words overload (#408).
+     */
     suspend fun sweepGapLimitFunds(): Result<String> = runCatching {
+        val words = getMnemonic() ?: throw Exception("Recovery phrase unavailable for this wallet")
+        sweepGapLimitFundsInner(words)
+    }
+
+    /** V2 entry: [words] were already unlocked by the caller's BiometricPrompt (#408). */
+    suspend fun sweepGapLimitFunds(words: List<String>): Result<String> = runCatching {
+        sweepGapLimitFundsInner(words)
+    }
+
+    private suspend fun sweepGapLimitFundsInner(words: List<String>): String {
         if (!gapLimitScanMutex.tryLock()) throw Exception("A scan or sweep is already running")
-        try {
+        return try {
             val wId = activeWalletId
             if (wId.isEmpty()) throw Exception("No active wallet")
             val myScript = _walletInfo.value?.script ?: throw Exception("Wallet not initialized")
-            val words = getMnemonic() ?: throw Exception("Recovery phrase unavailable for this wallet")
 
             val (inputs, _) = gatherSweepInputs(wId)
             val plan = transactionBuilder.buildSweep(inputs, myScript, currentNetwork).getOrThrow()

--- a/android/app/src/main/java/com/rjnr/pocketnode/data/wallet/SeedPhraseAuthorizer.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/wallet/SeedPhraseAuthorizer.kt
@@ -1,0 +1,79 @@
+package com.rjnr.pocketnode.data.wallet
+
+import androidx.fragment.app.FragmentActivity
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Acquires a wallet's recovery-phrase words for an operation that derives keys
+ * from the seed (the #382 gap-limit scan and sweep), driving the V2 auth-bound
+ * BiometricPrompt when needed.
+ *
+ * ## Why this exists (#408)
+ *
+ * `GatewayRepository.runGapLimitScan()` / `sweepGapLimitFunds()` originally read
+ * the seed via `getMnemonic()` with no cipher. For a kdfVersion=2 (auth-bound)
+ * wallet that throws "caller must supply an authenticated Cipher", so the scan
+ * and sweep failed on every V2 wallet. Sends already solved this by routing V2
+ * through [WalletKeyReader]; the scan/sweep were never migrated. This is the
+ * one boundary that turns a V2 wallet id + Activity into the seed words, so
+ * the two ViewModels share it instead of each re-deriving the biometric dance.
+ *
+ * V1 wallets keep using the repository's existing `getMnemonic()` path (which
+ * has an EncryptedSharedPreferences fallback this reader does not); callers
+ * dispatch on `kdfVersion` and only reach here for V2.
+ */
+@Singleton
+class SeedPhraseAuthorizer @Inject constructor(
+    private val walletKeyReader: WalletKeyReader,
+) {
+
+    sealed interface SeedResult {
+        /** Seed unlocked; [words] is the mnemonic split on whitespace. */
+        data class Words(val words: List<String>) : SeedResult
+        /** User dismissed the biometric prompt. Caller should quietly reset UI. */
+        object Cancelled : SeedResult
+        /**
+         * V2 Keystore key wiped by a biometric-enrollment change. The encrypted
+         * seed on disk is unrecoverable; caller must surface a re-import flow.
+         */
+        object KeyInvalidated : SeedResult
+        /** Auth error, no seed on the row, or a raw-key wallet with no mnemonic. */
+        data class Failed(val reason: String) : SeedResult
+    }
+
+    /**
+     * Drive the (V2) authenticated read for [walletId] and return the seed
+     * words. Exactly one BiometricPrompt for a V2 wallet; silent for V1 (though
+     * callers normally reserve this for V2 and take the repository path for V1).
+     */
+    suspend fun authorize(
+        activity: FragmentActivity,
+        walletId: String,
+        promptTitle: String,
+        promptSubtitle: String,
+    ): SeedResult = toSeedResult(
+        walletKeyReader.readKeyMaterial(activity, walletId, promptTitle, promptSubtitle)
+    )
+
+    companion object {
+        /** Pure mapping from a key-material read to a seed outcome. */
+        fun toSeedResult(material: WalletKeyReader.MaterialResult): SeedResult = when (material) {
+            is WalletKeyReader.MaterialResult.Success -> {
+                val words = material.mnemonic
+                    ?.trim()
+                    ?.takeIf { it.isNotEmpty() }
+                    ?.split(Regex("\\s+"))
+                if (words.isNullOrEmpty()) {
+                    SeedResult.Failed("Recovery phrase unavailable for this wallet")
+                } else {
+                    SeedResult.Words(words)
+                }
+            }
+            is WalletKeyReader.MaterialResult.Cancelled -> SeedResult.Cancelled
+            is WalletKeyReader.MaterialResult.KeyInvalidated -> SeedResult.KeyInvalidated
+            is WalletKeyReader.MaterialResult.AuthError -> SeedResult.Failed(material.message.toString())
+            is WalletKeyReader.MaterialResult.NotAvailable -> SeedResult.Failed(material.reason)
+        }
+    }
+}

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/home/HomeScreen.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/home/HomeScreen.kt
@@ -63,6 +63,7 @@ import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.platform.LocalClipboardManager
 import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.platform.LocalContext
+import androidx.fragment.app.FragmentActivity
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.buildAnnotatedString
@@ -491,7 +492,7 @@ fun HomeScreen(
                     onBgSyncStaleDismiss = { viewModel.dismissBgSyncStalePill() },
                     onGapLimitLearnMore = { onNavigateToFaq("imported_funds") },
                     onGapLimitDismiss = { viewModel.dismissGapLimitBanner() },
-                    onGapLimitScanNow = { viewModel.runGapLimitScan() },
+                    onGapLimitScanNow = { (context as? FragmentActivity)?.let { viewModel.runGapLimitScan(it) } },
                     onGapLimitSweep = { viewModel.requestGapLimitSweep() },
                 )
                 if (uiState.isSwitchingWallet) {
@@ -529,7 +530,7 @@ fun HomeScreen(
                     )
                 },
                 confirmButton = {
-                    TextButton(onClick = { viewModel.confirmGapLimitSweep() }) {
+                    TextButton(onClick = { (context as? FragmentActivity)?.let { viewModel.confirmGapLimitSweep(it) } }) {
                         Text(stringResource(R.string.sweep_dialog_confirm))
                     }
                 },

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/home/HomeViewModel.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/home/HomeViewModel.kt
@@ -1,6 +1,7 @@
 package com.rjnr.pocketnode.ui.screens.home
 
 import android.util.Log
+import androidx.fragment.app.FragmentActivity
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.rjnr.pocketnode.data.database.entity.WalletEntity
@@ -55,6 +56,8 @@ class HomeViewModel @Inject constructor(
     private val authManager: AuthManager,
     private val cacheManager: CacheManager,
     private val walletPreferences: com.rjnr.pocketnode.data.wallet.WalletPreferences,
+    private val seedPhraseAuthorizer: com.rjnr.pocketnode.data.wallet.SeedPhraseAuthorizer,
+    private val keyMaterialDao: com.rjnr.pocketnode.data.database.dao.KeyMaterialDao,
     private val savedStateHandle: androidx.lifecycle.SavedStateHandle,
 ) : ViewModel() {
 
@@ -863,14 +866,82 @@ class HomeViewModel @Inject constructor(
     }
 
     /**
-     * #382 Tier 2: explicit deep scan from the banner (wallets imported
-     * before auto-scan shipped, or window extension). Session-auth gated
-     * inside the repository via getMnemonic().
+     * Seed acquisition for a key-deriving op (scan/sweep). V1 wallets read the
+     * seed inside the repository via getMnemonic(); V2 (kdfVersion=2) wallets
+     * cannot decrypt without an authenticated Cipher, so we drive a
+     * BiometricPrompt here and hand the words to the repo's words overload
+     * (#408). Only the two banner/settings actions reach this.
      */
-    fun runGapLimitScan() {
+    private sealed interface SeedAcquire {
+        /** V1 wallet: caller runs the no-words repository overload. */
+        object UseV1 : SeedAcquire
+        data class Words(val words: List<String>) : SeedAcquire
+        object Cancelled : SeedAcquire
+        object KeyInvalidated : SeedAcquire
+        data class Failed(val reason: String) : SeedAcquire
+    }
+
+    private suspend fun acquireSeed(
+        activity: FragmentActivity,
+        promptTitle: String,
+        promptSubtitle: String,
+    ): SeedAcquire {
+        val walletId = walletRepository.activeWalletIdSnapshot()?.takeIf { it.isNotEmpty() }
+            ?: return SeedAcquire.Failed("No active wallet")
+        val kdfVersion = runCatching { keyMaterialDao.getKdfVersion(walletId) }.getOrNull()
+        if (kdfVersion != 2) return SeedAcquire.UseV1
+        return when (val r = seedPhraseAuthorizer.authorize(activity, walletId, promptTitle, promptSubtitle)) {
+            is com.rjnr.pocketnode.data.wallet.SeedPhraseAuthorizer.SeedResult.Words -> SeedAcquire.Words(r.words)
+            com.rjnr.pocketnode.data.wallet.SeedPhraseAuthorizer.SeedResult.Cancelled -> SeedAcquire.Cancelled
+            com.rjnr.pocketnode.data.wallet.SeedPhraseAuthorizer.SeedResult.KeyInvalidated -> SeedAcquire.KeyInvalidated
+            is com.rjnr.pocketnode.data.wallet.SeedPhraseAuthorizer.SeedResult.Failed -> SeedAcquire.Failed(r.reason)
+        }
+    }
+
+    /**
+     * #382 Tier 2: explicit deep scan from the banner (wallets imported
+     * before auto-scan shipped, or window extension). V2 wallets are prompted
+     * for biometric auth to unlock the seed (#408).
+     */
+    fun runGapLimitScan(activity: FragmentActivity) {
         viewModelScope.launch {
             _uiState.update { it.copy(gapLimitScanning = true, gapLimitScanAvailable = false) }
-            repository.runGapLimitScan()
+            val result: Result<Int> = when (val seed = acquireSeed(
+                activity,
+                "Authenticate to scan",
+                "Verify your identity to scan for funds on other addresses",
+            )) {
+                SeedAcquire.UseV1 -> repository.runGapLimitScan()
+                is SeedAcquire.Words -> repository.runGapLimitScan(seed.words)
+                SeedAcquire.Cancelled -> {
+                    _uiState.update { it.copy(gapLimitScanning = false, gapLimitScanAvailable = true) }
+                    return@launch
+                }
+                SeedAcquire.KeyInvalidated -> {
+                    _uiState.update {
+                        it.copy(
+                            gapLimitScanning = false, gapLimitScanAvailable = true,
+                            error = com.rjnr.pocketnode.ui.util.UiMessage.Resource(
+                                com.rjnr.pocketnode.R.string.gap_limit_scan_failed,
+                                listOf("Biometric changed. Re-import this wallet from its recovery phrase."),
+                            ),
+                        )
+                    }
+                    return@launch
+                }
+                is SeedAcquire.Failed -> {
+                    _uiState.update {
+                        it.copy(
+                            gapLimitScanning = false, gapLimitScanAvailable = true,
+                            error = com.rjnr.pocketnode.ui.util.UiMessage.Resource(
+                                com.rjnr.pocketnode.R.string.gap_limit_scan_failed, listOf(seed.reason),
+                            ),
+                        )
+                    }
+                    return@launch
+                }
+            }
+            result
                 .onSuccess {
                     Log.i(TAG, "gap-limit scan started (window $it)")
                     refreshTransactionsOnly(silent = true)
@@ -916,10 +987,45 @@ class HomeViewModel @Inject constructor(
         _uiState.update { it.copy(sweepPreview = null) }
     }
 
-    fun confirmGapLimitSweep() {
+    fun confirmGapLimitSweep(activity: FragmentActivity) {
         viewModelScope.launch {
             _uiState.update { it.copy(sweepPreview = null, sweepInProgress = true) }
-            repository.sweepGapLimitFunds()
+            val result: Result<String> = when (val seed = acquireSeed(
+                activity,
+                "Authenticate to move funds",
+                "Verify your identity to move funds to your main wallet",
+            )) {
+                SeedAcquire.UseV1 -> repository.sweepGapLimitFunds()
+                is SeedAcquire.Words -> repository.sweepGapLimitFunds(seed.words)
+                SeedAcquire.Cancelled -> {
+                    _uiState.update { it.copy(sweepInProgress = false) }
+                    return@launch
+                }
+                SeedAcquire.KeyInvalidated -> {
+                    _uiState.update {
+                        it.copy(
+                            sweepInProgress = false,
+                            error = com.rjnr.pocketnode.ui.util.UiMessage.Resource(
+                                com.rjnr.pocketnode.R.string.sweep_failed,
+                                listOf("Biometric changed. Re-import this wallet from its recovery phrase."),
+                            ),
+                        )
+                    }
+                    return@launch
+                }
+                is SeedAcquire.Failed -> {
+                    _uiState.update {
+                        it.copy(
+                            sweepInProgress = false,
+                            error = com.rjnr.pocketnode.ui.util.UiMessage.Resource(
+                                com.rjnr.pocketnode.R.string.sweep_failed, listOf(seed.reason),
+                            ),
+                        )
+                    }
+                    return@launch
+                }
+            }
+            result
                 .onSuccess { txHash ->
                     Log.i(TAG, "sweep broadcast: ${txHash.take(16)}...")
                     _uiState.update {

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/settings/SettingsScreen.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/settings/SettingsScreen.kt
@@ -54,6 +54,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalContext
+import androidx.fragment.app.FragmentActivity
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -364,7 +365,7 @@ fun SettingsScreen(
         },
         showThemeDialog = { viewModel.showThemeDialog() },
         onCheckForUpdate = { viewModel.checkForUpdate() },
-        onScanOtherAddresses = { viewModel.runGapLimitScan() },
+        onScanOtherAddresses = { (context as? FragmentActivity)?.let { viewModel.runGapLimitScan(it) } },
         onToggleBackgroundSync = { enabled ->
             if (enabled && Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
                 val hasPermission = ContextCompat.checkSelfPermission(

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/settings/SettingsViewModel.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/settings/SettingsViewModel.kt
@@ -1,13 +1,16 @@
 package com.rjnr.pocketnode.ui.screens.settings
 
+import androidx.fragment.app.FragmentActivity
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.rjnr.pocketnode.BuildConfig
 import com.rjnr.pocketnode.data.auth.PinManager
+import com.rjnr.pocketnode.data.database.dao.KeyMaterialDao
 import com.rjnr.pocketnode.data.gateway.GatewayRepository
 import com.rjnr.pocketnode.data.update.UpdateRepository
 import com.rjnr.pocketnode.data.gateway.models.NetworkType
 import com.rjnr.pocketnode.data.gateway.models.SyncMode
+import com.rjnr.pocketnode.data.wallet.SeedPhraseAuthorizer
 import com.rjnr.pocketnode.data.wallet.SyncStrategy
 import com.rjnr.pocketnode.data.wallet.ThemeMode
 import com.rjnr.pocketnode.data.wallet.WalletPreferences
@@ -27,6 +30,8 @@ class SettingsViewModel @Inject constructor(
     private val pinManager: PinManager,
     private val walletRepository: WalletRepository,
     private val updateRepository: UpdateRepository,
+    private val seedPhraseAuthorizer: SeedPhraseAuthorizer,
+    private val keyMaterialDao: KeyMaterialDao,
 ) : ViewModel() {
 
     /** Update-availability state for the About > Version row (#369). */
@@ -176,9 +181,34 @@ class SettingsViewModel @Inject constructor(
      * when the Home banner was dismissed, and the window-extension entry.
      * Feedback rides the same snackbar channel as other Settings actions.
      */
-    fun runGapLimitScan() {
+    fun runGapLimitScan(activity: FragmentActivity) {
         viewModelScope.launch {
-            repository.runGapLimitScan()
+            // V1 wallets read the seed in the repository; V2 (kdfVersion=2)
+            // wallets need a BiometricPrompt to unlock it (#408).
+            val walletId = walletRepository.activeWalletIdSnapshot()?.takeIf { it.isNotEmpty() }
+            val kdfVersion = walletId?.let { runCatching { keyMaterialDao.getKdfVersion(it) }.getOrNull() }
+            val result: Result<Int> = if (kdfVersion == 2 && walletId != null) {
+                when (val seed = seedPhraseAuthorizer.authorize(
+                    activity,
+                    walletId,
+                    "Authenticate to scan",
+                    "Verify your identity to scan for funds on other addresses",
+                )) {
+                    is SeedPhraseAuthorizer.SeedResult.Words -> repository.runGapLimitScan(seed.words)
+                    SeedPhraseAuthorizer.SeedResult.Cancelled -> return@launch
+                    SeedPhraseAuthorizer.SeedResult.KeyInvalidated -> {
+                        emitScanFailed("Biometric changed. Re-import this wallet from its recovery phrase.")
+                        return@launch
+                    }
+                    is SeedPhraseAuthorizer.SeedResult.Failed -> {
+                        emitScanFailed(seed.reason)
+                        return@launch
+                    }
+                }
+            } else {
+                repository.runGapLimitScan()
+            }
+            result
                 .onSuccess {
                     _uiState.update {
                         it.copy(
@@ -188,16 +218,18 @@ class SettingsViewModel @Inject constructor(
                         )
                     }
                 }
-                .onFailure { e ->
-                    _uiState.update {
-                        it.copy(
-                            error = com.rjnr.pocketnode.ui.util.UiMessage.Resource(
-                                com.rjnr.pocketnode.R.string.gap_limit_scan_failed,
-                                listOf(e.message ?: ""),
-                            ),
-                        )
-                    }
-                }
+                .onFailure { e -> emitScanFailed(e.message ?: "") }
+        }
+    }
+
+    private fun emitScanFailed(reason: String) {
+        _uiState.update {
+            it.copy(
+                error = com.rjnr.pocketnode.ui.util.UiMessage.Resource(
+                    com.rjnr.pocketnode.R.string.gap_limit_scan_failed,
+                    listOf(reason),
+                ),
+            )
         }
     }
 

--- a/android/app/src/test/java/com/rjnr/pocketnode/data/wallet/SeedPhraseAuthorizerTest.kt
+++ b/android/app/src/test/java/com/rjnr/pocketnode/data/wallet/SeedPhraseAuthorizerTest.kt
@@ -1,0 +1,81 @@
+package com.rjnr.pocketnode.data.wallet
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * The V2 gap-limit scan/sweep bug (#408): reading the seed for an auth-bound
+ * (kdfVersion=2) wallet needs an authenticated Cipher from a BiometricPrompt.
+ * [SeedPhraseAuthorizer] wraps [WalletKeyReader.readKeyMaterial] (which drives
+ * that prompt) and maps its result to a small outcome the scan/sweep call sites
+ * can act on. These lock in that mapping — the one piece of the fix that is pure
+ * and testable without an Activity or the biometric stack.
+ */
+class SeedPhraseAuthorizerTest {
+
+    private fun success(mnemonic: String?) = WalletKeyReader.MaterialResult.Success(
+        privateKey = ByteArray(32),
+        mnemonic = mnemonic,
+        walletType = "mnemonic",
+        mnemonicBackedUp = true,
+    )
+
+    @Test
+    fun `success with a mnemonic yields the split words`() {
+        val r = SeedPhraseAuthorizer.toSeedResult(
+            success("angle bonus strike comic jelly mom decrease galaxy error tackle together woman")
+        )
+        assertTrue(r is SeedPhraseAuthorizer.SeedResult.Words)
+        assertEquals(12, (r as SeedPhraseAuthorizer.SeedResult.Words).words.size)
+        assertEquals("angle", r.words.first())
+        assertEquals("woman", r.words.last())
+    }
+
+    @Test
+    fun `extra whitespace between words is collapsed`() {
+        val r = SeedPhraseAuthorizer.toSeedResult(success("  alpha   beta \n gamma  "))
+        assertEquals(listOf("alpha", "beta", "gamma"), (r as SeedPhraseAuthorizer.SeedResult.Words).words)
+    }
+
+    @Test
+    fun `raw-key wallet (null mnemonic) fails, not empty words`() {
+        // Imported private-key wallets have no seed to derive sub-accounts from.
+        val r = SeedPhraseAuthorizer.toSeedResult(success(null))
+        assertTrue(r is SeedPhraseAuthorizer.SeedResult.Failed)
+    }
+
+    @Test
+    fun `blank mnemonic fails rather than producing empty words`() {
+        val r = SeedPhraseAuthorizer.toSeedResult(success("   "))
+        assertTrue(r is SeedPhraseAuthorizer.SeedResult.Failed)
+    }
+
+    @Test
+    fun `user cancel maps to Cancelled`() {
+        val r = SeedPhraseAuthorizer.toSeedResult(WalletKeyReader.MaterialResult.Cancelled)
+        assertTrue(r is SeedPhraseAuthorizer.SeedResult.Cancelled)
+    }
+
+    @Test
+    fun `biometric enrollment change maps to KeyInvalidated`() {
+        val r = SeedPhraseAuthorizer.toSeedResult(WalletKeyReader.MaterialResult.KeyInvalidated)
+        assertTrue(r is SeedPhraseAuthorizer.SeedResult.KeyInvalidated)
+    }
+
+    @Test
+    fun `auth error carries its message into Failed`() {
+        val r = SeedPhraseAuthorizer.toSeedResult(
+            WalletKeyReader.MaterialResult.AuthError(7, "Too many attempts")
+        )
+        assertEquals("Too many attempts", (r as SeedPhraseAuthorizer.SeedResult.Failed).reason)
+    }
+
+    @Test
+    fun `not-available carries its reason into Failed`() {
+        val r = SeedPhraseAuthorizer.toSeedResult(
+            WalletKeyReader.MaterialResult.NotAvailable("no key_material row")
+        )
+        assertEquals("no key_material row", (r as SeedPhraseAuthorizer.SeedResult.Failed).reason)
+    }
+}


### PR DESCRIPTION
Closes #408.

## Problem

The #382 "Scan now" banner and the Tier 3 "Move to main wallet" sweep read the seed via `getMnemonic()` with no cipher. On a **kdfVersion=2** (auth-bound) wallet that throws `caller must supply an authenticated Cipher`, so both actions failed on every V2 wallet. A user (imported Neuron mining wallet) hit this on v1.7.9 once his balance came right and the banner became prominent. Funds and sends were unaffected — sends already route V2 through `WalletKeyReader`; the scan/sweep were never migrated.

## Fix (mirrors the send path)

- **`SeedPhraseAuthorizer`** (new): wraps `WalletKeyReader.readKeyMaterial` (which drives the V2 BiometricPrompt) and maps the result to seed words / `Cancelled` / `KeyInvalidated` / `Failed`. The pure `toSeedResult` mapping is unit-tested (8 cases).
- **`GatewayRepository`**: `runGapLimitScan` and `sweepGapLimitFunds` each gain a `words` overload; both delegate to a shared inner. The no-arg V1 path (with its EncryptedSharedPreferences fallback that `WalletKeyReader` lacks) is unchanged.
- **`HomeViewModel` / `SettingsViewModel`**: peek `kdfVersion`. V1 → existing path, byte-for-byte. V2 → authorize via BiometricPrompt, then call the `words` overload. Cancel is silent; `KeyInvalidated` tells the user to re-import.
- **Screens**: Home banner scan + sweep-confirm and Settings scan pass the host `FragmentActivity`, exactly like `SendScreen`.

## Scope / safety

- No new UI surface; the buttons already exist. V2 now shows a biometric prompt (same UX as send).
- V1 wallets are completely unchanged.
- Full unit suite green. Device verification: import a wallet (created at kdfVersion=2), tap Scan now → biometric prompt instead of the error.