### PR TITLE
fix(play): compile out the dataSync foreground service on the Play build (#338)

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -60,6 +60,15 @@ android {
         // REQUEST_INSTALL_PACKAGES (src/playRelease/AndroidManifest.xml).
         buildConfigField("boolean", "UPDATER_ENABLED", "true")
 
+        // Gates the background-sync foreground service (dataSync FGS). Default
+        // true for GitHub-distributed debug/release builds. The `playRelease`
+        // build type overrides this to false: Google Play's foreground-service
+        // policy rejected the dataSync justification, so the Play AAB never
+        // starts the FGS (sync stays foreground-first; a WorkManager catch-up
+        // worker is tracked in #337) and strips the FOREGROUND_SERVICE
+        // permissions (src/playRelease/AndroidManifest.xml).
+        buildConfigField("boolean", "BG_FGS_ENABLED", "true")
+
         // Only include ARM ABIs — x86_64 is emulator-only and adds ~29 MB.
         // CI's upgrade-smoke harness opts in via BUILD_X86_64=1 (matched in
         // external/ckb-light-client/build-android-jni.sh).
@@ -205,6 +214,7 @@ android {
             // Resolve dependency variants that only publish `release`.
             matchingFallbacks += "release"
             buildConfigField("boolean", "UPDATER_ENABLED", "false")
+            buildConfigField("boolean", "BG_FGS_ENABLED", "false")
             signingConfig = if (unsignedRelease) null else signingConfigs.getByName("release")
         }
     }

--- a/android/app/src/main/java/com/rjnr/pocketnode/data/gateway/GatewayRepository.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/gateway/GatewayRepository.kt
@@ -2,6 +2,7 @@ package com.rjnr.pocketnode.data.gateway
 
 import android.content.Context
 import android.util.Log
+import com.rjnr.pocketnode.BuildConfig
 import com.rjnr.pocketnode.data.database.AppDatabase
 import com.rjnr.pocketnode.data.database.DatabaseMaintenanceUtil
 import com.rjnr.pocketnode.data.database.dao.HeaderCacheDao
@@ -2912,6 +2913,15 @@ class GatewayRepository @Inject constructor(
      * Start the foreground sync service if background sync is enabled.
      */
     fun startBackgroundSync() {
+        // Play build ships no foreground service (Google FGS policy rejected the
+        // dataSync justification, #338). The flag is false only on `playRelease`;
+        // the GitHub/website release keeps the FGS. Guard here, the single call
+        // site, so the manifest overlay that strips FOREGROUND_SERVICE_* can never
+        // be paired with a startForegroundService() that would then crash.
+        if (!BuildConfig.BG_FGS_ENABLED) {
+            Log.d(TAG, "FGS compiled out for this build (Play); sync stays foreground-first")
+            return
+        }
         if (!walletPreferences.isBackgroundSyncEnabled()) {
             Log.d(TAG, "Background sync disabled, not starting service")
             return

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/components/BgSyncStaleBanner.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/components/BgSyncStaleBanner.kt
@@ -3,6 +3,7 @@ package com.rjnr.pocketnode.ui.components
 import android.Manifest
 import android.content.pm.PackageManager
 import android.os.Build
+import com.rjnr.pocketnode.BuildConfig
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.layout.Arrangement
@@ -99,7 +100,10 @@ fun BgSyncStaleBanner(
                 TextButton(onClick = onDismiss) {
                     Text(stringResource(R.string.bg_sync_pill_action_dismiss))
                 }
-                if (!bgSyncEnabled) {
+                // #427 / Codex P1: no foreground service on the Play build, so
+                // never offer the "enable background sync" action there (it
+                // would request POST_NOTIFICATIONS for a feature that cannot run).
+                if (BuildConfig.BG_FGS_ENABLED && !bgSyncEnabled) {
                     FilledTonalButton(onClick = {
                         val needsPermission = Build.VERSION.SDK_INT >= 33 &&
                             ContextCompat.checkSelfPermission(

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/navigation/NavGraph.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/navigation/NavGraph.kt
@@ -11,6 +11,7 @@ import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.navArgument
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import com.rjnr.pocketnode.BuildConfig
 import com.rjnr.pocketnode.data.auth.PinManager
 import com.rjnr.pocketnode.ui.MainScreen
 import com.rjnr.pocketnode.ui.screens.auth.AuthScreen
@@ -593,7 +594,16 @@ fun CkbNavGraph(
                     // #286: surface background sync at the point of choice,
                     // right after the mandatory PIN step. The opt-in screen
                     // self-skips when the preference is already set.
-                    navController.navigate(Screen.BackgroundSyncOptIn.route) {
+                    //
+                    // #427 / Codex P1: the Play build has no foreground service,
+                    // so there is nothing to opt into and no POST_NOTIFICATIONS
+                    // to request. Skip the opt-in and go straight to the wallet.
+                    val next = if (BuildConfig.BG_FGS_ENABLED) {
+                        Screen.BackgroundSyncOptIn.route
+                    } else {
+                        destinationAfterWalletReady()
+                    }
+                    navController.navigate(next) {
                         popUpTo(navController.graph.id) { inclusive = true }
                         launchSingleTop = true
                     }

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/settings/SettingsScreen.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/settings/SettingsScreen.kt
@@ -490,27 +490,33 @@ private fun SettingsScreenUI(
                 )
             }
 
-            item {
-                SettingsSwitchRow(
-                    icon = Lucide.RefreshCw,
-                    title = "Background Sync",
-                    checked = uiState.isBackgroundSyncEnabled,
-                    onCheckedChange = onToggleBackgroundSync
-                )
-            }
+            // Background sync is powered by the foreground service, which is
+            // compiled out of the Play build (BG_FGS_ENABLED=false, #338). Hide
+            // the toggle there so we don't offer a control that does nothing;
+            // the GitHub/website release still shows it.
+            if (BuildConfig.BG_FGS_ENABLED) {
+                item {
+                    SettingsSwitchRow(
+                        icon = Lucide.RefreshCw,
+                        title = "Background Sync",
+                        checked = uiState.isBackgroundSyncEnabled,
+                        onCheckedChange = onToggleBackgroundSync
+                    )
+                }
 
-            // #286: one-line tradeoff blurb at the point of choice.
-            item {
-                Text(
-                    text = "Keeps your balance fresh while the app is closed, with a small " +
-                        "ongoing notification. Android may still pause it after extended " +
-                        "background time.",
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    modifier = Modifier
-                        .padding(horizontal = 16.dp)
-                        .padding(top = 4.dp, bottom = 8.dp)
-                )
+                // #286: one-line tradeoff blurb at the point of choice.
+                item {
+                    Text(
+                        text = "Keeps your balance fresh while the app is closed, with a small " +
+                            "ongoing notification. Android may still pause it after extended " +
+                            "background time.",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier
+                            .padding(horizontal = 16.dp)
+                            .padding(top = 4.dp, bottom = 8.dp)
+                    )
+                }
             }
 
             item {

--- a/android/app/src/playRelease/AndroidManifest.xml
+++ b/android/app/src/playRelease/AndroidManifest.xml
@@ -1,9 +1,21 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  Play Store build overlay. The in-app updater is compiled out of this build
-  type (BuildConfig.UPDATER_ENABLED=false), and Google Play forbids apps that
-  self-install APKs, so REQUEST_INSTALL_PACKAGES must not appear in the merged
-  manifest of the uploaded AAB. tools:node="remove" strips it from the merge.
+  Play Store build overlay. Two things are stripped from the merged manifest of
+  the uploaded AAB:
+
+  1. REQUEST_INSTALL_PACKAGES — the in-app updater is compiled out
+     (BuildConfig.UPDATER_ENABLED=false) and Google Play forbids apps that
+     self-install APKs.
+
+  2. FOREGROUND_SERVICE and FOREGROUND_SERVICE_DATA_SYNC — Google Play's
+     foreground-service policy rejected the dataSync justification for the
+     background-sync service (#338). The Play build compiles the FGS out
+     (BuildConfig.BG_FGS_ENABLED=false, guarded in GatewayRepository), so these
+     permissions must not appear in the Play manifest. Sync stays
+     foreground-first; a WorkManager catch-up worker is tracked in #337. The
+     GitHub/website release build retains the FGS and these permissions.
+
+  tools:node="remove" strips each from the merge.
 -->
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
@@ -11,5 +23,26 @@
     <uses-permission
         android:name="android.permission.REQUEST_INSTALL_PACKAGES"
         tools:node="remove" />
+
+    <uses-permission
+        android:name="android.permission.FOREGROUND_SERVICE"
+        tools:node="remove" />
+
+    <uses-permission
+        android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC"
+        tools:node="remove" />
+
+    <!--
+      Also drop the service element itself so no `dataSync` foreground-service
+      signal remains in the Play manifest for Google's policy scan. The service
+      is never started on this build (guarded by BG_FGS_ENABLED in
+      GatewayRepository), and stopService() on an unregistered service is a
+      no-op, so removal is safe.
+    -->
+    <application>
+        <service
+            android:name=".data.sync.SyncForegroundService"
+            tools:node="remove" />
+    </application>
 
 </manifest>


### PR DESCRIPTION
## What

The Play Store build (`playRelease`) no longer ships the `dataSync` foreground service. The GitHub/website `release` build is unchanged and keeps it.

## Why

Google Play's foreground-service policy rejected the `dataSync` justification for the background-sync service and pulled the app from the store (enforced Aug 2). `dataSync` FGS is increasingly restricted, and this app already fights it on three fronts (Android 15's 6h cap, OEM battery killers, and now Play policy). Rather than re-litigate a declaration Google may keep rejecting, the Play build drops the FGS entirely and stays foreground-first. A WorkManager periodic catch-up worker is tracked separately in #337, where the schedule/interval is still to be decided.

## Changes

- **`BG_FGS_ENABLED` BuildConfig flag** (mirrors the existing `UPDATER_ENABLED` pattern): `true` by default, `false` only on `playRelease`.
- **`GatewayRepository.startBackgroundSync()`** short-circuits when the flag is off. This is the single call site of `SyncForegroundService.start()`, so the service can never start on Play.
- **`playRelease` manifest overlay** strips `FOREGROUND_SERVICE` and `FOREGROUND_SERVICE_DATA_SYNC` and removes the `SyncForegroundService` element, so no `dataSync` signal remains in the Play manifest.

## Verification

Packaged manifests inspected for both variants:
- `playRelease`: **zero** FGS permissions, no `foregroundServiceType`, `SyncForegroundService` absent.
- `release`: retains `FOREGROUND_SERVICE`, `FOREGROUND_SERVICE_DATA_SYNC`, and the service.

Both variants compile (`compilePlayReleaseKotlin`, `compileReleaseKotlin`).

## Follow-ups (not in this PR)

- The "keep syncing in background" toggle in Settings is a no-op on the Play build now; hide or relabel it there.
- WorkManager catch-up worker (#337) for background freshness on the Play build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Standard Android builds continue supporting background synchronization.
  * Play Store builds now use foreground-first synchronization without background foreground-service access.

* **Bug Fixes**
  * Improved Play Store compatibility by removing unnecessary background-sync service permissions and declarations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->