### PR TITLE
fix(pin): reset failed-attempt counter after a version upgrade (#370)

### DIFF
--- a/android/app/src/main/java/com/rjnr/pocketnode/MainActivity.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/MainActivity.kt
@@ -1,6 +1,7 @@
 package com.rjnr.pocketnode
 
 import android.os.Bundle
+import android.util.Log
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.compose.foundation.layout.fillMaxSize
@@ -62,6 +63,23 @@ class MainActivity : FragmentActivity() {
 
         // Clean up any orphaned .tmp files from interrupted PIN re-encryption
         keyBackupManager.cleanupOrphanedTmpFiles()
+
+        // #370: reset the PIN failed-attempt counter once after an overwrite
+        // install / version upgrade, BEFORE the startup gate below reads the
+        // lockout state. A fresh install (last-seen 0) just records the version;
+        // an ordinary same-version relaunch is a no-op. Note: this is a
+        // deliberate product choice (see #370) that trades a little brute-force
+        // hardening — a sideloaded higher-versionCode build would also clear the
+        // count — for not stranding a user who fumbled their PIN before updating.
+        run {
+            val lastSeen = walletPreferences.getLastSeenVersionCode()
+            val current = BuildConfig.VERSION_CODE
+            if (PinManager.shouldResetAttemptsForUpgrade(lastSeen, current)) {
+                pinManager.resetFailedAttempts()
+                Log.i("MainActivity", "PIN attempt counter reset after upgrade $lastSeen -> $current (#370)")
+            }
+            if (lastSeen != current) walletPreferences.setLastSeenVersionCode(current)
+        }
 
         // Startup gate: must resolve synchronously to determine start destination.
         // This is the ONE acceptable runBlocking site — it runs once during cold start

--- a/android/app/src/main/java/com/rjnr/pocketnode/data/auth/PinManager.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/auth/PinManager.kt
@@ -191,6 +191,22 @@ class PinManager @Inject constructor(
             .apply()
     }
 
+    /**
+     * #370: clear the failed-attempt counter and any lockout, keeping the PIN
+     * itself. Called once after an overwrite install / version upgrade so a
+     * user who fumbled their PIN before upgrading is not still staring at "out
+     * of attempts" on the freshly upgraded build. Committed synchronously
+     * because the caller runs it during cold start, before the PIN gate reads
+     * the lockout state.
+     */
+    fun resetFailedAttempts() {
+        prefs.edit()
+            .putInt(KEY_FAILED_ATTEMPTS, 0)
+            .remove(KEY_LAST_FAILED_AT)
+            .remove(KEY_LOCKOUT_UNTIL)
+            .commit()
+    }
+
     fun getRemainingAttempts(): Int {
         val failed = prefs.getInt(KEY_FAILED_ATTEMPTS, 0)
         return (MAX_ATTEMPTS - failed).coerceAtLeast(0)
@@ -327,5 +343,15 @@ class PinManager @Inject constructor(
         private const val KEY_FAILED_ATTEMPTS = "failed_attempts"
         private const val KEY_LAST_FAILED_AT = "last_failed_at"
         private const val KEY_LOCKOUT_UNTIL = "lockout_until"
+
+        /**
+         * #370: whether an overwrite install / version bump should reset the
+         * failed-attempt counter. True only on a genuine upgrade — a recorded
+         * previous version strictly below the current one. A fresh install
+         * (lastSeen 0) has no counter to reset; a same-version relaunch or a
+         * downgrade must not clear a legitimate lockout.
+         */
+        fun shouldResetAttemptsForUpgrade(lastSeen: Int, current: Int): Boolean =
+            lastSeen in 1 until current
     }
 }

--- a/android/app/src/main/java/com/rjnr/pocketnode/data/wallet/WalletPreferences.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/wallet/WalletPreferences.kt
@@ -107,6 +107,19 @@ class WalletPreferences @Inject constructor(
         prefs.edit().putString(KEY_SELECTED_NETWORK, network.name).commit()
     }
 
+    /**
+     * Last app versionCode seen at cold start (#370). Default 0 = never
+     * recorded (fresh install). Used to detect an overwrite install / upgrade
+     * and reset the PIN failed-attempt counter once.
+     */
+    fun getLastSeenVersionCode(): Int = prefs.getInt(KEY_LAST_SEEN_VERSION_CODE, 0)
+
+    fun setLastSeenVersionCode(code: Int) {
+        // commit(): the upgrade check runs during cold start before the PIN
+        // gate; the write must land before a possible Process.killProcess().
+        prefs.edit().putInt(KEY_LAST_SEEN_VERSION_CODE, code).commit()
+    }
+
     // --- Per-network key helper ---
 
     private fun networkKey(key: String, network: NetworkType? = null): String {
@@ -392,6 +405,7 @@ class WalletPreferences @Inject constructor(
         private const val TAG = "WalletPreferences"
         private const val PREFS_NAME = "ckb_wallet_prefs"
         private const val KEY_SELECTED_NETWORK = "selected_network"
+        private const val KEY_LAST_SEEN_VERSION_CODE = "last_seen_version_code"
         private const val KEY_SYNC_MODE = "sync_mode"
         private const val KEY_CUSTOM_BLOCK_HEIGHT = "custom_block_height"
         private const val KEY_INITIAL_SYNC_COMPLETED = "initial_sync_completed"

--- a/android/app/src/test/java/com/rjnr/pocketnode/data/auth/PinUpgradeResetTest.kt
+++ b/android/app/src/test/java/com/rjnr/pocketnode/data/auth/PinUpgradeResetTest.kt
@@ -1,0 +1,41 @@
+package com.rjnr.pocketnode.data.auth
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * #370: after an overwrite install / version upgrade, the PIN failed-attempt
+ * counter is reset. The decision is a pure comparison of the last-seen
+ * versionCode against the current one; these lock in that it fires only on a
+ * genuine upgrade — never on a fresh install, a re-launch at the same version,
+ * or a downgrade.
+ */
+class PinUpgradeResetTest {
+
+    @Test
+    fun `fresh install (no last-seen version) does not reset`() {
+        // Default 0 means we have never recorded a version -> nothing to reset.
+        assertFalse(PinManager.shouldResetAttemptsForUpgrade(lastSeen = 0, current = 20))
+    }
+
+    @Test
+    fun `an upgrade resets`() {
+        assertTrue(PinManager.shouldResetAttemptsForUpgrade(lastSeen = 19, current = 20))
+    }
+
+    @Test
+    fun `a multi-version jump resets`() {
+        assertTrue(PinManager.shouldResetAttemptsForUpgrade(lastSeen = 12, current = 20))
+    }
+
+    @Test
+    fun `same version (ordinary relaunch) does not reset`() {
+        assertFalse(PinManager.shouldResetAttemptsForUpgrade(lastSeen = 20, current = 20))
+    }
+
+    @Test
+    fun `a downgrade does not reset`() {
+        assertFalse(PinManager.shouldResetAttemptsForUpgrade(lastSeen = 21, current = 20))
+    }
+}


### PR DESCRIPTION
Closes #370.

Product decision (per issue): after an overwrite install / app upgrade, clear the PIN failed-attempt counter so a user who fumbled their PIN before updating is not still locked out on the fresh build.

## Changes
- **`PinManager.resetFailedAttempts()`** — clears the counter + lockout, keeps the PIN hash. Committed synchronously (runs during cold start, before the gate reads lockout state).
- **`PinManager.shouldResetAttemptsForUpgrade(lastSeen, current)`** — pure decision: true only when a recorded previous version is strictly below current. Unit-tested: fresh install (0), upgrade, multi-version jump, same version, downgrade.
- **`WalletPreferences.get/setLastSeenVersionCode`** — durable (commit) versionCode tracking; default 0 = never recorded.
- **`MainActivity`** — runs the check before the startup PIN gate.

## Tradeoff (accepted, documented in code)
This slightly softens the anti-brute-force design the counter was built for — a sideloaded higher-`versionCode` build could also clear the count — in exchange for not stranding legitimate users after an update. The escalating lockout *within* a version is unchanged. Chosen deliberately per the #370 discussion.

Full unit suite green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * PIN lockout attempts are now reset after upgrading to a newer app version.
  * Existing PIN credentials remain unchanged during the reset.
  * Fresh installs, relaunches, and downgrades do not trigger an unnecessary reset.

* **Tests**
  * Added coverage for upgrade, multi-version upgrade, fresh install, same-version, and downgrade scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->