### PR TITLE
security(reveal): gate no-lock V1 seed/key reveal behind the app PIN (F2)

### DIFF
--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/wallet/WalletSettingsScreen.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/wallet/WalletSettingsScreen.kt
@@ -104,6 +104,16 @@ fun WalletSettingsScreen(
         if (uiState.deleted) onNavigateBack()
     }
 
+    // F2: a no-lock V1 reveal asked for the app PIN. Route to PinEntry("verify");
+    // on success the returning flow calls viewModel.onPinVerified() (NavGraph),
+    // which loads the secret and unlocks the reveal.
+    LaunchedEffect(uiState.pinVerifyRequested) {
+        if (uiState.pinVerifyRequested) {
+            viewModel.onPinVerifyRequestHandled()
+            onNavigateToPinVerify()
+        }
+    }
+
     LaunchedEffect(uiState.error) {
         uiState.error?.let { msg ->
             snackbarHostState.showSnackbar(msg.resolveString(context))

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/wallet/WalletSettingsViewModel.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/wallet/WalletSettingsViewModel.kt
@@ -250,8 +250,13 @@ class WalletSettingsViewModel @Inject constructor(
     fun requiresPinForSeedPhrase(): Boolean = pinManager.hasPin()
 
     fun onPinVerified() {
-        _uiState.update { it.copy(seedPhraseUnlocked = true) }
+        _uiState.update { it.copy(seedPhraseUnlocked = true, pinVerifyRequested = false) }
         loadSensitiveData()
+    }
+
+    /** Screen consumed the [WalletSettingsUiState.pinVerifyRequested] navigation signal (F2). */
+    fun onPinVerifyRequestHandled() {
+        _uiState.update { it.copy(pinVerifyRequested = false) }
     }
 
     fun lockSeedPhrase() {
@@ -325,13 +330,22 @@ class WalletSettingsViewModel @Inject constructor(
                 // path available without a lock; AuthScreen's migration
                 // upgrades the row once the user enables one.
                 if (!authManager.isBiometricEnrolled() && !authManager.hasDeviceCredential()) {
-                    Log.i(TAG, "No secure lock — V1 reveal without lazy V2 upgrade for $walletId")
+                    // F2: no device lock, so no BiometricPrompt/CryptoObject gate
+                    // is available. The app PIN is then the only per-operation
+                    // gate for revealing the seed / private key. Require it
+                    // (route to PinEntry) instead of silently unlocking — a
+                    // momentarily-unlocked session must not reveal secrets
+                    // without the PIN. If there is no PIN either, there is
+                    // nothing to gate with, so proceed.
+                    if (noLockRevealNeedsPin(pinManager.hasPin(), _uiState.value.seedPhraseUnlocked)) {
+                        Log.i(TAG, "No secure lock — gating V1 reveal behind app PIN for $walletId")
+                        _uiState.update { it.copy(pinVerifyRequested = true) }
+                        return@launch
+                    }
+                    Log.i(TAG, "No secure lock, no PIN — V1 reveal for $walletId")
                     loadSensitiveData()
                     // The screen gate is `seedPhraseUnlocked || !requiresPin`;
-                    // without this flip the words loaded but stayed hidden and
-                    // the tap looked like a no-op (device-test 2026-07). No
-                    // stronger credential exists on a no-lock device — the
-                    // app-level PIN at entry is the gate.
+                    // flip so the loaded words show.
                     _uiState.update { it.copy(seedPhraseUnlocked = true) }
                     return@launch
                 }
@@ -488,6 +502,18 @@ class WalletSettingsViewModel @Inject constructor(
     fun clearError() {
         _uiState.update { it.copy(error = null) }
     }
+
+    companion object {
+        /**
+         * F2: on a no-lock device (no biometric, no device credential) the app
+         * PIN is the only per-operation gate for revealing secrets. A reveal
+         * needs the PIN when one is set and the seed is not already unlocked in
+         * this session. With no PIN there is nothing to gate with, so reveal
+         * proceeds.
+         */
+        fun noLockRevealNeedsPin(hasPin: Boolean, alreadyUnlocked: Boolean): Boolean =
+            hasPin && !alreadyUnlocked
+    }
 }
 
 data class WalletSettingsUiState(
@@ -504,5 +530,11 @@ data class WalletSettingsUiState(
     val error: com.rjnr.pocketnode.ui.util.UiMessage? = null,
     val seedPhraseUnlocked: Boolean = false,
     val privateKeyHex: String? = null,
-    val mnemonicWords: List<String>? = null
+    val mnemonicWords: List<String>? = null,
+    /**
+     * F2: a no-lock V1 reveal needs the app PIN. The screen observes this,
+     * navigates to PinEntry("verify"), and clears it; on success the returning
+     * flow calls [WalletSettingsViewModel.onPinVerified].
+     */
+    val pinVerifyRequested: Boolean = false,
 )

--- a/android/app/src/test/java/com/rjnr/pocketnode/ui/screens/wallet/NoLockRevealGateTest.kt
+++ b/android/app/src/test/java/com/rjnr/pocketnode/ui/screens/wallet/NoLockRevealGateTest.kt
@@ -1,0 +1,35 @@
+package com.rjnr.pocketnode.ui.screens.wallet
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * F2: on a no-lock device (no biometric, no device credential) revealing the
+ * seed / private key of a V1 wallet must go through the app PIN, not silently
+ * unlock. These lock in [WalletSettingsViewModel.noLockRevealNeedsPin]: require
+ * the PIN when one is set and the session has not already been unlocked; with
+ * no PIN there is nothing to gate with.
+ */
+class NoLockRevealGateTest {
+
+    @Test
+    fun `pin set and not yet unlocked requires the pin`() {
+        assertTrue(WalletSettingsViewModel.noLockRevealNeedsPin(hasPin = true, alreadyUnlocked = false))
+    }
+
+    @Test
+    fun `already unlocked this session does not re-prompt`() {
+        assertFalse(WalletSettingsViewModel.noLockRevealNeedsPin(hasPin = true, alreadyUnlocked = true))
+    }
+
+    @Test
+    fun `no pin means nothing to gate with, reveal proceeds`() {
+        assertFalse(WalletSettingsViewModel.noLockRevealNeedsPin(hasPin = false, alreadyUnlocked = false))
+    }
+
+    @Test
+    fun `no pin and already unlocked also proceeds`() {
+        assertFalse(WalletSettingsViewModel.noLockRevealNeedsPin(hasPin = false, alreadyUnlocked = true))
+    }
+}


### PR DESCRIPTION
Security finding F2 (High, local per-operation auth bypass).

On a device with **no biometric and no device credential**, `WalletSettingsViewModel.loadSensitiveData(activity)` revealed the seed / private key of a `kdfVersion=1` wallet by flipping `seedPhraseUnlocked = true` and loading the secret — with **no app-PIN gate**. The reveal buttons call `unlockSensitive()` directly, so a momentarily-unlocked session (or local accessibility control) could reveal recovery material without knowing the PIN.

## Fix
No `BiometricPrompt`/`CryptoObject` gate exists on a no-lock device, so the app PIN is the only per-operation gate available. The no-lock V1 branch now:
- **requires the app PIN** when one is set — sets a `pinVerifyRequested` state signal; the screen routes to `PinEntry("verify")`, and on success the existing `onPinVerified()` loads + unlocks (this PIN-verify-return path already existed in NavGraph, it just wasn't wired to reveal);
- reveals directly only when there is **no PIN either** (nothing to gate with).

`noLockRevealNeedsPin(hasPin, alreadyUnlocked)` is a pure helper, unit-tested (4 cases).

## Unchanged
- V2 wallets: reveal already gated by `BiometricPrompt` CryptoObject.
- V1 wallets **with** a device credential: reveal goes through the lazy V2 migration + biometric.

Full unit suite green.