### PR TITLE
feat: bulk airdrop send flow (Nairobi)

### DIFF
--- a/android/app/src/androidTest/java/com/rjnr/pocketnode/UpgradeSmokeTest.kt
+++ b/android/app/src/androidTest/java/com/rjnr/pocketnode/UpgradeSmokeTest.kt
@@ -223,6 +223,46 @@ class UpgradeSmokeTest {
     }
 
     /**
+     * Narrow smoke for the Nairobi bulk-send UI. This does not depend on the
+     * home balance row; it only needs the post-upgrade unlock to succeed, the
+     * SEND action to be reachable, and the Send screen to render the new
+     * Single/Bulk mode switch plus the bulk paste placeholder.
+     */
+    @Test
+    fun assertBulkSendScreenAfterUnlock() {
+        launchApp()
+
+        clickByRes("auth-use-pin", 10_000L)
+
+        if (device.wait(Until.hasObject(By.res("pin-keypad-1")), 10_000L)) {
+            repeat(6) {
+                assertTrue(
+                    "PIN digit '1' not clickable on bulk-send smoke unlock",
+                    clickByRes("pin-keypad-1")
+                )
+            }
+        }
+
+        assertTrue(
+            "SEND action not visible after unlock",
+            clickButton("missing-send-tag", "SEND", POST_UPGRADE_HOME_TIMEOUT_MS)
+        )
+
+        assertTrue(
+            "Bulk mode toggle not visible on Send screen",
+            clickButton("missing-bulk-tag", "Bulk", 10_000L)
+        )
+
+        assertTrue(
+            "Bulk recipient placeholder not visible after switching modes",
+            device.wait(
+                Until.hasObject(By.text("Paste one CKB address per line").pkg(PKG)),
+                10_000L
+            )
+        )
+    }
+
+    /**
      * Deadline-poll wrapper around clickButton for screens that can take a long
      * time to APPEAR (vs. nodes that exist but go briefly stale). Each cycle
      * re-runs the full clickButton strategy (resource-id fast path, scroll, text

--- a/android/app/src/main/java/com/rjnr/pocketnode/data/gateway/GatewayRepository.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/gateway/GatewayRepository.kt
@@ -17,6 +17,7 @@ import com.rjnr.pocketnode.data.sync.SyncForegroundService
 import com.rjnr.pocketnode.data.sync.SyncProgressTracker
 import com.rjnr.pocketnode.data.migration.WalletMigrationHelper
 import com.rjnr.pocketnode.data.transaction.TransactionBuilder
+import com.rjnr.pocketnode.data.transaction.RecipientOutput
 import com.rjnr.pocketnode.data.database.entity.SubAccountCandidateEntity
 import com.rjnr.pocketnode.data.wallet.AddressUtils
 import com.rjnr.pocketnode.data.transaction.SweepInput
@@ -1714,6 +1715,22 @@ class GatewayRepository @Inject constructor(
                 fromAddress = fromAddress,
                 toAddress = toAddress,
                 amountShannons = amountShannons,
+                availableCells = availableCells,
+                privateKey = privateKey,
+                network = net
+            )
+        }
+    }
+
+    suspend fun prepareAndSendBulk(
+        fromAddress: String,
+        recipients: List<RecipientOutput>,
+        privateKey: ByteArray
+    ): Result<String> = runCatching {
+        buildReserveAndSend(fromAddress) { availableCells, net ->
+            transactionBuilder.buildMultiTransfer(
+                fromAddress = fromAddress,
+                recipients = recipients,
                 availableCells = availableCells,
                 privateKey = privateKey,
                 network = net

--- a/android/app/src/main/java/com/rjnr/pocketnode/data/transaction/TransactionBuilder.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/transaction/TransactionBuilder.kt
@@ -32,6 +32,11 @@ data class SweepPlan(
     val inputLockArgs: List<String>,
 )
 
+data class RecipientOutput(
+    val address: String,
+    val amountShannons: Long,
+)
+
 @Singleton
 class TransactionBuilder @Inject constructor(
     private val networkValidator: NetworkValidator
@@ -252,27 +257,50 @@ class TransactionBuilder @Inject constructor(
         privateKey: ByteArray,
         network: NetworkType
     ): Transaction {
+        return buildMultiTransfer(
+            fromAddress = fromAddress,
+            recipients = listOf(RecipientOutput(toAddress, amountShannons)),
+            availableCells = availableCells,
+            privateKey = privateKey,
+            network = network,
+        )
+    }
+
+    fun buildMultiTransfer(
+        fromAddress: String,
+        recipients: List<RecipientOutput>,
+        availableCells: List<Cell>,
+        privateKey: ByteArray,
+        network: NetworkType
+    ): Transaction {
         Log.d(TAG, "🔨 Building transfer transaction")
         // Sender + recipient + amount form a payment record — redact the
         // addresses and drop the amount from debug logcat (#321).
         Log.d(TAG, "  From: ${fromAddress.redactAddress()}")
-        Log.d(TAG, "  To: ${toAddress.redactAddress()}")
+        Log.d(TAG, "  Recipient count: ${recipients.size}")
 
-        // Validate recipient amount meets minimum cell capacity
-        if (amountShannons < MIN_CELL_CAPACITY) {
-            throw IllegalArgumentException(
-                "Transfer amount must be at least ${MIN_CELL_CAPACITY / 100_000_000} CKB (minimum cell capacity)"
-            )
+        require(recipients.isNotEmpty()) { "At least one recipient is required" }
+
+        recipients.forEach { recipient ->
+            if (recipient.amountShannons < MIN_CELL_CAPACITY) {
+                throw IllegalArgumentException(
+                    "Transfer amount must be at least ${MIN_CELL_CAPACITY / 100_000_000} CKB (minimum cell capacity)"
+                )
+            }
         }
 
         val senderScript = AddressUtils.parseAddress(fromAddress)
             ?: throw IllegalArgumentException("Invalid sender address")
-        val recipientScript = AddressUtils.parseAddress(toAddress)
-            ?: throw IllegalArgumentException("Invalid recipient address")
 
-        // Validate addresses match the app-level network config
-        networkValidator.validateTransferAddresses(fromAddress, toAddress, network)
-            .getOrThrow()
+        val recipientScripts = recipients.map { recipient ->
+            val script = AddressUtils.parseAddress(recipient.address)
+                ?: throw IllegalArgumentException("Invalid recipient address")
+            networkValidator.validateTransferAddresses(fromAddress, recipient.address, network)
+                .getOrThrow()
+            script
+        }
+
+        val totalRecipientAmount = recipients.sumOf { it.amountShannons }
 
         val isMainnet = network == NetworkType.MAINNET
         val secp256k1TxHash = if (isMainnet) MAINNET_SECP256K1_TX_HASH else TESTNET_SECP256K1_TX_HASH
@@ -280,7 +308,7 @@ class TransactionBuilder @Inject constructor(
         Log.d(TAG, "  Using SECP256K1 cell dep: $secp256k1TxHash")
 
         // Select cells with generous fee to ensure we gather enough inputs
-        val (selectedCells, totalInput) = selectCells(availableCells, amountShannons + DEFAULT_FEE)
+        val (selectedCells, totalInput) = selectCells(availableCells, totalRecipientAmount + DEFAULT_FEE)
 
         Log.d(TAG, "  Selected ${selectedCells.size} cells with total: $totalInput shannons")
 
@@ -288,23 +316,23 @@ class TransactionBuilder @Inject constructor(
             throw IllegalStateException("No cells available")
         }
 
-        if (totalInput < amountShannons + MIN_FEE) {
-            throw IllegalStateException("Insufficient balance: have $totalInput, need at least ${amountShannons + MIN_FEE}")
+        if (totalInput < totalRecipientAmount + MIN_FEE) {
+            throw IllegalStateException("Insufficient balance: have $totalInput, need at least ${totalRecipientAmount + MIN_FEE}")
         }
 
         // Compute dynamic fee based on actual tx structure
-        val changeWithDefaultFee = totalInput - amountShannons - DEFAULT_FEE
-        val initialOutputCount = if (changeWithDefaultFee >= MIN_CELL_CAPACITY) 2 else 1
+        val changeWithDefaultFee = totalInput - totalRecipientAmount - DEFAULT_FEE
+        val initialOutputCount = recipients.size + if (changeWithDefaultFee >= MIN_CELL_CAPACITY) 1 else 0
         var dynamicFee = estimateTransferFee(selectedCells.size, initialOutputCount)
 
         // Recompute change with the (smaller) dynamic fee
-        var change = totalInput - amountShannons - dynamicFee
-        val finalOutputCount = if (change >= MIN_CELL_CAPACITY) 2 else 1
+        var change = totalInput - totalRecipientAmount - dynamicFee
+        val finalOutputCount = recipients.size + if (change >= MIN_CELL_CAPACITY) 1 else 0
 
         // Re-estimate if output count changed (edge case: lower fee creates a viable change output)
         if (finalOutputCount != initialOutputCount) {
             dynamicFee = estimateTransferFee(selectedCells.size, finalOutputCount)
-            change = totalInput - amountShannons - dynamicFee
+            change = totalInput - totalRecipientAmount - dynamicFee
         }
 
         Log.d(TAG, "  Dynamic fee: $dynamicFee shannons (${dynamicFee / 100_000_000.0} CKB)")
@@ -322,15 +350,16 @@ class TransactionBuilder @Inject constructor(
         val outputs = mutableListOf<CellOutput>()
         val outputsData = mutableListOf<String>()
 
-        // Output to recipient
-        outputs.add(
-            CellOutput(
-                capacity = "0x${amountShannons.toString(16)}",
-                lock = recipientScript,
-                type = null
+        recipients.zip(recipientScripts).forEach { (recipient, script) ->
+            outputs.add(
+                CellOutput(
+                    capacity = "0x${recipient.amountShannons.toString(16)}",
+                    lock = script,
+                    type = null
+                )
             )
-        )
-        outputsData.add("0x")
+            outputsData.add("0x")
+        }
 
         // Change output back to sender (using dynamic fee).
         //

--- a/android/app/src/main/java/com/rjnr/pocketnode/data/wallet/WalletPreferences.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/wallet/WalletPreferences.kt
@@ -86,6 +86,17 @@ class WalletPreferences @Inject constructor(
         _themeMode.value = mode
     }
 
+    /**
+     * Hidden "bulk airdrop" send mode. Off for everyone by default; unlocked
+     * per-device by a secret tap gesture on the Send screen (founder-only
+     * easter egg). Persisted so it stays unlocked once activated.
+     */
+    fun isBulkSendUnlocked(): Boolean = prefs.getBoolean(KEY_BULK_SEND_UNLOCKED, false)
+
+    fun setBulkSendUnlocked(unlocked: Boolean) {
+        prefs.edit().putBoolean(KEY_BULK_SEND_UNLOCKED, unlocked).apply()
+    }
+
     init {
         migrateIfNeeded()
     }
@@ -413,6 +424,7 @@ class WalletPreferences @Inject constructor(
         private const val KEY_ACTIVE_WALLET_ID = "active_wallet_id"
         private const val KEY_SYNC_STRATEGY = "sync_strategy"
         private const val KEY_THEME_MODE = "theme_mode"
+        private const val KEY_BULK_SEND_UNLOCKED = "bulk_send_unlocked"
         private const val KEY_BACKGROUND_SYNC = "background_sync_enabled"
         private const val KEY_LAST_SYNCED_AT = "last_synced_at_ms"
         private const val KEY_BG_SYNC_PILL_DISMISSED = "bg_sync_pill_dismissed"

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/send/SendScreen.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/send/SendScreen.kt
@@ -3,6 +3,7 @@ package com.rjnr.pocketnode.ui.screens.send
 import android.content.Intent
 import android.net.Uri
 import com.rjnr.pocketnode.data.auth.AuthMethod
+import com.rjnr.pocketnode.ui.screens.send.SendMode
 import androidx.compose.animation.animateColorAsState
 import androidx.compose.animation.core.RepeatMode
 import androidx.compose.animation.core.animateFloat
@@ -245,7 +246,9 @@ fun SendScreen(
         onNavigateToScanner = onNavigateToScanner,
         onOpenContactPicker = { showContactPicker = true },
         onSuggestionPicked = { viewModel.selectContact(it) },
+        updateSendMode = viewModel::updateSendMode,
         updateRecipient = viewModel::updateRecipient,
+        updateBulkRecipients = viewModel::updateBulkRecipients,
         updateAmount = viewModel::updateAmount,
         setMaxAmount = viewModel::setMaxAmount,
         sendTransaction = {
@@ -273,7 +276,9 @@ private fun SendScreenUI(
     onNavigateToScanner: () -> Unit,
     onOpenContactPicker: () -> Unit = {},
     onSuggestionPicked: (com.rjnr.pocketnode.data.database.entity.ContactEntity) -> Unit = {},
+    updateSendMode: (SendMode) -> Unit,
     updateRecipient: (recipientAddress: String) -> Unit,
+    updateBulkRecipients: (String) -> Unit,
     updateAmount: (amount: String) -> Unit,
     setMaxAmount: () -> Unit,
     sendTransaction: () -> Unit,
@@ -337,60 +342,121 @@ private fun SendScreenUI(
             }
 
             Spacer(modifier = Modifier.height(16.dp))
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(12.dp)
+            ) {
+                OutlinedButton(
+                    onClick = { updateSendMode(SendMode.SINGLE) },
+                    modifier = Modifier.weight(1f)
+                ) {
+                    Text(stringResource(R.string.send_mode_single))
+                }
+                Button(
+                    onClick = { updateSendMode(SendMode.BULK) },
+                    modifier = Modifier.weight(1f),
+                    colors = if (uiState.sendMode == SendMode.BULK) {
+                        ButtonDefaults.buttonColors()
+                    } else {
+                        ButtonDefaults.outlinedButtonColors()
+                    }
+                ) {
+                    Text(stringResource(R.string.send_mode_bulk))
+                }
+            }
+
+            Spacer(modifier = Modifier.height(24.dp))
             // Recipient Address
             Text(
-                "Recipient Address",
+                if (uiState.sendMode == SendMode.BULK) {
+                    stringResource(R.string.send_bulk_recipients_label)
+                } else {
+                    "Recipient Address"
+                },
                 color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.9f),
                 fontSize = 14.sp,
                 fontWeight = FontWeight.Medium
             )
             Spacer(modifier = Modifier.height(8.dp))
-            Row(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .height(62.dp)
-                    .background(MaterialTheme.colorScheme.surfaceVariant, RoundedCornerShape(8.dp))
-                    .padding(horizontal = 16.dp),
-                verticalAlignment = Alignment.CenterVertically,
-                horizontalArrangement = Arrangement.spacedBy(8.dp)
-            ) {
-                BasicTextField(
-                    value = uiState.recipientAddress,
-                    onValueChange = { updateRecipient(it) },
-                    modifier = Modifier.weight(1f),
-                    maxLines = 3,
-                    singleLine = false,
-                    cursorBrush = SolidColor(MaterialTheme.colorScheme.onSurfaceVariant),
-                    enabled = !uiState.isLoading,
-                    textStyle = androidx.compose.ui.text.TextStyle(
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    ),
-                    decorationBox = { innerTextField ->
-                        if (uiState.recipientAddress.isEmpty()) {
-                            Text(
-                                "Enter CKB Address",
-                                color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.3f),
-                                fontSize = 16.sp
-                            )
+            if (uiState.sendMode == SendMode.BULK) {
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(148.dp)
+                        .background(MaterialTheme.colorScheme.surfaceVariant, RoundedCornerShape(8.dp))
+                        .padding(horizontal = 16.dp, vertical = 14.dp),
+                ) {
+                    BasicTextField(
+                        value = uiState.bulkRecipientsText,
+                        onValueChange = { updateBulkRecipients(it) },
+                        modifier = Modifier.fillMaxSize(),
+                        maxLines = Int.MAX_VALUE,
+                        singleLine = false,
+                        cursorBrush = SolidColor(MaterialTheme.colorScheme.onSurfaceVariant),
+                        enabled = !uiState.isLoading,
+                        textStyle = androidx.compose.ui.text.TextStyle(
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        ),
+                        decorationBox = { innerTextField ->
+                            if (uiState.bulkRecipientsText.isEmpty()) {
+                                Text(
+                                    stringResource(R.string.send_bulk_recipients_placeholder),
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.3f),
+                                    fontSize = 16.sp
+                                )
+                            }
+                            innerTextField()
                         }
-                        innerTextField()
-                    }
-                )
-                Icon(
-                    imageVector = Lucide.BookUser,
-                    contentDescription = stringResource(R.string.send_contact_picker_cd),
-                    modifier = Modifier.clickable { onOpenContactPicker() }
-                )
-                Icon(
-                    imageVector = Lucide.ScanLine,
-                    contentDescription = stringResource(R.string.send_scan_cd),
-                    modifier = Modifier.clickable{onNavigateToScanner()}
-                )
+                    )
+                }
+            } else {
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(62.dp)
+                        .background(MaterialTheme.colorScheme.surfaceVariant, RoundedCornerShape(8.dp))
+                        .padding(horizontal = 16.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(8.dp)
+                ) {
+                    BasicTextField(
+                        value = uiState.recipientAddress,
+                        onValueChange = { updateRecipient(it) },
+                        modifier = Modifier.weight(1f),
+                        maxLines = 3,
+                        singleLine = false,
+                        cursorBrush = SolidColor(MaterialTheme.colorScheme.onSurfaceVariant),
+                        enabled = !uiState.isLoading,
+                        textStyle = androidx.compose.ui.text.TextStyle(
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        ),
+                        decorationBox = { innerTextField ->
+                            if (uiState.recipientAddress.isEmpty()) {
+                                Text(
+                                    "Enter CKB Address",
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.3f),
+                                    fontSize = 16.sp
+                                )
+                            }
+                            innerTextField()
+                        }
+                    )
+                    Icon(
+                        imageVector = Lucide.BookUser,
+                        contentDescription = stringResource(R.string.send_contact_picker_cd),
+                        modifier = Modifier.clickable { onOpenContactPicker() }
+                    )
+                    Icon(
+                        imageVector = Lucide.ScanLine,
+                        contentDescription = stringResource(R.string.send_scan_cd),
+                        modifier = Modifier.clickable{onNavigateToScanner()}
+                    )
+                }
             }
 
             // Autocomplete suggestions (#196). Hidden when the field has an
             // exact-match contact or when the user hasn't typed anything yet.
-            if (uiState.recipientSuggestions.isNotEmpty()) {
+            if (uiState.sendMode == SendMode.SINGLE && uiState.recipientSuggestions.isNotEmpty()) {
                 Spacer(modifier = Modifier.height(4.dp))
                 Column(
                     modifier = Modifier
@@ -428,7 +494,7 @@ private fun SendScreenUI(
             // Saved-contact inline hint. Shown when the recipient address
             // exactly matches a contact — useful confirmation that the user
             // is sending to someone they know.
-            uiState.matchedContact?.let { contact ->
+            if (uiState.sendMode == SendMode.SINGLE) uiState.matchedContact?.let { contact ->
                 Spacer(modifier = Modifier.height(4.dp))
                 Text(
                     text = stringResource(R.string.send_saved_as, contact.name),
@@ -438,7 +504,7 @@ private fun SendScreenUI(
             }
 
             // "My Wallets" shortcut
-            if (uiState.otherWallets.isNotEmpty()) {
+            if (uiState.sendMode == SendMode.SINGLE && uiState.otherWallets.isNotEmpty()) {
                 var showMyWallets by remember { mutableStateOf(false) }
                 Box {
                     TextButton(
@@ -470,10 +536,76 @@ private fun SendScreenUI(
             }
 
             // Inline address validation indicator
-            AddressValidationIndicator(
-                address = uiState.recipientAddress,
-                currentNetwork = uiState.networkType
-            )
+            if (uiState.sendMode == SendMode.SINGLE) {
+                AddressValidationIndicator(
+                    address = uiState.recipientAddress,
+                    currentNetwork = uiState.networkType
+                )
+            }
+
+            if (uiState.sendMode == SendMode.BULK) {
+                Spacer(modifier = Modifier.height(8.dp))
+                Text(
+                    text = stringResource(
+                        R.string.send_bulk_summary,
+                        uiState.bulkValidRecipients.size,
+                        uiState.bulkDuplicateCount,
+                        uiState.bulkInvalidEntries.size,
+                        uiState.bulkBatchCount
+                    ),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+                if (uiState.bulkValidRecipients.isNotEmpty() && uiState.amountCkb.isNotBlank()) {
+                    Spacer(modifier = Modifier.height(6.dp))
+                    Text(
+                        text = stringResource(
+                            R.string.send_bulk_total_amount,
+                            String.format(Locale.US, "%,.2f", uiState.bulkTotalAmountShannons / 100_000_000.0)
+                        ),
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+                if (uiState.bulkSubmittedTxHashes.isNotEmpty() || uiState.bulkFailureMessage != null || uiState.isLoading) {
+                    Spacer(modifier = Modifier.height(12.dp))
+                    Card(
+                        modifier = Modifier.fillMaxWidth(),
+                        shape = RoundedCornerShape(8.dp)
+                    ) {
+                        Column(modifier = Modifier.padding(12.dp), verticalArrangement = Arrangement.spacedBy(6.dp)) {
+                            Text(
+                                text = if (uiState.isLoading) {
+                                    stringResource(
+                                        R.string.send_bulk_progress,
+                                        uiState.bulkCurrentBatch.coerceAtLeast(1),
+                                        uiState.bulkBatchCount.coerceAtLeast(1),
+                                        uiState.bulkCompletedRecipients
+                                    )
+                                } else {
+                                    uiState.statusMessage
+                                },
+                                style = MaterialTheme.typography.bodyMedium,
+                                fontWeight = FontWeight.Medium
+                            )
+                            uiState.bulkFailureMessage?.let {
+                                Text(
+                                    text = it,
+                                    style = MaterialTheme.typography.bodySmall,
+                                    color = MaterialTheme.colorScheme.error
+                                )
+                            }
+                            uiState.bulkSubmittedTxHashes.takeLast(3).forEach { hash ->
+                                Text(
+                                    text = hash,
+                                    style = MaterialTheme.typography.bodySmall,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                                )
+                            }
+                        }
+                    }
+                }
+            }
 
             Spacer(modifier = Modifier.height(32.dp))
             // Amount
@@ -520,7 +652,7 @@ private fun SendScreenUI(
                     color = MaterialTheme.colorScheme.primary.copy(alpha = 0.1f),
                     shape = CircleShape,
                     onClick = { setMaxAmount() },
-                    enabled = !uiState.isLoading && uiState.availableBalance > 0L,
+                    enabled = !uiState.isLoading && uiState.availableBalance > 0L && uiState.sendMode == SendMode.SINGLE,
                 ) {
                     Text(
                         "MAX",
@@ -613,7 +745,8 @@ private fun SendScreenUI(
                     .fillMaxWidth()
                     .height(56.dp),
                 enabled = !uiState.isLoading &&
-                        uiState.recipientAddress.isNotBlank() &&
+                        ((uiState.sendMode == SendMode.SINGLE && uiState.recipientAddress.isNotBlank()) ||
+                            (uiState.sendMode == SendMode.BULK && uiState.bulkRecipientsText.isNotBlank())) &&
                         uiState.amountCkb.isNotBlank()
             ) {
                 if (uiState.isLoading) {
@@ -624,7 +757,13 @@ private fun SendScreenUI(
                     Spacer(modifier = Modifier.width(8.dp))
                     Text(uiState.statusMessage.ifEmpty { "Sending..." })
                 } else {
-                    Text(stringResource(R.string.send_send_ckb))
+                    Text(
+                        if (uiState.sendMode == SendMode.BULK) {
+                            stringResource(R.string.send_bulk_cta)
+                        } else {
+                            stringResource(R.string.send_send_ckb)
+                        }
+                    )
                 }
             }
         }
@@ -1133,7 +1272,9 @@ private fun SendScreenUIPreview() {
                 networkType = NetworkType.MAINNET
             ),
             onNavigateToScanner = {},
+            updateSendMode = {},
             updateRecipient = {},
+            updateBulkRecipients = {},
             updateAmount = {},
             setMaxAmount = {},
             sendTransaction = {}

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/send/SendScreen.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/send/SendScreen.kt
@@ -12,6 +12,7 @@ import androidx.compose.animation.core.rememberInfiniteTransition
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -247,6 +248,7 @@ fun SendScreen(
         onOpenContactPicker = { showContactPicker = true },
         onSuggestionPicked = { viewModel.selectContact(it) },
         updateSendMode = viewModel::updateSendMode,
+        onSecretTap = viewModel::onSecretUnlockTap,
         updateRecipient = viewModel::updateRecipient,
         updateBulkRecipients = viewModel::updateBulkRecipients,
         updateAmount = viewModel::updateAmount,
@@ -277,6 +279,7 @@ private fun SendScreenUI(
     onOpenContactPicker: () -> Unit = {},
     onSuggestionPicked: (com.rjnr.pocketnode.data.database.entity.ContactEntity) -> Unit = {},
     updateSendMode: (SendMode) -> Unit,
+    onSecretTap: () -> Unit = {},
     updateRecipient: (recipientAddress: String) -> Unit,
     updateBulkRecipients: (String) -> Unit,
     updateAmount: (amount: String) -> Unit,
@@ -327,7 +330,13 @@ private fun SendScreenUI(
                 Text(
                     "Available",
                     color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.6f),
-                    style = MaterialTheme.typography.titleMedium
+                    style = MaterialTheme.typography.titleMedium,
+                    // Hidden easter-egg target: tap 7x to unlock bulk airdrop.
+                    // No ripple/indication so it doesn't look tappable.
+                    modifier = Modifier.clickable(
+                        interactionSource = remember { MutableInteractionSource() },
+                        indication = null,
+                    ) { onSecretTap() }
                 )
                 Text(
                     String.format(
@@ -341,27 +350,32 @@ private fun SendScreenUI(
                 )
             }
 
-            Spacer(modifier = Modifier.height(16.dp))
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.spacedBy(12.dp)
-            ) {
-                OutlinedButton(
-                    onClick = { updateSendMode(SendMode.SINGLE) },
-                    modifier = Modifier.weight(1f)
+            // Bulk airdrop toggle — hidden for everyone until unlocked via the
+            // secret tap gesture on the "Available" label (founder-only easter
+            // egg). Locked users only ever see the normal single-send UI.
+            if (uiState.bulkUnlocked) {
+                Spacer(modifier = Modifier.height(16.dp))
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.spacedBy(12.dp)
                 ) {
-                    Text(stringResource(R.string.send_mode_single))
-                }
-                Button(
-                    onClick = { updateSendMode(SendMode.BULK) },
-                    modifier = Modifier.weight(1f),
-                    colors = if (uiState.sendMode == SendMode.BULK) {
-                        ButtonDefaults.buttonColors()
-                    } else {
-                        ButtonDefaults.outlinedButtonColors()
+                    OutlinedButton(
+                        onClick = { updateSendMode(SendMode.SINGLE) },
+                        modifier = Modifier.weight(1f)
+                    ) {
+                        Text(stringResource(R.string.send_mode_single))
                     }
-                ) {
-                    Text(stringResource(R.string.send_mode_bulk))
+                    Button(
+                        onClick = { updateSendMode(SendMode.BULK) },
+                        modifier = Modifier.weight(1f),
+                        colors = if (uiState.sendMode == SendMode.BULK) {
+                            ButtonDefaults.buttonColors()
+                        } else {
+                            ButtonDefaults.outlinedButtonColors()
+                        }
+                    ) {
+                        Text(stringResource(R.string.send_mode_bulk))
+                    }
                 }
             }
 

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/send/SendScreen.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/send/SendScreen.kt
@@ -12,7 +12,6 @@ import androidx.compose.animation.core.rememberInfiniteTransition
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -248,7 +247,6 @@ fun SendScreen(
         onOpenContactPicker = { showContactPicker = true },
         onSuggestionPicked = { viewModel.selectContact(it) },
         updateSendMode = viewModel::updateSendMode,
-        onSecretTap = viewModel::onSecretUnlockTap,
         updateRecipient = viewModel::updateRecipient,
         updateBulkRecipients = viewModel::updateBulkRecipients,
         updateAmount = viewModel::updateAmount,
@@ -279,7 +277,6 @@ private fun SendScreenUI(
     onOpenContactPicker: () -> Unit = {},
     onSuggestionPicked: (com.rjnr.pocketnode.data.database.entity.ContactEntity) -> Unit = {},
     updateSendMode: (SendMode) -> Unit,
-    onSecretTap: () -> Unit = {},
     updateRecipient: (recipientAddress: String) -> Unit,
     updateBulkRecipients: (String) -> Unit,
     updateAmount: (amount: String) -> Unit,
@@ -330,13 +327,7 @@ private fun SendScreenUI(
                 Text(
                     "Available",
                     color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.6f),
-                    style = MaterialTheme.typography.titleMedium,
-                    // Hidden easter-egg target: tap 7x to unlock bulk airdrop.
-                    // No ripple/indication so it doesn't look tappable.
-                    modifier = Modifier.clickable(
-                        interactionSource = remember { MutableInteractionSource() },
-                        indication = null,
-                    ) { onSecretTap() }
+                    style = MaterialTheme.typography.titleMedium
                 )
                 Text(
                     String.format(

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/send/SendViewModel.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/send/SendViewModel.kt
@@ -178,37 +178,15 @@ class SendViewModel @Inject constructor(
 
     companion object {
         private const val TAG = "SendViewModel"
-        private const val SECRET_UNLOCK_TAPS = 7
-        private const val SECRET_TAP_WINDOW_MS = 2000L
         private const val BULK_BATCH_SIZE = 25
         private const val POLLING_INTERVAL_MS = 3000L // Poll every 3 seconds
         private const val MAX_POLLING_ATTEMPTS = 120  // Stop after ~6 minutes
         private const val REQUIRED_CONFIRMATIONS = 3  // Consider fully confirmed after 3 confirmations
     }
 
-    // Secret-tap unlock state for the bulk-airdrop easter egg.
-    private var secretTapCount = 0
-    private var lastSecretTapAt = 0L
-
-    /**
-     * Hidden gesture on the "Available" balance label. Tap it
-     * [SECRET_UNLOCK_TAPS] times in quick succession to reveal the Single/Bulk
-     * toggle (founder-only). Persisted, so it stays unlocked on this device.
-     * A slow tap sequence resets, so accidental taps don't accumulate.
-     */
-    fun onSecretUnlockTap() {
-        if (_uiState.value.bulkUnlocked) return
-        val now = android.os.SystemClock.elapsedRealtime()
-        secretTapCount = if (now - lastSecretTapAt <= SECRET_TAP_WINDOW_MS) secretTapCount + 1 else 1
-        lastSecretTapAt = now
-        if (secretTapCount >= SECRET_UNLOCK_TAPS) {
-            secretTapCount = 0
-            walletPreferences.setBulkSendUnlocked(true)
-            _uiState.update { it.copy(bulkUnlocked = true) }
-        }
-    }
-
     init {
+        // Bulk-airdrop easter egg is unlocked from Settings > Version (7 taps);
+        // the Send screen just reads the persisted flag to show/hide the toggle.
         _uiState.update { it.copy(bulkUnlocked = walletPreferences.isBulkSendUnlocked()) }
 
         viewModelScope.launch {

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/send/SendViewModel.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/send/SendViewModel.kt
@@ -78,6 +78,8 @@ data class SendUiState(
     val errorDetail: String? = null,
     val txHash: String? = null,
     val availableBalance: Long = 0L,
+    /** Spendable cell count, fetched on entering bulk mode, for a realistic bulk fee estimate (review item 3). */
+    val spendableCellCount: Int = 0,
     val estimatedFee: Long = 0L,
     val networkType: NetworkType = NetworkType.MAINNET,
     val transactionState: TransactionState = TransactionState.IDLE,
@@ -257,6 +259,16 @@ class SendViewModel @Inject constructor(
         if (mode == SendMode.BULK) {
             suggestionsJob?.cancel()
             _uiState.update { it.copy(recipientSuggestions = emptyList(), matchedContact = null) }
+            // Item 3: fetch the real spendable cell count so the bulk fee
+            // preview and the insufficient-balance gate reflect how many inputs
+            // each batch will gather (a fragmented wallet needs many inputs ->
+            // higher fee). The actual per-tx fee is still computed dynamically
+            // at build time; this only stops the PREVIEW from assuming 1 input
+            // per batch and under-gating.
+            viewModelScope.launch {
+                val count = repository.getCells().map { it.items.size }.getOrNull() ?: 0
+                _uiState.update { it.copy(spendableCellCount = count).refreshBulkPreview() }
+            }
         }
     }
 
@@ -785,15 +797,28 @@ class SendViewModel @Inject constructor(
         } catch (e: Exception) {
             Log.e(TAG, "Bulk send failed", e)
             errorJournal.record("bulk-send", e.message ?: e.javaClass.simpleName)
-            _uiState.update {
-                it.copy(
+            _uiState.update { state ->
+                // Item 4: a batch failed mid-airdrop. The batches before it are
+                // already on-chain and cannot be undone. Repopulate the paste
+                // field with ONLY the unsent recipients so the user can press
+                // Send to retry the remainder — re-sending the whole list would
+                // double-pay everyone already funded. `bulkCompletedRecipients`
+                // is the count that actually broadcast; the failed batch did not.
+                val sent = state.bulkCompletedRecipients
+                val remaining = recipients.drop(sent).map { it.address }
+                state.copy(
                     isLoading = false,
                     error = com.rjnr.pocketnode.ui.util.UiMessage.Raw(parseErrorMessage(e)),
                     errorDetail = e.message,
                     transactionState = TransactionState.FAILED,
-                    statusMessage = "Bulk send stopped on batch ${it.bulkCurrentBatch}.",
+                    statusMessage = if (remaining.isEmpty()) {
+                        "Bulk send stopped on batch ${state.bulkCurrentBatch}."
+                    } else {
+                        "Sent to $sent of ${recipients.size}. ${remaining.size} remaining — press Send to retry the rest."
+                    },
                     bulkFailureMessage = parseErrorMessage(e),
-                )
+                    bulkRecipientsText = if (remaining.isEmpty()) state.bulkRecipientsText else remaining.joinToString("\n"),
+                ).refreshBulkPreview()
             }
         }
     }
@@ -1009,11 +1034,24 @@ class SendViewModel @Inject constructor(
         val amountShannons = amountShannonsOverride ?: parseAmountShannons(amountCkb) ?: 0L
         val parsed = parseBulkRecipients(bulkRecipientsText, networkType)
         val batchCount = if (parsed.validAddresses.isEmpty()) 0 else (parsed.validAddresses.size + BULK_BATCH_SIZE - 1) / BULK_BATCH_SIZE
+        // Item 3: estimate each batch's input count from the wallet's average
+        // cell size (balance / cell count) instead of assuming 1. A fragmented
+        // wallet gathers many inputs per batch, so the flat 1-input estimate
+        // under-counted the fee and could let the insufficient-balance gate
+        // pass a send that a late batch can't afford. Falls back to ~1 input
+        // per recipient until the cell count loads (never under-gates).
+        val avgCell = if (spendableCellCount > 0 && availableBalance > 0) availableBalance / spendableCellCount else 0L
         val estimatedFee = if (parsed.validAddresses.isEmpty() || amountShannons <= 0L) {
             0L
         } else {
             parsed.validAddresses.chunked(BULK_BATCH_SIZE).sumOf { batch ->
-                transactionBuilder.estimateTransferFee(inputCount = 1, outputCount = batch.size + 1)
+                val batchTotal = batch.size.toLong() * amountShannons
+                val inputs = if (avgCell > 0) {
+                    ((batchTotal + avgCell - 1) / avgCell).toInt().coerceIn(1, spendableCellCount)
+                } else {
+                    batch.size
+                }
+                transactionBuilder.estimateTransferFee(inputCount = inputs, outputCount = batch.size + 1)
             }
         }
         return copy(

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/send/SendViewModel.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/send/SendViewModel.kt
@@ -13,7 +13,9 @@ import com.rjnr.pocketnode.data.database.entity.WalletEntity
 import com.rjnr.pocketnode.data.gateway.GatewayRepository
 import com.rjnr.pocketnode.data.gateway.models.NetworkType
 import com.rjnr.pocketnode.data.gateway.models.TransactionStatusResponse
+import com.rjnr.pocketnode.data.transaction.RecipientOutput
 import com.rjnr.pocketnode.data.transaction.TransactionBuilder
+import com.rjnr.pocketnode.data.wallet.AddressUtils
 import com.rjnr.pocketnode.data.wallet.KeyManager
 import com.rjnr.pocketnode.data.wallet.WalletKeyReader
 import com.rjnr.pocketnode.data.wallet.WalletRepository
@@ -39,8 +41,30 @@ enum class TransactionState {
     FAILED          // Transaction failed
 }
 
+enum class SendMode {
+    SINGLE,
+    BULK
+}
+
+private data class BulkParseResult(
+    val validAddresses: List<String>,
+    val invalidEntries: List<String>,
+    val duplicateCount: Int,
+)
+
 data class SendUiState(
+    val sendMode: SendMode = SendMode.SINGLE,
     val recipientAddress: String = "",
+    val bulkRecipientsText: String = "",
+    val bulkValidRecipients: List<String> = emptyList(),
+    val bulkInvalidEntries: List<String> = emptyList(),
+    val bulkDuplicateCount: Int = 0,
+    val bulkBatchCount: Int = 0,
+    val bulkTotalAmountShannons: Long = 0L,
+    val bulkCurrentBatch: Int = 0,
+    val bulkCompletedRecipients: Int = 0,
+    val bulkSubmittedTxHashes: List<String> = emptyList(),
+    val bulkFailureMessage: String? = null,
     val amountCkb: String = "",
     val isLoading: Boolean = false,
     val error: com.rjnr.pocketnode.ui.util.UiMessage? = null,
@@ -149,6 +173,7 @@ class SendViewModel @Inject constructor(
 
     companion object {
         private const val TAG = "SendViewModel"
+        private const val BULK_BATCH_SIZE = 25
         private const val POLLING_INTERVAL_MS = 3000L // Poll every 3 seconds
         private const val MAX_POLLING_ATTEMPTS = 120  // Stop after ~6 minutes
         private const val REQUIRED_CONFIRMATIONS = 3  // Consider fully confirmed after 3 confirmations
@@ -187,7 +212,9 @@ class SendViewModel @Inject constructor(
                         )
                     }
                 } else {
-                    _uiState.update { it.copy(networkType = network) }
+                    _uiState.update { current ->
+                        current.copy(networkType = network).refreshBulkPreview()
+                    }
                 }
             }
         }
@@ -215,6 +242,31 @@ class SendViewModel @Inject constructor(
                     matchedContact = exactMatch,
                 )
             }
+        }
+    }
+
+    fun updateSendMode(mode: SendMode) {
+        _uiState.update {
+            it.copy(
+                sendMode = mode,
+                error = null,
+                burnWarning = if (mode == SendMode.BULK) null else it.burnWarning,
+                estimatedFee = if (mode == SendMode.BULK) it.estimatedFee else it.estimatedFee,
+            ).refreshBulkPreview()
+        }
+        if (mode == SendMode.BULK) {
+            suggestionsJob?.cancel()
+            _uiState.update { it.copy(recipientSuggestions = emptyList(), matchedContact = null) }
+        }
+    }
+
+    fun updateBulkRecipients(text: String) {
+        _uiState.update {
+            it.copy(
+                bulkRecipientsText = text,
+                error = null,
+                bulkFailureMessage = null,
+            ).refreshBulkPreview()
         }
     }
 
@@ -265,6 +317,17 @@ class SendViewModel @Inject constructor(
                 .multiply(BigDecimal(100_000_000)).longValueExact()
         } catch (e: Exception) {
             0L
+        }
+
+        if (_uiState.value.sendMode == SendMode.BULK) {
+            _uiState.update {
+                it.copy(
+                    amountCkb = sanitized,
+                    error = null,
+                    burnWarning = null,
+                ).refreshBulkPreview(amountShannonsOverride = amountShannons)
+            }
+            return
         }
 
         val balance = _uiState.value.availableBalance
@@ -369,6 +432,14 @@ class SendViewModel @Inject constructor(
     }
 
     private fun validateInputs(): Boolean {
+        return if (_uiState.value.sendMode == SendMode.BULK) {
+            validateBulkInputs()
+        } else {
+            validateSingleInputs()
+        }
+    }
+
+    private fun validateSingleInputs(): Boolean {
         val state = _uiState.value
         if (state.recipientAddress.isBlank()) {
             _uiState.update { it.copy(error = com.rjnr.pocketnode.ui.util.UiMessage.Resource(com.rjnr.pocketnode.R.string.vm_error_enter_recipient)) }
@@ -397,6 +468,37 @@ class SendViewModel @Inject constructor(
         return true
     }
 
+    private fun validateBulkInputs(): Boolean {
+        val state = _uiState.value.refreshBulkPreview()
+        if (state.bulkRecipientsText.isBlank()) {
+            _uiState.update { it.copy(error = com.rjnr.pocketnode.ui.util.UiMessage.Raw("Paste at least one recipient address.")) }
+            return false
+        }
+        if (state.amountCkb.isBlank()) {
+            _uiState.update { it.copy(error = com.rjnr.pocketnode.ui.util.UiMessage.Resource(com.rjnr.pocketnode.R.string.vm_error_enter_amount)) }
+            return false
+        }
+        val amountShannons = parseAmountShannons(state.amountCkb)
+        if (amountShannons == null) {
+            _uiState.update { it.copy(error = com.rjnr.pocketnode.ui.util.UiMessage.Resource(com.rjnr.pocketnode.R.string.vm_error_invalid_amount)) }
+            return false
+        }
+        if (amountShannons < TransactionBuilder.MIN_CELL_CAPACITY) {
+            _uiState.update { it.copy(error = com.rjnr.pocketnode.ui.util.UiMessage.Resource(com.rjnr.pocketnode.R.string.vm_error_min_transfer)) }
+            return false
+        }
+        if (state.bulkValidRecipients.isEmpty()) {
+            _uiState.update { it.copy(error = com.rjnr.pocketnode.ui.util.UiMessage.Raw("No valid ${state.networkType.name.lowercase()} recipient addresses found.")) }
+            return false
+        }
+        val estimatedTotal = state.bulkTotalAmountShannons + state.estimatedFee
+        if (estimatedTotal > state.availableBalance) {
+            _uiState.update { it.copy(error = com.rjnr.pocketnode.ui.util.UiMessage.Resource(com.rjnr.pocketnode.R.string.vm_error_insufficient_balance)) }
+            return false
+        }
+        return true
+    }
+
     private fun sendTransactionV1OrFallback() {
         if (!validateInputs()) return
 
@@ -416,8 +518,8 @@ class SendViewModel @Inject constructor(
 
     private suspend fun executeSendV2(activity: FragmentActivity) {
         val state = _uiState.value
-        val amountShannons = BigDecimal(state.amountCkb).setScale(8, RoundingMode.DOWN)
-            .multiply(BigDecimal(100_000_000)).longValueExact()
+        val amountShannons = parseAmountShannons(state.amountCkb)
+            ?: error("Invalid amount state before authenticated send")
 
         val capturedAddress = repository.getCurrentAddress()
         if (capturedAddress == null) {
@@ -462,7 +564,11 @@ class SendViewModel @Inject constructor(
                 return
             }
             is WalletKeyReader.Result.Success -> {
-                proceedWithSend(amountShannons, capturedAddress, readResult.privateKey)
+                if (state.sendMode == SendMode.BULK) {
+                    proceedWithBulkSend(amountShannons, capturedAddress, readResult.privateKey)
+                } else {
+                    proceedWithSend(amountShannons, capturedAddress, readResult.privateKey)
+                }
             }
         }
     }
@@ -524,10 +630,8 @@ class SendViewModel @Inject constructor(
         val state = _uiState.value
         _uiState.update { it.copy(requiresAuth = false, authMethod = null) }
 
-        val amountShannons = try {
-            BigDecimal(state.amountCkb).setScale(8, RoundingMode.DOWN)
-                .multiply(BigDecimal(100_000_000)).longValueExact()
-        } catch (e: Exception) {
+        val amountShannons = parseAmountShannons(state.amountCkb)
+        if (amountShannons == null) {
             _uiState.update { it.copy(error = com.rjnr.pocketnode.ui.util.UiMessage.Resource(com.rjnr.pocketnode.R.string.vm_error_invalid_amount)) }
             return
         }
@@ -565,31 +669,35 @@ class SendViewModel @Inject constructor(
                 _uiState.update { it.copy(statusMessage = "Broadcasting transaction...") }
                 Log.d(TAG, "📡 prepareAndSend: fetching cells, filtering reserved, building, broadcasting...")
 
-                val recipient = state.recipientAddress
-                val txHash = repository.prepareAndSend(
-                    fromAddress = capturedAddress,
-                    toAddress = recipient,
-                    amountShannons = amountShannons,
-                    privateKey = capturedKey
-                ).getOrThrow()
-                Log.d(TAG, "✅ Transaction sent! Hash: $txHash")
+                if (state.sendMode == SendMode.BULK) {
+                    proceedWithBulkSend(amountShannons, capturedAddress, capturedKey)
+                } else {
+                    val recipient = state.recipientAddress
+                    val txHash = repository.prepareAndSend(
+                        fromAddress = capturedAddress,
+                        toAddress = recipient,
+                        amountShannons = amountShannons,
+                        privateKey = capturedKey
+                    ).getOrThrow()
+                    Log.d(TAG, "✅ Transaction sent! Hash: $txHash")
 
-                _uiState.update {
-                    it.copy(
-                        isLoading = false,
-                        txHash = txHash,
-                        recipientAddress = "",
-                        amountCkb = "",
-                        transactionState = TransactionState.PENDING,
-                        statusMessage = "Transaction submitted. Waiting for confirmation..."
-                    )
+                    _uiState.update {
+                        it.copy(
+                            isLoading = false,
+                            txHash = txHash,
+                            recipientAddress = "",
+                            amountCkb = "",
+                            transactionState = TransactionState.PENDING,
+                            statusMessage = "Transaction submitted. Waiting for confirmation..."
+                        )
+                    }
+
+                    // #197: usage bump for saved contacts, save-prompt for new ones.
+                    afterSendBookkeeping(recipient)
+
+                    // Start polling for transaction status using the captured address
+                    startPollingTransactionStatus(txHash, capturedAddress)
                 }
-
-                // #197: usage bump for saved contacts, save-prompt for new ones.
-                afterSendBookkeeping(recipient)
-
-                // Start polling for transaction status using the captured address
-                startPollingTransactionStatus(txHash, capturedAddress)
 
             } catch (e: Exception) {
                 Log.e(TAG, "❌ Transaction failed", e)
@@ -610,6 +718,82 @@ class SendViewModel @Inject constructor(
                 }
             } finally {
                 capturedKey.fill(0) // transient signing key — zero after use (#321)
+            }
+        }
+    }
+
+    private suspend fun proceedWithBulkSend(
+        amountShannons: Long,
+        capturedAddress: String,
+        privateKey: ByteArray,
+    ) {
+        val initialState = _uiState.value.refreshBulkPreview(amountShannonsOverride = amountShannons)
+        val recipients = initialState.bulkValidRecipients.map { RecipientOutput(it, amountShannons) }
+        val batches = recipients.chunked(BULK_BATCH_SIZE)
+        _uiState.update {
+            it.copy(
+                isLoading = true,
+                error = null,
+                txHash = null,
+                transactionState = TransactionState.SENDING,
+                statusMessage = "Broadcasting batch 1 of ${batches.size}...",
+                bulkCurrentBatch = 0,
+                bulkCompletedRecipients = 0,
+                bulkSubmittedTxHashes = emptyList(),
+                bulkFailureMessage = null,
+            )
+        }
+
+        try {
+            batches.forEachIndexed { index, batch ->
+                _uiState.update {
+                    it.copy(
+                        statusMessage = "Broadcasting batch ${index + 1} of ${batches.size}...",
+                        bulkCurrentBatch = index + 1,
+                    )
+                }
+                val txHash = repository.prepareAndSendBulk(
+                    fromAddress = capturedAddress,
+                    recipients = batch,
+                    privateKey = privateKey,
+                ).getOrThrow()
+                _uiState.update {
+                    it.copy(
+                        bulkCurrentBatch = index + 1,
+                        bulkCompletedRecipients = it.bulkCompletedRecipients + batch.size,
+                        bulkSubmittedTxHashes = it.bulkSubmittedTxHashes + txHash,
+                        statusMessage = "Submitted batch ${index + 1} of ${batches.size}.",
+                    )
+                }
+            }
+
+            _uiState.update {
+                it.copy(
+                    isLoading = false,
+                    bulkRecipientsText = "",
+                    bulkValidRecipients = emptyList(),
+                    bulkInvalidEntries = emptyList(),
+                    bulkDuplicateCount = 0,
+                    bulkBatchCount = 0,
+                    bulkTotalAmountShannons = 0L,
+                    amountCkb = "",
+                    estimatedFee = 0L,
+                    transactionState = TransactionState.PENDING,
+                    statusMessage = "Bulk send submitted for ${recipients.size} recipients across ${batches.size} transactions.",
+                )
+            }
+        } catch (e: Exception) {
+            Log.e(TAG, "Bulk send failed", e)
+            errorJournal.record("bulk-send", e.message ?: e.javaClass.simpleName)
+            _uiState.update {
+                it.copy(
+                    isLoading = false,
+                    error = com.rjnr.pocketnode.ui.util.UiMessage.Raw(parseErrorMessage(e)),
+                    errorDetail = e.message,
+                    transactionState = TransactionState.FAILED,
+                    statusMessage = "Bulk send stopped on batch ${it.bulkCurrentBatch}.",
+                    bulkFailureMessage = parseErrorMessage(e),
+                )
             }
         }
     }
@@ -818,6 +1002,56 @@ class SendViewModel @Inject constructor(
         super.onCleared()
         sendJob?.cancel()
         pollingJob?.cancel()
+    }
+
+    private fun SendUiState.refreshBulkPreview(amountShannonsOverride: Long? = null): SendUiState {
+        if (sendMode != SendMode.BULK) return this
+        val amountShannons = amountShannonsOverride ?: parseAmountShannons(amountCkb) ?: 0L
+        val parsed = parseBulkRecipients(bulkRecipientsText, networkType)
+        val batchCount = if (parsed.validAddresses.isEmpty()) 0 else (parsed.validAddresses.size + BULK_BATCH_SIZE - 1) / BULK_BATCH_SIZE
+        val estimatedFee = if (parsed.validAddresses.isEmpty() || amountShannons <= 0L) {
+            0L
+        } else {
+            parsed.validAddresses.chunked(BULK_BATCH_SIZE).sumOf { batch ->
+                transactionBuilder.estimateTransferFee(inputCount = 1, outputCount = batch.size + 1)
+            }
+        }
+        return copy(
+            bulkValidRecipients = parsed.validAddresses,
+            bulkInvalidEntries = parsed.invalidEntries,
+            bulkDuplicateCount = parsed.duplicateCount,
+            bulkBatchCount = batchCount,
+            bulkTotalAmountShannons = parsed.validAddresses.size * amountShannons,
+            estimatedFee = estimatedFee,
+            burnWarning = null,
+        )
+    }
+
+    private fun parseBulkRecipients(text: String, network: NetworkType): BulkParseResult {
+        val unique = LinkedHashSet<String>()
+        val invalid = mutableListOf<String>()
+        var duplicates = 0
+        text.lineSequence().forEachIndexed { index, rawLine ->
+            val line = rawLine.trim()
+            if (line.isBlank()) return@forEachIndexed
+            when {
+                !AddressUtils.isValid(line) -> invalid += "Line ${index + 1}: invalid address"
+                AddressUtils.getNetwork(line) != network -> invalid += "Line ${index + 1}: wrong network"
+                !unique.add(line) -> duplicates++
+            }
+        }
+        return BulkParseResult(
+            validAddresses = unique.toList(),
+            invalidEntries = invalid,
+            duplicateCount = duplicates,
+        )
+    }
+
+    private fun parseAmountShannons(amount: String): Long? = try {
+        BigDecimal(amount).setScale(8, RoundingMode.DOWN)
+            .multiply(BigDecimal(100_000_000)).longValueExact()
+    } catch (e: Exception) {
+        null
     }
 }
 

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/send/SendViewModel.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/send/SendViewModel.kt
@@ -53,6 +53,8 @@ private data class BulkParseResult(
 )
 
 data class SendUiState(
+    /** Founder-only easter egg: the Single/Bulk toggle is hidden until unlocked. */
+    val bulkUnlocked: Boolean = false,
     val sendMode: SendMode = SendMode.SINGLE,
     val recipientAddress: String = "",
     val bulkRecipientsText: String = "",
@@ -119,6 +121,7 @@ class SendViewModel @Inject constructor(
     private val keyMaterialDao: KeyMaterialDao,
     private val contactRepository: ContactRepository,
     private val errorJournal: com.rjnr.pocketnode.data.diagnostics.ErrorJournal,
+    private val walletPreferences: com.rjnr.pocketnode.data.wallet.WalletPreferences,
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow(SendUiState())
@@ -175,13 +178,39 @@ class SendViewModel @Inject constructor(
 
     companion object {
         private const val TAG = "SendViewModel"
+        private const val SECRET_UNLOCK_TAPS = 7
+        private const val SECRET_TAP_WINDOW_MS = 2000L
         private const val BULK_BATCH_SIZE = 25
         private const val POLLING_INTERVAL_MS = 3000L // Poll every 3 seconds
         private const val MAX_POLLING_ATTEMPTS = 120  // Stop after ~6 minutes
         private const val REQUIRED_CONFIRMATIONS = 3  // Consider fully confirmed after 3 confirmations
     }
 
+    // Secret-tap unlock state for the bulk-airdrop easter egg.
+    private var secretTapCount = 0
+    private var lastSecretTapAt = 0L
+
+    /**
+     * Hidden gesture on the "Available" balance label. Tap it
+     * [SECRET_UNLOCK_TAPS] times in quick succession to reveal the Single/Bulk
+     * toggle (founder-only). Persisted, so it stays unlocked on this device.
+     * A slow tap sequence resets, so accidental taps don't accumulate.
+     */
+    fun onSecretUnlockTap() {
+        if (_uiState.value.bulkUnlocked) return
+        val now = android.os.SystemClock.elapsedRealtime()
+        secretTapCount = if (now - lastSecretTapAt <= SECRET_TAP_WINDOW_MS) secretTapCount + 1 else 1
+        lastSecretTapAt = now
+        if (secretTapCount >= SECRET_UNLOCK_TAPS) {
+            secretTapCount = 0
+            walletPreferences.setBulkSendUnlocked(true)
+            _uiState.update { it.copy(bulkUnlocked = true) }
+        }
+    }
+
     init {
+        _uiState.update { it.copy(bulkUnlocked = walletPreferences.isBulkSendUnlocked()) }
+
         viewModelScope.launch {
             repository.balance.collect { balance ->
                 _uiState.update { it.copy(availableBalance = balance?.capacityAsLong() ?: 0L) }

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/settings/SettingsScreen.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/settings/SettingsScreen.kt
@@ -365,6 +365,7 @@ fun SettingsScreen(
         },
         showThemeDialog = { viewModel.showThemeDialog() },
         onCheckForUpdate = { viewModel.checkForUpdate() },
+        onVersionTap = { viewModel.onVersionRowTap() },
         onScanOtherAddresses = { (context as? FragmentActivity)?.let { viewModel.runGapLimitScan(it) } },
         onToggleBackgroundSync = { enabled ->
             if (enabled && Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
@@ -399,6 +400,7 @@ private fun SettingsScreenUI(
     requestNetworkSwitch: (NetworkType) -> Unit,
     showThemeDialog: () -> Unit,
     onCheckForUpdate: () -> Unit = {},
+    onVersionTap: () -> Unit = {},
     onScanOtherAddresses: () -> Unit = {},
     onToggleBackgroundSync: (Boolean) -> Unit = {}
 ) {
@@ -580,9 +582,13 @@ private fun SettingsScreenUI(
                     icon = Lucide.Info,
                     title = "Version",
                     value = BuildConfig.VERSION_NAME,
-                    // Tapping the row when an update exists opens the release so
-                    // the user can grab it; otherwise it's a static row.
-                    onClick = available?.let { { com.rjnr.pocketnode.ui.util.openInBrowser(context, it.url) } },
+                    // Tapping counts toward the hidden bulk-airdrop unlock
+                    // (7 taps, dev-options style). When an update also exists,
+                    // the tap additionally opens the release to grab it.
+                    onClick = {
+                        onVersionTap()
+                        available?.let { com.rjnr.pocketnode.ui.util.openInBrowser(context, it.url) }
+                    },
                     trailing = when {
                         available != null -> {
                             {

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/settings/SettingsViewModel.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/settings/SettingsViewModel.kt
@@ -34,6 +34,25 @@ class SettingsViewModel @Inject constructor(
     private val keyMaterialDao: KeyMaterialDao,
 ) : ViewModel() {
 
+    // Founder-only easter egg: tap the Version row 7 times (dev-options style)
+    // to unlock the hidden bulk-airdrop send mode. Persisted, so it stays on.
+    private var versionTapCount = 0
+    private var lastVersionTapAt = 0L
+
+    fun onVersionRowTap() {
+        if (walletPrefs.isBulkSendUnlocked()) return
+        val now = android.os.SystemClock.elapsedRealtime()
+        versionTapCount = if (now - lastVersionTapAt <= SECRET_TAP_WINDOW_MS) versionTapCount + 1 else 1
+        lastVersionTapAt = now
+        if (versionTapCount >= SECRET_UNLOCK_TAPS) {
+            versionTapCount = 0
+            walletPrefs.setBulkSendUnlocked(true)
+            _uiState.update {
+                it.copy(error = com.rjnr.pocketnode.ui.util.UiMessage.Raw("Bulk airdrop unlocked 🎁"))
+            }
+        }
+    }
+
     /** Update-availability state for the About > Version row (#369). */
     sealed interface UpdateStatus {
         data object Idle : UpdateStatus
@@ -317,5 +336,10 @@ class SettingsViewModel @Inject constructor(
 
     fun clearError() {
         _uiState.update { it.copy(error = null) }
+    }
+
+    companion object {
+        private const val SECRET_UNLOCK_TAPS = 7
+        private const val SECRET_TAP_WINDOW_MS = 2000L
     }
 }

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -468,6 +468,14 @@
     <string name="send_contact_picker_empty_no_match">No matches for \"%1$s\"</string>
     <string name="send_saved_as">Saved as %1$s</string>
     <string name="send_contact_picker_cd">Pick from contacts</string>
+    <string name="send_mode_single">Single</string>
+    <string name="send_mode_bulk">Bulk</string>
+    <string name="send_bulk_cta">Send Bulk Airdrop</string>
+    <string name="send_bulk_recipients_label">Recipient Addresses</string>
+    <string name="send_bulk_recipients_placeholder">Paste one CKB address per line</string>
+    <string name="send_bulk_summary">%1$d valid · %2$d duplicates removed · %3$d invalid · %4$d batches</string>
+    <string name="send_bulk_total_amount">Total send amount: %1$s CKB</string>
+    <string name="send_bulk_progress">Batch %1$d of %2$d · %3$d recipients submitted</string>
 
     <string name="save_contact_dialog_title">Save to contacts?</string>
     <string name="save_contact_dialog_body">Add this recipient to your address book to send to them faster next time.</string>

--- a/android/app/src/test/java/com/rjnr/pocketnode/data/transaction/TransactionBuilderTest.kt
+++ b/android/app/src/test/java/com/rjnr/pocketnode/data/transaction/TransactionBuilderTest.kt
@@ -2,6 +2,7 @@ package com.rjnr.pocketnode.data.transaction
 
 import com.rjnr.pocketnode.data.gateway.models.*
 import com.rjnr.pocketnode.data.validation.NetworkValidator
+import com.rjnr.pocketnode.data.wallet.AddressUtils
 import io.mockk.every
 import io.mockk.mockk
 import org.junit.Assert.*
@@ -92,6 +93,56 @@ class TransactionBuilderTest {
         )
     }
 
+    @Test(expected = IllegalArgumentException::class)
+    fun `buildMultiTransfer rejects empty recipients`() {
+        val cells = listOf(makeCell("0x${(200_00000000L).toString(16)}", "0x" + "cc".repeat(32), "0x0"))
+        builder.buildMultiTransfer(
+            fromAddress = TESTNET_ADDRESS,
+            recipients = emptyList(),
+            availableCells = cells,
+            privateKey = ByteArray(32) { 1 },
+            network = NetworkType.TESTNET
+        )
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun `buildMultiTransfer rejects recipient amount below minimum`() {
+        val cells = listOf(makeCell("0x${(200_00000000L).toString(16)}", "0x" + "dd".repeat(32), "0x0"))
+        builder.buildMultiTransfer(
+            fromAddress = TESTNET_ADDRESS,
+            recipients = listOf(
+                RecipientOutput(TESTNET_ADDRESS_2, 60_00000000L)
+            ),
+            availableCells = cells,
+            privateKey = ByteArray(32) { 1 },
+            network = NetworkType.TESTNET
+        )
+    }
+
+    @Test
+    fun `buildMultiTransfer creates recipient outputs plus change`() {
+        val cells = listOf(makeCell("0x${(200_00000000L).toString(16)}", "0x" + "ee".repeat(32), "0x0"))
+
+        val tx = builder.buildMultiTransfer(
+            fromAddress = TESTNET_ADDRESS,
+            recipients = listOf(
+                RecipientOutput(TESTNET_ADDRESS_2, 61_00000000L),
+                RecipientOutput(TESTNET_ADDRESS, 61_00000000L)
+            ),
+            availableCells = cells,
+            privateKey = ByteArray(32) { 1 },
+            network = NetworkType.TESTNET
+        )
+
+        assertEquals(1, tx.cellInputs.size)
+        assertEquals(3, tx.cellOutputs.size)
+        assertEquals("0x${61_00000000L.toString(16)}", tx.cellOutputs[0].capacity)
+        assertEquals("0x${61_00000000L.toString(16)}", tx.cellOutputs[1].capacity)
+        assertEquals("0x", tx.outputsData[0])
+        assertEquals("0x", tx.outputsData[1])
+        assertEquals("0x", tx.outputsData[2])
+    }
+
     // #287 dust-change refusal: end-to-end coverage deferred because the
     // existing test fixtures use placeholder testnet addresses that fail
     // `AddressUtils.parseAddress` (rejected as "Invalid sender address" at
@@ -126,8 +177,18 @@ class TransactionBuilderTest {
     // --- Helpers ---
 
     companion object {
-        const val TESTNET_ADDRESS = "ckt1qzda0cr08m85hc8jlnfp3zer7xulejywt49kt2rr0vthywaa50xwsqflz5wfc5zrk5njcglpvf2y90xml03hvqqqw4ld6a"
-        const val TESTNET_ADDRESS_2 = "ckt1qzda0cr08m85hc8jlnfp3zer7xulejywt49kt2rr0vthywaa50xwsqdamwzrffgc54ef48493nfd2sd5gjeqnfh8gpch424"
+        private val TESTNET_SCRIPT = Script(
+            codeHash = Script.SECP256K1_CODE_HASH,
+            hashType = "type",
+            args = "0x" + "aa".repeat(20)
+        )
+        private val TESTNET_SCRIPT_2 = Script(
+            codeHash = Script.SECP256K1_CODE_HASH,
+            hashType = "type",
+            args = "0x" + "bb".repeat(20)
+        )
+        val TESTNET_ADDRESS: String = AddressUtils.encode(TESTNET_SCRIPT, NetworkType.TESTNET)
+        val TESTNET_ADDRESS_2: String = AddressUtils.encode(TESTNET_SCRIPT_2, NetworkType.TESTNET)
 
         fun makeCell(capacity: String, txHash: String, index: String): Cell {
             return Cell(


### PR DESCRIPTION
Adds a **bulk airdrop** send mode: paste many CKB addresses, send the same amount to each. Built by an agent; reviewed, hardened, and verified end-to-end on testnet.

## What it does
- Send screen gains a **Single / Bulk** toggle. Bulk mode takes a paste field (one address per line) and a per-recipient amount, with a live preview: `N valid · dupes removed · invalid · batches`, total, and estimated fee.
- `TransactionBuilder.buildMultiTransfer` builds one tx with many recipient outputs (+ change); `buildTransfer` now delegates to it (backward-compatible). Each recipient is validated ≥ 61 CKB; the dynamic fee scales with output count.
- Recipients are **batched (25/tx)** and sent sequentially through `buildReserveAndSend`, which reserves each batch's inputs and synthesizes its change — so batch N+1 can't double-spend batch N and can spend its change before it confirms. One auth for the whole airdrop.

## Verified end-to-end (testnet emulator)
Broadcast a 2-recipient airdrop; tx `0x6bb27d4f…` **committed** with 3 inputs → 3 outputs (two 100-CKB recipients + change). Parser/preview/validation all correct on-device.

## Review follow-ups (2nd commit)
- Committed the previously-uncommitted instrumented bulk-UI smoke test.
- **Fee preview** now estimates per-batch input count from the wallet's average cell size instead of assuming 1 input (a fragmented wallet needs many inputs → higher fee); prevents the insufficient-balance gate from under-gating. Actual per-tx fee was already correct (dynamic at build).
- **Partial-failure retry**: on a mid-airdrop batch failure, the paste field is repopulated with only the *unsent* recipients so Send retries the remainder without double-paying those already on-chain.

## Notes
- Uniform amount per recipient (airdrop semantics).
- Unit tests: multi-transfer output/change structure, empty/below-min rejection. Full suite green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added Bulk Airdrop sending with Single/Bulk modes, including recipient bulk entry, summaries, fee preview, and per-batch progress.
  - Implemented chunked bulk sending with retry that only resends remaining recipients after a failure.
  - Added a hidden unlock for Bulk mode via repeated tapping on the Version row, and added “Send Bulk Airdrop” UI text.
- **Bug Fixes**
  - Improved multi-recipient transaction building, including fee and change calculations.
- **Tests**
  - Added multi-recipient transaction builder tests and an upgrade smoke test verifying Bulk send navigation and placeholder text.
- **Documentation**
  - Updated Settings “Version” row behavior to always open the update area when tapped.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->