### PR TITLE
fix(home): switch network inline from the chip (#405)

### DIFF
--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/home/HomeScreen.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/home/HomeScreen.kt
@@ -478,6 +478,7 @@ fun HomeScreen(
                     onNavigateToSecurityChecklist = onNavigateToSecurityChecklist,
                     onNavigateToNodeStatus = onNavigateToNodeStatus,
                     onNavigateToSettings = onNavigateToSettings,
+                    onRequestNetworkSwitch = { viewModel.requestNetworkSwitch(it) },
                     dismissBackupReminder = { viewModel.dismissBackupReminder() },
                     onToggleBalanceVisibility = { viewModel.toggleBalanceVisibility() },
                     clipboardManager = clipboardManager,
@@ -589,6 +590,7 @@ fun HomeScreenUI(
     onNavigateToSecurityChecklist: () -> Unit = {},
     onNavigateToNodeStatus: () -> Unit = {},
     onNavigateToSettings: () -> Unit = {},
+    onRequestNetworkSwitch: (NetworkType) -> Unit = {},
     dismissBackupReminder: () -> Unit,
     onToggleBalanceVisibility: () -> Unit,
     clipboardManager: androidx.compose.ui.platform.ClipboardManager,
@@ -644,7 +646,15 @@ fun HomeScreenUI(
             item {
                 NetworkBadge(
                     network = uiState.currentNetwork,
-                    onClick = onNavigateToSettings,
+                    // #405: switch inline from the chip. Tapping it targets the
+                    // other network and opens the existing restart-confirm dialog
+                    // in place, instead of deep-linking to Settings.
+                    onClick = {
+                        onRequestNetworkSwitch(
+                            if (uiState.currentNetwork == NetworkType.MAINNET) NetworkType.TESTNET
+                            else NetworkType.MAINNET
+                        )
+                    },
                 )
                 Spacer(Modifier.width(4.dp))
             }
@@ -1324,9 +1334,9 @@ private fun NetworkBadge(network: NetworkType, onClick: (() -> Unit)? = null) {
     Surface(
         shape = RoundedCornerShape(12.dp),
         color = backgroundColor,
-        // #353: the chip looked tappable but wasn't. Tapping it now opens
-        // Settings, where the network switcher (with its restart-confirm
-        // dialog) lives.
+        // #353/#405: the chip looked tappable but wasn't, then deep-linked to
+        // Settings. It now switches the network inline — tapping it targets the
+        // other network and raises the restart-confirm dialog in place.
         modifier = Modifier
             .padding(8.dp)
             .then(if (onClick != null) Modifier.clickable { onClick() } else Modifier)


### PR DESCRIPTION
Closes #405.

The network chip deep-linked to Settings (#353) to reach the switcher. The inline switch flow already existed on Home — `requestNetworkSwitch` → the restart-confirm `AlertDialog` → `confirmNetworkSwitch` → `repository.switchNetwork` — but the chip was never wired to it (`requestNetworkSwitch` had zero callers).

Tapping the chip now targets the other network and raises that existing confirm dialog in place, then the usual process-restart switch runs on confirm. Only the chip's `onClick` changed (from `onNavigateToSettings` to `onRequestNetworkSwitch(other)`); the dialog and switch flow are unchanged, and Settings keeps its own switcher.

Compiles; no logic added beyond the rewire.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the ability to switch directly between Mainnet and Testnet by tapping the network badge on the home screen.
  * Displays the existing restart confirmation dialog during the network switch, without navigating to Settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->