### PR TITLE
security(keys): informed consent before V1 key downgrade (F1/F3)

### DIFF
--- a/android/app/src/main/java/com/rjnr/pocketnode/data/wallet/WalletKeyWriter.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/wallet/WalletKeyWriter.kt
@@ -106,21 +106,17 @@ class WalletKeyWriter @Inject constructor(
         promptTitle: String = "Secure wallet",
         promptSubtitle: String = "Use your phone's screen lock — fingerprint, face, or device PIN — to encrypt this wallet's keys.",
     ): Result {
-        // #354 follow-up: a V2 auth-bound key cannot exist without an enrolled
-        // biometric or device credential. AddWalletViewModel pre-gated this,
-        // but other callers (WalletSettings addSubAccount, discovery restore)
-        // called straight in and crashed with "Secure lock screen must be
-        // enabled" on no-lock devices. Gate HERE so every caller falls back to
-        // the V1 software key; the AuthScreen migration loop upgrades the row
-        // to V2 once the user enables a device lock.
+        // #354 follow-up + security F1: a V2 auth-bound key cannot exist
+        // without an enrolled biometric or device credential. Do NOT silently
+        // downgrade to the V1 software key here — that hid a storage-security
+        // downgrade from callers (Add Wallet, WalletSettings addSubAccount,
+        // discovery restore) whose prompt copy implied secure persistence.
+        // Return NoSecureLock; each UI flow decides whether to opt into
+        // persistNewWalletV1Fallback AFTER showing the informed-consent
+        // "Continue without a device lock?" dialog, matching onboarding.
         if (!authManager.isBiometricEnrolled() && !authManager.hasDeviceCredential()) {
-            Log.i(TAG, "No secure lock on device — persisting $walletId at V1 fallback")
-            return persistNewWalletV1Fallback(
-                walletId = walletId,
-                bundle = bundle,
-                walletType = walletType,
-                mnemonicBackedUp = mnemonicBackedUp,
-            )
+            Log.i(TAG, "No secure lock on device — returning NoSecureLock for $walletId")
+            return Result.NoSecureLock
         }
 
         val cipher = try {
@@ -135,25 +131,17 @@ class WalletKeyWriter @Inject constructor(
             // it. Race path only now that the pre-gate above exists (e.g. lock
             // removed mid-flow): fall back to V1 like the gate would have.
             if (e.cause?.message?.contains("Secure lock screen", ignoreCase = true) == true) {
-                Log.w(TAG, "V2 key creation refused mid-flow (no secure lock); V1 fallback", e)
-                return persistNewWalletV1Fallback(
-                    walletId = walletId,
-                    bundle = bundle,
-                    walletType = walletType,
-                    mnemonicBackedUp = mnemonicBackedUp,
-                )
+                // Race: the lock was removed mid-flow. Same as the pre-gate —
+                // return NoSecureLock (F1) rather than silently downgrading.
+                Log.w(TAG, "V2 key creation refused mid-flow (no secure lock); NoSecureLock", e)
+                return Result.NoSecureLock
             }
             throw e
         } catch (e: IllegalStateException) {
             // Same condition, unwrapped form (older API levels).
             if (e.message?.contains("Secure lock screen", ignoreCase = true) == true) {
-                Log.w(TAG, "V2 key creation refused mid-flow (no secure lock); V1 fallback", e)
-                return persistNewWalletV1Fallback(
-                    walletId = walletId,
-                    bundle = bundle,
-                    walletType = walletType,
-                    mnemonicBackedUp = mnemonicBackedUp,
-                )
+                Log.w(TAG, "V2 key creation refused mid-flow (no secure lock); NoSecureLock", e)
+                return Result.NoSecureLock
             }
             throw e
         }

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/components/NoDeviceLockConsentDialog.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/components/NoDeviceLockConsentDialog.kt
@@ -1,0 +1,46 @@
+package com.rjnr.pocketnode.ui.components
+
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+
+/**
+ * Informed-consent dialog shown before persisting a wallet at the V1
+ * software-only fallback because the device has no biometric and no device
+ * credential (security F1/F3).
+ *
+ * Onboarding already warned about this weaker storage mode; the other flows
+ * (Add Wallet, sub-account creation, discovery restore) previously downgraded
+ * to V1 silently. This is the shared warning so every flow surfaces the same
+ * informed consent before the downgrade. [onConfirm] proceeds with the V1
+ * fallback; [onDismiss] aborts.
+ */
+@Composable
+fun NoDeviceLockConsentDialog(
+    onConfirm: () -> Unit,
+    onDismiss: () -> Unit,
+) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text("Continue without a device lock?") },
+        text = {
+            Text(
+                text = "This phone has no PIN, pattern, password, or biometric set.\n\n" +
+                    "Your wallet will still work, but the keys will be stored in a software-only " +
+                    "encryption layer that protects against casual theft of the device but is " +
+                    "not hardware-bound to your fingerprint or PIN.\n\n" +
+                    "If you enable a device lock later, the app will upgrade your wallet to " +
+                    "hardware-backed protection automatically on the next launch.",
+                style = MaterialTheme.typography.bodyMedium,
+            )
+        },
+        confirmButton = {
+            TextButton(onClick = onConfirm) { Text("Continue anyway") }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) { Text("Cancel") }
+        },
+    )
+}

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/wallet/AddWalletScreen.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/wallet/AddWalletScreen.kt
@@ -115,6 +115,15 @@ fun AddWalletScreen(
         }
     }
 
+    // F1/F3: no device lock -> warn before persisting at the V1 software
+    // fallback, matching onboarding, instead of silently downgrading.
+    if (uiState.showNoLockConsent) {
+        com.rjnr.pocketnode.ui.components.NoDeviceLockConsentDialog(
+            onConfirm = { viewModel.confirmNoLockConsent() },
+            onDismiss = { viewModel.dismissNoLockConsent() },
+        )
+    }
+
     Scaffold(
         topBar = {
             TopAppBar(

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/wallet/AddWalletViewModel.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/wallet/AddWalletViewModel.kt
@@ -27,6 +27,8 @@ private const val TAG = "AddWalletVM"
 
 data class AddWalletUiState(
     val isLoading: Boolean = false,
+    /** F1/F3: show the no-device-lock informed-consent dialog before a V1 fallback write. */
+    val showNoLockConsent: Boolean = false,
     val name: String = "",
     val importWords: List<String> = List(12) { "" },
     val importSuggestions: Map<Int, List<String>> = emptyMap(),
@@ -60,6 +62,30 @@ class AddWalletViewModel @Inject constructor(
      */
     private fun canCreateV2BoundKey(): Boolean =
         authManager.isBiometricEnrolled() || authManager.hasDeviceCredential()
+
+    // F1/F3: on a no-lock device, persisting drops to the V1 software fallback.
+    // Onboarding warns before this; the Add Wallet flows must too. Each action
+    // takes a `consented` flag: the first call, if no secure lock, stashes a
+    // re-invocation and shows the shared consent dialog instead of silently
+    // downgrading. Confirm re-runs the action with consented=true.
+    private var pendingNoLockAction: (() -> Unit)? = null
+
+    private fun requestNoLockConsent(action: () -> Unit) {
+        pendingNoLockAction = action
+        _uiState.update { it.copy(showNoLockConsent = true) }
+    }
+
+    fun confirmNoLockConsent() {
+        val action = pendingNoLockAction
+        pendingNoLockAction = null
+        _uiState.update { it.copy(showNoLockConsent = false) }
+        action?.invoke()
+    }
+
+    fun dismissNoLockConsent() {
+        pendingNoLockAction = null
+        _uiState.update { it.copy(showNoLockConsent = false, isLoading = false) }
+    }
 
     /**
      * Persist a new wallet's keys, choosing the V1 software-only fallback when
@@ -139,7 +165,7 @@ class AddWalletViewModel @Inject constructor(
      *   2. Encrypt + persist the new sub-account's key material via
      *      [WalletKeyWriter.persistNewWallet] (inside [persistKeys]).
      */
-    fun createSubAccount(activity: FragmentActivity) {
+    fun createSubAccount(activity: FragmentActivity, consented: Boolean = false) {
         if (_uiState.value.isLoading) return // prevent double-tap
         val name = _uiState.value.name.trim()
         val parentId = _uiState.value.selectedParentId
@@ -150,6 +176,10 @@ class AddWalletViewModel @Inject constructor(
         }
         if (parentId == null) {
             _uiState.update { it.copy(error = UiMessage.Resource(R.string.vm_error_select_parent_wallet)) }
+            return
+        }
+        if (!consented && !canCreateV2BoundKey()) {
+            requestNoLockConsent { createSubAccount(activity, consented = true) }
             return
         }
 
@@ -289,11 +319,15 @@ class AddWalletViewModel @Inject constructor(
         _uiState.update { it.copy(importPrivateKey = key) }
     }
 
-    fun createNewWallet(activity: FragmentActivity) {
+    fun createNewWallet(activity: FragmentActivity, consented: Boolean = false) {
         if (_uiState.value.isLoading) return // prevent double-tap
         val name = _uiState.value.name.trim()
         if (name.isBlank()) {
             _uiState.update { it.copy(error = UiMessage.Resource(R.string.vm_error_enter_wallet_name)) }
+            return
+        }
+        if (!consented && !canCreateV2BoundKey()) {
+            requestNoLockConsent { createNewWallet(activity, consented = true) }
             return
         }
 
@@ -328,7 +362,7 @@ class AddWalletViewModel @Inject constructor(
         }
     }
 
-    fun importMnemonic(activity: FragmentActivity) {
+    fun importMnemonic(activity: FragmentActivity, consented: Boolean = false) {
         if (_uiState.value.isLoading) return // prevent double-tap
         val name = _uiState.value.name.trim()
         val words = _uiState.value.importWords.map { it.trim().lowercase() }
@@ -347,6 +381,10 @@ class AddWalletViewModel @Inject constructor(
         }
         if (!mnemonicManager.validateMnemonic(words)) {
             _uiState.update { it.copy(error = UiMessage.Resource(R.string.vm_error_invalid_mnemonic)) }
+            return
+        }
+        if (!consented && !canCreateV2BoundKey()) {
+            requestNoLockConsent { importMnemonic(activity, consented = true) }
             return
         }
 
@@ -375,7 +413,7 @@ class AddWalletViewModel @Inject constructor(
         }
     }
 
-    fun importRawKey(activity: FragmentActivity) {
+    fun importRawKey(activity: FragmentActivity, consented: Boolean = false) {
         if (_uiState.value.isLoading) return // prevent double-tap
         val name = _uiState.value.name.trim()
         val key = _uiState.value.importPrivateKey.trim()
@@ -386,6 +424,10 @@ class AddWalletViewModel @Inject constructor(
         }
         if (key.removePrefix("0x").length != 64) {
             _uiState.update { it.copy(error = UiMessage.Resource(R.string.vm_error_invalid_private_key)) }
+            return
+        }
+        if (!consented && !canCreateV2BoundKey()) {
+            requestNoLockConsent { importRawKey(activity, consented = true) }
             return
         }
 

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/wallet/WalletManagerScreen.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/wallet/WalletManagerScreen.kt
@@ -66,6 +66,15 @@ fun WalletManagerScreen(
     val snackbarHostState = remember { SnackbarHostState() }
     val context = androidx.compose.ui.platform.LocalContext.current
 
+    // F1/F3: no device lock -> warn before restoring sub-accounts at the V1
+    // software fallback, matching onboarding.
+    if (uiState.showNoLockConsent) {
+        com.rjnr.pocketnode.ui.components.NoDeviceLockConsentDialog(
+            onConfirm = { viewModel.confirmNoLockConsent() },
+            onDismiss = { viewModel.dismissNoLockConsent() },
+        )
+    }
+
     LaunchedEffect(uiState.error) {
         uiState.error?.let { msg ->
             snackbarHostState.showSnackbar(msg.resolveString(context))

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/wallet/WalletManagerViewModel.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/wallet/WalletManagerViewModel.kt
@@ -23,7 +23,32 @@ class WalletManagerViewModel @Inject constructor(
     private val subAccountCandidateDao: com.rjnr.pocketnode.data.database.dao.SubAccountCandidateDao,
     private val walletKeyReader: com.rjnr.pocketnode.data.wallet.WalletKeyReader,
     private val walletKeyWriter: com.rjnr.pocketnode.data.wallet.WalletKeyWriter,
+    private val authManager: com.rjnr.pocketnode.data.auth.AuthManager,
 ) : ViewModel() {
+
+    private fun canCreateV2BoundKey(): Boolean =
+        authManager.isBiometricEnrolled() || authManager.hasDeviceCredential()
+
+    // F1/F3: no device lock -> restored sub-accounts persist at the V1 software
+    // fallback. Warn once before the batch, matching onboarding.
+    private var pendingNoLockAction: (() -> Unit)? = null
+
+    private fun requestNoLockConsent(action: () -> Unit) {
+        pendingNoLockAction = action
+        _uiState.update { it.copy(showNoLockConsent = true) }
+    }
+
+    fun confirmNoLockConsent() {
+        val action = pendingNoLockAction
+        pendingNoLockAction = null
+        _uiState.update { it.copy(showNoLockConsent = false) }
+        action?.invoke()
+    }
+
+    fun dismissNoLockConsent() {
+        pendingNoLockAction = null
+        _uiState.update { it.copy(showNoLockConsent = false) }
+    }
 
     private val _uiState = MutableStateFlow(WalletManagerUiState())
     val uiState: StateFlow<WalletManagerUiState> = _uiState.asStateFlow()
@@ -63,9 +88,16 @@ class WalletManagerViewModel @Inject constructor(
      * per restored account — the same two-prompt contract as manual
      * sub-account creation, just batched and user-initiated from the banner.
      */
-    fun restoreFoundSubAccounts(activity: androidx.fragment.app.FragmentActivity) {
+    fun restoreFoundSubAccounts(
+        activity: androidx.fragment.app.FragmentActivity,
+        consented: Boolean = false,
+    ) {
         val found = _uiState.value.foundCandidates
         if (found.isEmpty() || _uiState.value.isRestoring) return
+        if (!consented && !canCreateV2BoundKey()) {
+            requestNoLockConsent { restoreFoundSubAccounts(activity, consented = true) }
+            return
+        }
         _uiState.update { it.copy(isRestoring = true) }
         viewModelScope.launch {
             try {
@@ -90,15 +122,25 @@ class WalletManagerViewModel @Inject constructor(
                             parentMnemonic = words,
                             explicitIndex = candidate.accountIndex,
                             persistKeys = { newWalletId, bundle ->
-                                walletKeyWriter.persistNewWallet(
-                                    activity = activity,
-                                    walletId = newWalletId,
-                                    bundle = bundle,
-                                    walletType = com.rjnr.pocketnode.data.wallet.KeyManager.WALLET_TYPE_MNEMONIC,
-                                    mnemonicBackedUp = false,
-                                    promptTitle = "Secure restored sub-account",
-                                    promptSubtitle = "Encrypt sub-account ${candidate.accountIndex}'s keys.",
-                                )
+                                if (canCreateV2BoundKey()) {
+                                    walletKeyWriter.persistNewWallet(
+                                        activity = activity,
+                                        walletId = newWalletId,
+                                        bundle = bundle,
+                                        walletType = com.rjnr.pocketnode.data.wallet.KeyManager.WALLET_TYPE_MNEMONIC,
+                                        mnemonicBackedUp = false,
+                                        promptTitle = "Secure restored sub-account",
+                                        promptSubtitle = "Encrypt sub-account ${candidate.accountIndex}'s keys.",
+                                    )
+                                } else {
+                                    // No secure lock; user consented to V1 above.
+                                    walletKeyWriter.persistNewWalletV1Fallback(
+                                        walletId = newWalletId,
+                                        bundle = bundle,
+                                        walletType = com.rjnr.pocketnode.data.wallet.KeyManager.WALLET_TYPE_MNEMONIC,
+                                        mnemonicBackedUp = false,
+                                    )
+                                }
                             },
                         ).onSuccess { wallet ->
                             restored++
@@ -153,5 +195,7 @@ data class WalletManagerUiState(
     /** Discovered-but-unrestored sub-account slots with on-chain history (#82). */
     val foundCandidates: List<com.rjnr.pocketnode.data.database.entity.SubAccountCandidateEntity> = emptyList(),
     val isRestoring: Boolean = false,
+    /** F1/F3: show the no-device-lock consent dialog before V1 restore writes. */
+    val showNoLockConsent: Boolean = false,
     val error: com.rjnr.pocketnode.ui.util.UiMessage? = null,
 )

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/wallet/WalletSettingsScreen.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/wallet/WalletSettingsScreen.kt
@@ -111,6 +111,15 @@ fun WalletSettingsScreen(
         }
     }
 
+    // F1/F3: no device lock -> warn before persisting a sub-account at the V1
+    // software fallback, matching onboarding.
+    if (uiState.showNoLockConsent) {
+        com.rjnr.pocketnode.ui.components.NoDeviceLockConsentDialog(
+            onConfirm = { viewModel.confirmNoLockConsent() },
+            onDismiss = { viewModel.dismissNoLockConsent() },
+        )
+    }
+
     // Delete confirmation dialog
     if (uiState.showDeleteConfirm) {
         val warningText = buildString {

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/wallet/WalletSettingsViewModel.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/wallet/WalletSettingsViewModel.kt
@@ -429,7 +429,36 @@ class WalletSettingsViewModel @Inject constructor(
      *
      * Replaces the old V1-fallback path which crashed on V2 parents.
      */
-    fun addSubAccount(activity: FragmentActivity, name: String) {
+    private fun canCreateV2BoundKey(): Boolean =
+        authManager.isBiometricEnrolled() || authManager.hasDeviceCredential()
+
+    // F1/F3: on a no-lock device the new sub-account persists at the V1
+    // software fallback. Warn first (shared consent dialog), matching
+    // onboarding, instead of silently downgrading.
+    private var pendingNoLockAction: (() -> Unit)? = null
+
+    private fun requestNoLockConsent(action: () -> Unit) {
+        pendingNoLockAction = action
+        _uiState.update { it.copy(showNoLockConsent = true) }
+    }
+
+    fun confirmNoLockConsent() {
+        val action = pendingNoLockAction
+        pendingNoLockAction = null
+        _uiState.update { it.copy(showNoLockConsent = false) }
+        action?.invoke()
+    }
+
+    fun dismissNoLockConsent() {
+        pendingNoLockAction = null
+        _uiState.update { it.copy(showNoLockConsent = false) }
+    }
+
+    fun addSubAccount(activity: FragmentActivity, name: String, consented: Boolean = false) {
+        if (!consented && !canCreateV2BoundKey()) {
+            requestNoLockConsent { addSubAccount(activity, name, consented = true) }
+            return
+        }
         viewModelScope.launch {
             when (val readResult = walletKeyReader.readKeyMaterial(
                 activity = activity,
@@ -456,15 +485,25 @@ class WalletSettingsViewModel @Inject constructor(
                     // so the user knows this is securing the NEW sub-account,
                     // not re-confirming the parent unlock from prompt #1.
                     val result = walletRepository.createSubAccount(walletId, name, parentMnemonic = words) { newWalletId, bundle ->
-                        walletKeyWriter.persistNewWallet(
-                            activity = activity,
-                            walletId = newWalletId,
-                            bundle = bundle,
-                            walletType = KeyManager.WALLET_TYPE_MNEMONIC,
-                            mnemonicBackedUp = false,
-                            promptTitle = "Secure new sub-account",
-                            promptSubtitle = "Encrypt the new account's keys.",
-                        )
+                        if (canCreateV2BoundKey()) {
+                            walletKeyWriter.persistNewWallet(
+                                activity = activity,
+                                walletId = newWalletId,
+                                bundle = bundle,
+                                walletType = KeyManager.WALLET_TYPE_MNEMONIC,
+                                mnemonicBackedUp = false,
+                                promptTitle = "Secure new sub-account",
+                                promptSubtitle = "Encrypt the new account's keys.",
+                            )
+                        } else {
+                            // No secure lock; the user consented to V1 above.
+                            walletKeyWriter.persistNewWalletV1Fallback(
+                                walletId = newWalletId,
+                                bundle = bundle,
+                                walletType = KeyManager.WALLET_TYPE_MNEMONIC,
+                                mnemonicBackedUp = false,
+                            )
+                        }
                     }
                     result.onFailure { e ->
                         // Cancelled at the persist prompt: silent. Other errors: surface.
@@ -493,6 +532,8 @@ class WalletSettingsViewModel @Inject constructor(
 data class WalletSettingsUiState(
     val wallet: WalletEntity? = null,
     val subAccounts: List<WalletEntity> = emptyList(),
+    /** F1/F3: show the no-device-lock consent dialog before a V1 sub-account write. */
+    val showNoLockConsent: Boolean = false,
     val isEditing: Boolean = false,
     val editName: String = "",
     val isBackedUp: Boolean = false,

--- a/android/app/src/test/java/com/rjnr/pocketnode/data/wallet/WalletKeyWriterTest.kt
+++ b/android/app/src/test/java/com/rjnr/pocketnode/data/wallet/WalletKeyWriterTest.kt
@@ -111,24 +111,40 @@ class WalletKeyWriterTest {
     }
 
     /**
-     * No secure lock on the device: persistNewWallet must fall back to the
-     * V1 software key with NO auth prompt instead of crashing with
-     * "Secure lock screen must be enabled" (emulator repro, #354 follow-up:
-     * WalletSettings addSubAccount and discovery restore hit this — only
-     * AddWalletViewModel had the pre-gate).
+     * Security F1: no secure lock on the device. persistNewWallet must NOT
+     * silently downgrade to V1 — that hid a storage-security downgrade from
+     * callers whose prompt copy implied secure persistence. It returns
+     * NoSecureLock and writes nothing; each UI flow shows the no-lock consent
+     * dialog and only then opts into persistNewWalletV1Fallback.
      */
     @Test
-    fun `persistNewWallet falls back to V1 when device has no secure lock`() = runTest {
+    fun `persistNewWallet returns NoSecureLock and writes nothing when no secure lock`() = runTest {
         io.mockk.every { authManager.isBiometricEnrolled() } returns false
         io.mockk.every { authManager.hasDeviceCredential() } returns false
 
         val result = writer.persistNewWallet(activity, "w-nolock", bundle, "mnemonic", false)
 
+        assertEquals(WalletKeyWriter.Result.NoSecureLock, result)
+        assertNull(keyMaterialDao.getByWalletId("w-nolock"))
+        // No prompt, no silent downgrade.
+        coVerify(exactly = 0) {
+            authManager.authenticateForCipher(any(), any<Cipher>(), any(), any())
+        }
+    }
+
+    /**
+     * The explicit, post-consent fallback still writes a V1 row (kdfVersion=1)
+     * with no auth prompt — this is what the UI flows call after the user
+     * confirms the no-lock consent dialog.
+     */
+    @Test
+    fun `persistNewWalletV1Fallback writes a V1 row without a prompt`() = runTest {
+        val result = writer.persistNewWalletV1Fallback("w-v1", bundle, "mnemonic", false)
+
         assertEquals(WalletKeyWriter.Result.Success, result)
-        val entity = keyMaterialDao.getByWalletId("w-nolock")
+        val entity = keyMaterialDao.getByWalletId("w-v1")
         assertNotNull(entity)
         assertEquals(1, entity!!.kdfVersion)
-        // The V2 prompt must never fire on the fallback path.
         coVerify(exactly = 0) {
             authManager.authenticateForCipher(any(), any<Cipher>(), any(), any())
         }


### PR DESCRIPTION
Security findings F1 + F3 (both High) — silent key-storage downgrade.

The no-lock V1 fallback (added for the #354 crash) is intended, but it downgraded key storage to the **unrestricted V1 software key silently** in every flow except onboarding. `WalletKeyWriter.persistNewWallet` returned `Success` from the fallback, and Add Wallet / `WalletSettings.addSubAccount` / discovery-restore all called it with prompt copy implying secure persistence — so a user could create/import/derive a wallet on a no-lock device with weaker key protection and no warning.

## Fix (keeps no-lock support, removes the silent downgrade)
- **`WalletKeyWriter.persistNewWallet`** no longer falls back internally — it returns `Result.NoSecureLock`, including for the mid-flow `InvalidAlgorithmParameterException` / `IllegalStateException` "Secure lock screen" race the finding called out. `persistNewWalletV1Fallback` stays as the **explicit, post-consent** writer.
- **New shared `NoDeviceLockConsentDialog`** — onboarding's "Continue without a device lock?" copy, reused everywhere.
- **Add Wallet** (create / import mnemonic / import raw key / sub-account), **`WalletSettings.addSubAccount`**, and **`WalletManager` discovery-restore** now show the consent dialog before the V1 fallback. Each action takes a `consented` flag; the first no-lock call stashes a re-invocation and shows the dialog; the persist uses `persistNewWalletV1Fallback` only after the user confirms.

## Tests
`WalletKeyWriterTest`: `persistNewWallet` now returns `NoSecureLock` and writes nothing on a no-lock device (was: silent V1 write); a new test covers the explicit fallback still writing a `kdfVersion=1` row. Full unit suite green (828 tests).

## Decision
Per maintainer: consent-then-allow (matches onboarding), not block-outside-onboarding. Devices with a lock are unaffected — V2 as before.