### PR TITLE
chore(website): add Telegram channel link to footer

### DIFF
--- a/website/components/Footer.tsx
+++ b/website/components/Footer.tsx
@@ -48,6 +48,9 @@ export function Footer() {
           </FooterColumn>
 
           <FooterColumn title="Project">
+            <FooterLink href="https://t.me/pocket_node" external>
+              Telegram
+            </FooterLink>
             <FooterLink href="https://github.com/RaheemJnr/pocket-node" external>
               GitHub
             </FooterLink>


### PR DESCRIPTION
Adds the community Telegram channel (https://t.me/pocket_node) to the website footer's Project column, alongside GitHub / Releases / Nervos Forum. Deploys to production on merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Telegram link to the website footer’s Project links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->