### PR TITLE
chore(website): add X (Twitter) link to footer

### DIFF
--- a/website/components/Footer.tsx
+++ b/website/components/Footer.tsx
@@ -51,6 +51,9 @@ export function Footer() {
             <FooterLink href="https://t.me/pocket_node" external>
               Telegram
             </FooterLink>
+            <FooterLink href="https://x.com/PocketNodeCKB" external>
+              X (Twitter)
+            </FooterLink>
             <FooterLink href="https://github.com/RaheemJnr/pocket-node" external>
               GitHub
             </FooterLink>


### PR DESCRIPTION
Adds the project's X account (@PocketNodeCKB, https://x.com/PocketNodeCKB) to the footer, next to Telegram and GitHub. Deploys to production on merge.