### PR TITLE
security(ci): pin release-workflow actions to full commit SHAs (F4)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
       - name: Checkout release workflow branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
 
@@ -73,19 +73,19 @@ jobs:
         # refs/tags/v1.7.0), and then have checkout resolve to the malicious
         # branch with release-signing secrets available. SHAs are
         # unambiguous and cannot be shadowed. (#291)
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           ref: ${{ steps.validate_tag.outputs.tag_commit }}
           fetch-depth: 0
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
         with:
           java-version: '17'
           distribution: 'temurin'
 
       - name: Setup Android SDK
-        uses: android-actions/setup-android@v3
+        uses: android-actions/setup-android@9fc6c4e9069bf8d3d10b2204b1fb8f6ef7065407 # v3
 
       - name: Setup Android NDK
         # NDK r27c (27.0.12077973) — matches AGP 8.13.2 default. Bump in
@@ -93,7 +93,7 @@ jobs:
         # sdkmanager produced partial installs missing the llvm toolchain
         # ("clang not found in NDK").
         id: setup-ndk
-        uses: nttld/setup-ndk@v1
+        uses: nttld/setup-ndk@ed92fe6cadad69be94a966a7ee3271275e62f779 # v1
         with:
           ndk-version: r27c
           add-to-path: false
@@ -104,12 +104,12 @@ jobs:
 
       - name: Set up Rust (stable + Android targets)
         # Two ABIs only — matches RUST_TARGETS in build-android-jni.sh.
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable (pinned)
         with:
           targets: aarch64-linux-android,armv7-linux-androideabi
 
       - name: Cache Cargo target
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: |
             ~/.cargo/registry
@@ -119,7 +119,7 @@ jobs:
           restore-keys: cargo-
 
       - name: Cache Gradle
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: |
             ~/.gradle/caches
@@ -177,7 +177,7 @@ jobs:
           echo "Native library found in APK for both ABIs."
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
         with:
           tag_name: ${{ steps.validate_tag.outputs.release_tag }}
           files: android/app/build/outputs/apk/release/*.apk


### PR DESCRIPTION
Security finding F4 (High, supply-chain).

The signed release workflow injects the keystore secrets (`KEYSTORE_*`, `KEY_PASSWORD`, `RELEASE_CERT_SHA256`) and publishes the APK distributed to users, but referenced every action by a **mutable tag/branch** — `nttld/setup-ndk@v1`, `dtolnay/rust-toolchain@stable`, `actions/checkout@v4`, `actions/setup-java@v4`, `android-actions/setup-android@v3`, `actions/cache@v4`, `softprops/action-gh-release@v2`. A compromised upstream tag could run attacker code in the same runner as the signing secrets, or tamper with the APK before signing.

## Fix
Pin every action in `release.yml` to the full commit SHA the tag currently resolves to, with the version in a trailing comment. Dependabot can bump these going forward.

## Not in this PR
- The finding also suggests building the native artifact in a **no-secrets** job and signing in a minimal isolated job. That job split is a larger change; tracking separately.
- The other workflows (`android-ci.yml`, `upgrade-smoke*.yml`) are not keystore-secret-bearing; they can be pinned in a follow-up for consistency.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Pinned release workflow actions to exact revisions for more consistent and reproducible releases.
  * Preserved existing build steps, validation, release behavior, and generated artifacts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->