### PR TITLE
feat(activity): badge bulk-airdrop transactions as "Bulk"

### DIFF
--- a/android/app/src/main/java/com/rjnr/pocketnode/data/gateway/GatewayRepository.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/gateway/GatewayRepository.kt
@@ -1727,7 +1727,7 @@ class GatewayRepository @Inject constructor(
         recipients: List<RecipientOutput>,
         privateKey: ByteArray
     ): Result<String> = runCatching {
-        buildReserveAndSend(fromAddress) { availableCells, net ->
+        val txHash = buildReserveAndSend(fromAddress) { availableCells, net ->
             transactionBuilder.buildMultiTransfer(
                 fromAddress = fromAddress,
                 recipients = recipients,
@@ -1736,6 +1736,9 @@ class GatewayRepository @Inject constructor(
                 network = net
             )
         }
+        // Remember this batch's hash so the activity list can badge it "Bulk".
+        walletPreferences.addBulkTxHash(txHash)
+        txHash
     }
 
     /**
@@ -2197,7 +2200,12 @@ class GatewayRepository @Inject constructor(
         // directly and the full set lives in Room. Cursor is always null now:
         // no UI caller ever passed one (Room Paging does the scrolling), and
         // the full walk leaves nothing to continue from.
-        val mergedItems = (pendingLocal + items).take(limit)
+        val mergedItems = (pendingLocal + items)
+            .take(limit)
+            // Badge batches of a bulk airdrop (marked at send time). Computed
+            // from the persisted set so it survives the pending->confirmed and
+            // cache-resync transitions.
+            .map { it.copy(isBulk = walletPreferences.isBulkTxHash(it.txHash)) }
 
         TransactionsResponse(mergedItems, null)
     }

--- a/android/app/src/main/java/com/rjnr/pocketnode/data/gateway/models/CkbModels.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/gateway/models/CkbModels.kt
@@ -99,6 +99,9 @@ data class TransactionRecord(
     @SerialName("block_timestamp_hex") val blockTimestampHex: String? = null,
     // True if the transaction interacts with a DAO type script cell
     @SerialName("is_dao_related") val isDaoRelated: Boolean = false,
+    // True if this tx was sent as one batch of a bulk airdrop. Set at display
+    // time from a persisted set of bulk tx hashes (not serialized or synced).
+    @SerialName("is_bulk") val isBulk: Boolean = false,
     // "PENDING", "CONFIRMED", "FAILED" — defaults to CONFIRMED so historical
     // rows that never had an explicit status (pre-#115) render as confirmed.
     @SerialName("status") val status: String = "CONFIRMED"

--- a/android/app/src/main/java/com/rjnr/pocketnode/data/wallet/WalletPreferences.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/wallet/WalletPreferences.kt
@@ -97,6 +97,22 @@ class WalletPreferences @Inject constructor(
         prefs.edit().putBoolean(KEY_BULK_SEND_UNLOCKED, unlocked).apply()
     }
 
+    /**
+     * Tx hashes broadcast as batches of a bulk airdrop. Used to badge those rows
+     * as "Bulk" in the activity list. Tx hashes are globally unique, so a single
+     * set across wallets/networks is fine; the set only grows on the rare bulk
+     * send (founder easter egg).
+     */
+    fun isBulkTxHash(hash: String): Boolean =
+        prefs.getStringSet(KEY_BULK_TX_HASHES, emptySet())?.contains(hash) == true
+
+    fun addBulkTxHash(hash: String) {
+        // Copy the returned set before mutating — SharedPreferences hands back a
+        // shared instance that must not be modified in place.
+        val current = prefs.getStringSet(KEY_BULK_TX_HASHES, emptySet()) ?: emptySet()
+        prefs.edit().putStringSet(KEY_BULK_TX_HASHES, current + hash).apply()
+    }
+
     init {
         migrateIfNeeded()
     }
@@ -425,6 +441,7 @@ class WalletPreferences @Inject constructor(
         private const val KEY_SYNC_STRATEGY = "sync_strategy"
         private const val KEY_THEME_MODE = "theme_mode"
         private const val KEY_BULK_SEND_UNLOCKED = "bulk_send_unlocked"
+        private const val KEY_BULK_TX_HASHES = "bulk_tx_hashes"
         private const val KEY_BACKGROUND_SYNC = "background_sync_enabled"
         private const val KEY_LAST_SYNCED_AT = "last_synced_at_ms"
         private const val KEY_BG_SYNC_PILL_DISMISSED = "bg_sync_pill_dismissed"

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/activity/ActivityScreen.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/activity/ActivityScreen.kt
@@ -454,6 +454,20 @@ private fun ActivityTransactionItem(
                         )
                     }
                 }
+                if (transaction.isBulk) {
+                    Spacer(modifier = Modifier.width(6.dp))
+                    Surface(
+                        color = MaterialTheme.colorScheme.primary.copy(alpha = 0.15f),
+                        shape = RoundedCornerShape(4.dp)
+                    ) {
+                        Text(
+                            text = "Bulk",
+                            style = MaterialTheme.typography.labelSmall,
+                            color = MaterialTheme.colorScheme.primary,
+                            modifier = Modifier.padding(horizontal = 6.dp, vertical = 2.dp)
+                        )
+                    }
+                }
             }
             Spacer(modifier = Modifier.height(2.dp))
             Text(

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/activity/ActivityViewModel.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/activity/ActivityViewModel.kt
@@ -70,7 +70,9 @@ class ActivityViewModel @Inject constructor(
                 Filter.SENT -> transactionDao.getSentTransactionsPaged(walletId, network.name)
             }
         }.flow.map { pagingData ->
-            pagingData.map { it.toTransactionRecord() }
+            pagingData.map {
+                it.toTransactionRecord().copy(isBulk = walletPreferences.isBulkTxHash(it.txHash))
+            }
         }
     }.cachedIn(viewModelScope)
 

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/home/Components.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/home/Components.kt
@@ -445,6 +445,20 @@ fun TransactionItems(
                         )
                     }
                 }
+                if (transaction.isBulk) {
+                    Surface(
+                        color = daoColor.copy(alpha = 0.1f),
+                        shape = CircleShape
+                    ) {
+                        Text(
+                            "Bulk",
+                            color = daoColor,
+                            fontSize = 9.sp,
+                            fontWeight = FontWeight.Bold,
+                            modifier = Modifier.padding(horizontal = 8.dp, vertical = 2.dp)
+                        )
+                    }
+                }
                 // Status chip — distinct visuals for Failed vs Pending vs
                 // Confirmed. Failed is tappable; the parent renders the
                 // confirm dialog and routes the retry through HomeViewModel.


### PR DESCRIPTION
Adds a small **Bulk** badge to activity rows for transactions sent as part of a bulk airdrop.

## How
- `prepareAndSendBulk` records each batch's tx hash in a persisted set (`WalletPreferences`).
- `TransactionRecord.isBulk` is set at **display time** from that set, in both list sources: `getTransactions` (Home preview) and `ActivityViewModel`'s paged flow (full Activity screen). No DB migration; survives the pending→confirmed and cache-resync transitions.
- The Home row and the Activity row render the badge (PocketGreen) next to the existing DAO / status chips.

Only affects transactions sent via the (hidden) bulk airdrop; normal sends are unchanged. Full unit suite green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Bulk transactions are now identified and labeled throughout transaction history.
  * Added “Bulk” badges to activity and home transaction views.
  * Bulk transaction records are now tracked persistently after sending.

* **Bug Fixes**
  * Bulk transaction labels now remain visible for both pending and completed transactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->