### PR TITLE
chore(website): add Google Search Console verification file

### DIFF
--- a/website/public/google7cda538228c1f983.html
+++ b/website/public/google7cda538228c1f983.html
@@ -1,0 +1,1 @@
+google-site-verification: google7cda538228c1f983.html


### PR DESCRIPTION
Adds the Google Search Console domain-verification file so Google can confirm ownership of pocket-node.com (required to upload the app to the Play Store).

- Served at **https://www.pocket-node.com/google7cda538228c1f983.html** (Next.js serves `website/public/` at the site root).
- Content is the standard verification token: `google-site-verification: google7cda538228c1f983.html` (53 bytes).

Merging to main triggers the Vercel production deploy; once live, click **VERIFY** in Search Console. Google says to keep the file even after verification succeeds.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added Google site verification for the website.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->