### PR TITLE
chore(diag): startup-gate logging to diagnose #424 overwrite-install onboarding

### DIFF
--- a/android/app/src/main/java/com/rjnr/pocketnode/MainActivity.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/MainActivity.kt
@@ -107,8 +107,15 @@ class MainActivity : FragmentActivity() {
             // detection (keyMaterial>0 but hasWallet=false) vs. actual data loss
             // (keyMaterial=0) vs. the corruption/ESP path. Counts + a UUID only;
             // no key bytes are ever logged.
+            //
+            // Log.println, NOT Log.i: proguard-rules.pro strips v/d/i/w/e/wtf via
+            // -assumenosideeffects in release/playRelease, which would erase this
+            // line from exactly the signed builds the reporter runs (a debug
+            // build can't overwrite their release-signed install). println is not
+            // in that strip list, so it survives R8 and still reaches logcat.
             runCatching {
-                Log.i(
+                Log.println(
+                    Log.INFO,
                     "StartupGate",
                     "#424 route=$route hasWallet=$cachedHasWallet wasReset=$wasReset " +
                         "hasPin=$hasPin ${keyManager.diagnosticKeyState()} " +

--- a/android/app/src/main/java/com/rjnr/pocketnode/MainActivity.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/MainActivity.kt
@@ -25,6 +25,7 @@ import com.rjnr.pocketnode.data.wallet.KeyManager
 import com.rjnr.pocketnode.ui.navigation.CkbNavGraph
 import com.rjnr.pocketnode.ui.navigation.Screen
 import com.rjnr.pocketnode.data.wallet.WalletPreferences
+import com.rjnr.pocketnode.data.wallet.WalletRepository
 import com.rjnr.pocketnode.ui.theme.CkbWalletTheme
 import com.rjnr.pocketnode.ui.util.LocalWindowSizeClass
 import dagger.hilt.android.AndroidEntryPoint
@@ -44,6 +45,9 @@ class MainActivity : FragmentActivity() {
 
     @Inject
     lateinit var keyManager: KeyManager
+
+    @Inject
+    lateinit var walletRepository: WalletRepository
 
     @Inject
     lateinit var keyBackupManager: KeyBackupManager
@@ -86,15 +90,34 @@ class MainActivity : FragmentActivity() {
         // on the main thread before any UI is shown.
         val startDestination = runBlocking {
             cachedHasWallet = repository.hasWallet()
-            when {
+            @Suppress("DEPRECATION")
+            val wasReset = keyManager.wasResetDueToCorruption()
+            val hasPin = pinManager.hasPin()
+            val route = when {
                 // Suppressed, not removed: the corruption flag guards the ESP
                 // legacy-key path, which un-migrated installs still read.
-                @Suppress("DEPRECATION")
-                keyManager.wasResetDueToCorruption() -> Screen.Recovery.route
+                wasReset -> Screen.Recovery.route
                 !cachedHasWallet -> Screen.Onboarding.route
-                !pinManager.hasPin() -> Screen.InitialPinSetup.route
+                !hasPin -> Screen.InitialPinSetup.route
                 else -> Screen.Auth.route
             }
+            // #424 diagnostic: users report onboarding after an overwrite
+            // install despite preserved data. Log the exact startup-gate inputs
+            // so a repro on the reporter's device shows which signal is wrong —
+            // detection (keyMaterial>0 but hasWallet=false) vs. actual data loss
+            // (keyMaterial=0) vs. the corruption/ESP path. Counts + a UUID only;
+            // no key bytes are ever logged.
+            runCatching {
+                Log.i(
+                    "StartupGate",
+                    "#424 route=$route hasWallet=$cachedHasWallet wasReset=$wasReset " +
+                        "hasPin=$hasPin ${keyManager.diagnosticKeyState()} " +
+                        "wallets=${walletRepository.walletCount()} " +
+                        "activeWalletId=${walletRepository.activeWalletIdSnapshot()} " +
+                        "lastSeenVc=${walletPreferences.getLastSeenVersionCode()} vc=${BuildConfig.VERSION_CODE}"
+                )
+            }
+            route
         }
 
         setContent {

--- a/android/app/src/main/java/com/rjnr/pocketnode/data/migration/KeyStoreMigrationHelper.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/migration/KeyStoreMigrationHelper.kt
@@ -208,6 +208,14 @@ class KeyStoreMigrationHelper(
         return keyMaterialDao.count() > 0
     }
 
+    /**
+     * Diagnostic-only (#424): total / V1 / V2 row counts in key_material.
+     * Used by the startup-gate log to distinguish "wallet detection failed"
+     * from "key material actually gone" on overwrite-install reports.
+     */
+    suspend fun keyMaterialCounts(): Triple<Int, Int, Int> =
+        Triple(keyMaterialDao.count(), keyMaterialDao.countV1Wallets(), keyMaterialDao.countV2Wallets())
+
     companion object {
         private const val TAG = "KeyStoreMigrationHelper"
         private const val KEY_MIGRATION_COMPLETE = "esp_to_room_migration_complete"

--- a/android/app/src/main/java/com/rjnr/pocketnode/data/wallet/KeyManager.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/wallet/KeyManager.kt
@@ -159,6 +159,23 @@ class KeyManager @Inject constructor(
         return prefs.contains(KEY_PRIVATE_KEY)
     }
 
+    /**
+     * Diagnostic-only (#424): "total/V1/V2 key_material rows, espKey" for the
+     * startup-gate log. Returns (-1, -1, -1, false) if the Room helper is not
+     * wired. Never logs key bytes — counts and an existence flag only.
+     */
+    suspend fun diagnosticKeyState(): String {
+        val helper = keyStoreMigrationHelper
+        val (total, v1, v2) = helper?.keyMaterialCounts() ?: Triple(-1, -1, -1)
+        val espKey = try {
+            @Suppress("DEPRECATION")
+            prefs.contains(KEY_PRIVATE_KEY)
+        } catch (e: Exception) {
+            "err(${e.javaClass.simpleName})"
+        }
+        return "keyMaterial=$total(v1=$v1,v2=$v2) espKey=$espKey"
+    }
+
     suspend fun getMnemonic(): List<String>? {
         val helper = keyStoreMigrationHelper
         if (helper != null) {

--- a/android/app/src/main/java/com/rjnr/pocketnode/data/wallet/KeyManager.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/wallet/KeyManager.kt
@@ -161,17 +161,32 @@ class KeyManager @Inject constructor(
 
     /**
      * Diagnostic-only (#424): "total/V1/V2 key_material rows, espKey" for the
-     * startup-gate log. Returns (-1, -1, -1, false) if the Room helper is not
-     * wired. Never logs key bytes — counts and an existence flag only.
+     * startup-gate log. Read-only: never logs key bytes, only counts and an
+     * existence flag.
+     *
+     * Side-effect note: the ESP presence check is skipped when Room already
+     * holds keys (`total > 0`), exactly mirroring [hasWallet]'s short-circuit.
+     * Touching `prefs` lazily initializes `encryptedPrefs`, which can flip
+     * `walletResetDueToCorruption` on an unreadable legacy file; gating on
+     * `total > 0` keeps a migrated wallet's routing untouched (Codex/CodeRabbit
+     * review on #425). Each probe is independently guarded so one failure still
+     * yields a usable line rather than dropping the whole log event.
      */
     suspend fun diagnosticKeyState(): String {
         val helper = keyStoreMigrationHelper
-        val (total, v1, v2) = helper?.keyMaterialCounts() ?: Triple(-1, -1, -1)
-        val espKey = try {
-            @Suppress("DEPRECATION")
-            prefs.contains(KEY_PRIVATE_KEY)
+        val (total, v1, v2) = try {
+            helper?.keyMaterialCounts() ?: Triple(-1, -1, -1)
         } catch (e: Exception) {
-            "err(${e.javaClass.simpleName})"
+            Triple(-2, -2, -2) // -2 marks a count-probe failure
+        }
+        val espKey = when {
+            total > 0 -> "skip" // Room has keys; don't touch ESP (no side effect)
+            else -> try {
+                @Suppress("DEPRECATION")
+                prefs.contains(KEY_PRIVATE_KEY).toString()
+            } catch (e: Exception) {
+                "err(${e.javaClass.simpleName})"
+            }
         }
         return "keyMaterial=$total(v1=$v1,v2=$v2) espKey=$espKey"
     }


### PR DESCRIPTION
## What

Adds a single diagnostic `Log.i("StartupGate", ...)` at the cold-start routing gate in `MainActivity`, plus the read-only count helpers it needs. Investigation for #424.

## Why

#424 reports the onboarding screen after an overwrite install (`adb install -r`, same signing cert, install returns `Success`) even though the wallet data is preserved.

I could not reproduce it locally. I built v1.7.9 and v1.8.0 from the tags (both debug and R8-release, signed with one matching key), created a wallet on 1.7.9's actual code, then `adb install -r` the 1.8.0 APK:

| Wallet tier | Build | Result after overwrite |
|---|---|---|
| V1 (kdfVersion=1, no lock) | debug | Auth lock screen — `key_material` row survives |
| V2 (kdfVersion=2, auth-bound) | debug | PIN setup (hasWallet=true) — row survives |
| V2, fully set up + app PIN | release (R8) | Auth → PIN unlocks → same wallet address |

In every case `hasWallet()` returns true and the `key_material` row persists (DB stays v15, no migration runs, no destructive fallback). The only path that produces onboarding is a signing-key mismatch, which Android blocks with `INSTALL_FAILED_UPDATE_INCOMPATIBLE` and forces an uninstall.

Since it will not reproduce here, we need the startup-gate signals from the reporter's device.

## What it logs

One line at the gate, driven by what actually chose the route:

- `route`, `hasWallet`, `wasReset` (corruption flag), `hasPin`
- `keyMaterial=total(v1=..,v2=..)` and `espKey` presence
- `wallets` count, `activeWalletId` (UUID)
- `lastSeenVc` / `vc`

This separates the three possible failures:
- `keyMaterial>0` but `hasWallet=false` → detection bug
- `keyMaterial=0` → real data loss
- `wasReset=true` → keystore/ESP corruption path

## Safety

- Counts and a UUID only — **no key bytes are logged**.
- Wrapped in `runCatching` so diagnostics can never break cold start.
- No behavior change to routing; the `when` is refactored to capture the chosen route into a local.

## Follow-up

Ship a build with this to the #424 reporter, have them redo the overwrite, and capture `adb logcat | grep StartupGate`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved startup diagnostics with clearer differentiation between wallet-detection failures and key-material recovery issues.
  * Preserved existing startup routing and corruption/reset behavior.
  * Enhanced diagnostics to report only key/material presence and row counts, avoiding any sensitive key material.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->