### PR TITLE
feat(sync): WorkManager background catch-up for the Play build (#337, Option D)

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -296,6 +296,11 @@ dependencies {
     ksp(libs.hilt.compiler)
     implementation(libs.hilt.navigation.compose)
 
+    // WorkManager + Hilt integration (background sync catch-up on the Play build, #337)
+    implementation(libs.androidx.work.runtime.ktx)
+    implementation(libs.androidx.hilt.work)
+    ksp(libs.androidx.hilt.compiler)
+
     // Serialization
     implementation(libs.kotlinx.serialization.json)
 

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
 
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.CAMERA" />
@@ -41,6 +42,24 @@
             <meta-data
                 android:name="android.support.FILE_PROVIDER_PATHS"
                 android:resource="@xml/file_provider_paths" />
+        </provider>
+
+        <!--
+          WorkManager on-demand initialization. CkbWalletApp implements
+          Configuration.Provider and supplies the HiltWorkerFactory, so the
+          default startup initializer must be removed (otherwise WorkManager
+          initializes before Hilt and cannot construct @HiltWorker workers).
+          Keeps androidx.startup for any other initializers.
+        -->
+        <provider
+            android:name="androidx.startup.InitializationProvider"
+            android:authorities="${applicationId}.androidx-startup"
+            android:exported="false"
+            tools:node="merge">
+            <meta-data
+                android:name="androidx.work.WorkManagerInitializer"
+                android:value="androidx.startup"
+                tools:node="remove" />
         </provider>
     </application>
 

--- a/android/app/src/main/java/com/rjnr/pocketnode/CkbWalletApp.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/CkbWalletApp.kt
@@ -1,16 +1,35 @@
 package com.rjnr.pocketnode
 
 import android.app.Application
+import androidx.hilt.work.HiltWorkerFactory
+import androidx.work.Configuration
 import com.rjnr.pocketnode.data.sync.BroadcastWatchdog
+import com.rjnr.pocketnode.data.sync.SyncWorkScheduler
 import dagger.hilt.android.HiltAndroidApp
 import javax.inject.Inject
 
 @HiltAndroidApp
-class CkbWalletApp : Application() {
+class CkbWalletApp : Application(), Configuration.Provider {
     @Inject lateinit var broadcastWatchdog: BroadcastWatchdog
+
+    // Supplies the HiltWorkerFactory so @HiltWorker workers can be constructed
+    // with their injected dependencies. Paired with the default WorkManager
+    // initializer being removed in the manifest (on-demand initialization).
+    @Inject lateinit var workerFactory: HiltWorkerFactory
+
+    @Inject lateinit var syncWorkScheduler: SyncWorkScheduler
+
+    override val workManagerConfiguration: Configuration
+        get() = Configuration.Builder()
+            .setWorkerFactory(workerFactory)
+            .build()
 
     override fun onCreate() {
         super.onCreate()
         broadcastWatchdog.start()
+        // Register the periodic background-sync catch-up. No-ops on builds that
+        // keep the foreground service (BG_FGS_ENABLED=true); only the Play build
+        // relies on WorkManager for background freshness (#337).
+        syncWorkScheduler.ensurePeriodicCatchUpScheduled()
     }
 }

--- a/android/app/src/main/java/com/rjnr/pocketnode/MainActivity.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/MainActivity.kt
@@ -191,11 +191,11 @@ class MainActivity : FragmentActivity() {
         super.onStop()
         // Play build only (self-gated): enqueue a one-time catch-up so the light
         // client keeps syncing for a few minutes after the app is backgrounded,
-        // while the process is still warm. No-op on builds that keep the
-        // foreground service (#337).
-        if (cachedHasWallet) {
-            syncWorkScheduler.enqueueBackgroundCatchUp()
-        }
+        // while the process is still warm. Always enqueue: the worker itself
+        // checks hasWallet(), so a fresh install that just created its wallet
+        // during onboarding is covered even though cachedHasWallet (set once in
+        // onCreate) is still stale here (Codex #428 P1). No-op on FGS builds.
+        syncWorkScheduler.enqueueBackgroundCatchUp()
         // Use cached value — avoids blocking main thread on every onStop
         if (cachedHasWallet && pinManager.hasPin()) {
             _requireReauth.value = true

--- a/android/app/src/main/java/com/rjnr/pocketnode/MainActivity.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/MainActivity.kt
@@ -20,6 +20,7 @@ import androidx.navigation.compose.rememberNavController
 import com.rjnr.pocketnode.data.auth.AuthManager
 import com.rjnr.pocketnode.data.auth.PinManager
 import com.rjnr.pocketnode.data.gateway.GatewayRepository
+import com.rjnr.pocketnode.data.sync.SyncWorkScheduler
 import com.rjnr.pocketnode.data.wallet.KeyBackupManager
 import com.rjnr.pocketnode.data.wallet.KeyManager
 import com.rjnr.pocketnode.ui.navigation.CkbNavGraph
@@ -54,6 +55,9 @@ class MainActivity : FragmentActivity() {
 
     @Inject
     lateinit var authManager: AuthManager
+
+    @Inject
+    lateinit var syncWorkScheduler: SyncWorkScheduler
 
     private val _requireReauth = mutableStateOf(false)
 
@@ -185,6 +189,13 @@ class MainActivity : FragmentActivity() {
 
     override fun onStop() {
         super.onStop()
+        // Play build only (self-gated): enqueue a one-time catch-up so the light
+        // client keeps syncing for a few minutes after the app is backgrounded,
+        // while the process is still warm. No-op on builds that keep the
+        // foreground service (#337).
+        if (cachedHasWallet) {
+            syncWorkScheduler.enqueueBackgroundCatchUp()
+        }
         // Use cached value — avoids blocking main thread on every onStop
         if (cachedHasWallet && pinManager.hasPin()) {
             _requireReauth.value = true

--- a/android/app/src/main/java/com/rjnr/pocketnode/data/sync/SyncCatchUpWorker.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/sync/SyncCatchUpWorker.kt
@@ -9,7 +9,7 @@ import com.rjnr.pocketnode.BuildConfig
 import com.rjnr.pocketnode.data.gateway.GatewayRepository
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedInject
-import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.withTimeoutOrNull
 
 /**
@@ -55,23 +55,37 @@ class SyncCatchUpWorker @AssistedInject constructor(
 
         return try {
             repository.initializeWallet()
-            repository.startSyncPolling()
 
             val outcome = withTimeoutOrNull(MAX_RUN_MS) {
-                // Probe: if the native client emits no tip within PROBE_MS it is
-                // not running in this (likely cold) process. Bail rather than
-                // spin the full window.
-                val nodeLive = withTimeoutOrNull(PROBE_MS) {
-                    repository.syncProgress.first { it.tipBlockNumber > 0 }
-                    true
-                } ?: false
-
-                if (!nodeLive) {
-                    "no-live-node"
-                } else {
-                    repository.syncProgress.first { !it.isSyncing && it.percentage >= 100 }
-                    "caught-up"
+                // Poll getAccountStatus() directly rather than driving the shared
+                // startSyncPolling job. That job is process-wide state owned by
+                // the foreground UI; a worker that started/stopped it would cancel
+                // the Home screen's progress poller on a warm process and stale it
+                // (Codex #428 P1). getAccountStatus is a cheap local JNI read with
+                // no shared ownership. The native client keeps syncing on its own
+                // threads while WorkManager holds the process alive here; we only
+                // observe progress and return once caught up.
+                var sawNode = false
+                val probeDeadline = System.currentTimeMillis() + PROBE_MS
+                var result: String? = null
+                while (result == null) {
+                    val status = repository.getAccountStatus().getOrNull()
+                    val synced = status?.syncedToBlock?.toLongOrNull() ?: 0L
+                    val tip = status?.tipNumber?.toLongOrNull() ?: 0L
+                    when {
+                        tip > 0L && synced >= tip -> result = "caught-up"
+                        tip > 0L -> sawNode = true
+                    }
+                    // No tip within PROBE_MS => native client not running in this
+                    // (likely cold) process. Bail rather than spin the full window.
+                    if (result == null && !sawNode &&
+                        System.currentTimeMillis() > probeDeadline
+                    ) {
+                        result = "no-live-node"
+                    }
+                    if (result == null) delay(POLL_INTERVAL_MS)
                 }
+                result
             } ?: "timed-out-still-syncing"
 
             Log.i(TAG, "catch-up finished: $outcome")
@@ -79,8 +93,6 @@ class SyncCatchUpWorker @AssistedInject constructor(
         } catch (e: Exception) {
             Log.w(TAG, "catch-up failed; will retry with backoff", e)
             Result.retry()
-        } finally {
-            repository.stopSyncPolling()
         }
     }
 
@@ -93,5 +105,8 @@ class SyncCatchUpWorker @AssistedInject constructor(
         // How long to wait for the native client to show any chain data before
         // concluding it is not running in this process.
         private const val PROBE_MS = 45L * 1000L
+
+        // Cadence for the direct getAccountStatus() catch-up poll.
+        private const val POLL_INTERVAL_MS = 5L * 1000L
     }
 }

--- a/android/app/src/main/java/com/rjnr/pocketnode/data/sync/SyncCatchUpWorker.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/sync/SyncCatchUpWorker.kt
@@ -1,0 +1,97 @@
+package com.rjnr.pocketnode.data.sync
+
+import android.content.Context
+import android.util.Log
+import androidx.hilt.work.HiltWorker
+import androidx.work.CoroutineWorker
+import androidx.work.WorkerParameters
+import com.rjnr.pocketnode.BuildConfig
+import com.rjnr.pocketnode.data.gateway.GatewayRepository
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedInject
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.withTimeoutOrNull
+
+/**
+ * Background-sync catch-up for the Play build, which ships no foreground service
+ * (see BG_FGS_ENABLED, #338/#427). Scheduled by [SyncWorkScheduler] as a ~4h
+ * periodic backstop and as a one-time run when the app goes to the background.
+ *
+ * The worker drives the native light client's progress poller and waits, within
+ * a bound that stays well inside WorkManager's ~10-minute execution window, for
+ * the client to reach the chain tip. It is best-effort: whatever the light
+ * client syncs is persisted, and the next run continues from there.
+ *
+ * ## Scope note (warm vs cold process)
+ *
+ * This body reuses only the safe, non-native-lifecycle methods
+ * ([GatewayRepository.initializeWallet] derives address state; startSyncPolling
+ * polls status). It fully catches up when the process is **warm** (the native
+ * node is already running, e.g. the one-time run right after the app is
+ * backgrounded, which is the main freshness win). In a **cold** process the
+ * node is not running; the probe below detects "no tip within PROBE_MS" and
+ * returns instead of spinning. Cold-start of the native node from a worker
+ * touches the OnceLock lifecycle (the same reason a network switch restarts the
+ * process) and is intentionally left as a device-tested follow-up rather than
+ * coded blind. See #337.
+ */
+@HiltWorker
+class SyncCatchUpWorker @AssistedInject constructor(
+    @Assisted appContext: Context,
+    @Assisted params: WorkerParameters,
+    private val repository: GatewayRepository,
+) : CoroutineWorker(appContext, params) {
+
+    override suspend fun doWork(): Result {
+        // Builds that keep the foreground service never rely on WorkManager for
+        // sync. The scheduler already guards this; this is defence in depth so a
+        // stale enqueued request on an upgraded install is a no-op.
+        if (BuildConfig.BG_FGS_ENABLED) return Result.success()
+
+        if (!repository.hasWallet()) {
+            Log.d(TAG, "No wallet; nothing to catch up")
+            return Result.success()
+        }
+
+        return try {
+            repository.initializeWallet()
+            repository.startSyncPolling()
+
+            val outcome = withTimeoutOrNull(MAX_RUN_MS) {
+                // Probe: if the native client emits no tip within PROBE_MS it is
+                // not running in this (likely cold) process. Bail rather than
+                // spin the full window.
+                val nodeLive = withTimeoutOrNull(PROBE_MS) {
+                    repository.syncProgress.first { it.tipBlockNumber > 0 }
+                    true
+                } ?: false
+
+                if (!nodeLive) {
+                    "no-live-node"
+                } else {
+                    repository.syncProgress.first { !it.isSyncing && it.percentage >= 100 }
+                    "caught-up"
+                }
+            } ?: "timed-out-still-syncing"
+
+            Log.i(TAG, "catch-up finished: $outcome")
+            Result.success() // best-effort in every case; next run continues
+        } catch (e: Exception) {
+            Log.w(TAG, "catch-up failed; will retry with backoff", e)
+            Result.retry()
+        } finally {
+            repository.stopSyncPolling()
+        }
+    }
+
+    companion object {
+        private const val TAG = "SyncCatchUpWorker"
+
+        // Stay comfortably inside WorkManager's ~10-minute cap.
+        private const val MAX_RUN_MS = 8L * 60L * 1000L
+
+        // How long to wait for the native client to show any chain data before
+        // concluding it is not running in this process.
+        private const val PROBE_MS = 45L * 1000L
+    }
+}

--- a/android/app/src/main/java/com/rjnr/pocketnode/data/sync/SyncWorkScheduler.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/sync/SyncWorkScheduler.kt
@@ -1,0 +1,93 @@
+package com.rjnr.pocketnode.data.sync
+
+import android.content.Context
+import android.util.Log
+import androidx.work.BackoffPolicy
+import androidx.work.Constraints
+import androidx.work.ExistingPeriodicWorkPolicy
+import androidx.work.ExistingWorkPolicy
+import androidx.work.NetworkType
+import androidx.work.OneTimeWorkRequestBuilder
+import androidx.work.PeriodicWorkRequestBuilder
+import androidx.work.WorkManager
+import com.rjnr.pocketnode.BuildConfig
+import dagger.hilt.android.qualifiers.ApplicationContext
+import java.util.concurrent.TimeUnit
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Schedules the [SyncCatchUpWorker] for the Play build (Option D, #337):
+ *
+ *  - a **~4h periodic** backstop, and
+ *  - a **one-time** run enqueued when the app goes to the background, which
+ *    catches up while the process is still warm (the freshness win).
+ *
+ * All scheduling is gated on `!BG_FGS_ENABLED`: the GitHub/website build keeps
+ * its foreground service and must not also run WorkManager sync, so there is
+ * exactly one background mechanism per build. On a build that has the FGS, the
+ * methods here cancel any previously scheduled work (covers a user moving from a
+ * Play install to a sideloaded build) and otherwise no-op.
+ */
+@Singleton
+class SyncWorkScheduler @Inject constructor(
+    @ApplicationContext private val context: Context,
+) {
+    private val workManager get() = WorkManager.getInstance(context)
+
+    private val constraints = Constraints.Builder()
+        // Any network (incremental light-client sync is small). A "sync on
+        // metered" user preference can tighten this later (#338).
+        .setRequiredNetworkType(NetworkType.CONNECTED)
+        .setRequiresBatteryNotLow(true)
+        .build()
+
+    /** Registered once at app start (CkbWalletApp). Idempotent. */
+    fun ensurePeriodicCatchUpScheduled() {
+        if (BuildConfig.BG_FGS_ENABLED) {
+            // FGS build: make sure no stale periodic work lingers.
+            workManager.cancelUniqueWork(PERIODIC_NAME)
+            return
+        }
+        val request = PeriodicWorkRequestBuilder<SyncCatchUpWorker>(
+            PERIODIC_INTERVAL_HOURS, TimeUnit.HOURS,
+            PERIODIC_FLEX_HOURS, TimeUnit.HOURS,
+        )
+            .setConstraints(constraints)
+            .setBackoffCriteria(BackoffPolicy.EXPONENTIAL, 30, TimeUnit.MINUTES)
+            .build()
+
+        // KEEP so app restarts don't reset the interval timer.
+        workManager.enqueueUniquePeriodicWork(
+            PERIODIC_NAME,
+            ExistingPeriodicWorkPolicy.KEEP,
+            request,
+        )
+        Log.d(TAG, "Periodic catch-up scheduled (${PERIODIC_INTERVAL_HOURS}h)")
+    }
+
+    /** Enqueued when the app goes to the background (MainActivity.onStop). */
+    fun enqueueBackgroundCatchUp() {
+        if (BuildConfig.BG_FGS_ENABLED) return
+        val request = OneTimeWorkRequestBuilder<SyncCatchUpWorker>()
+            .setConstraints(constraints)
+            .build()
+
+        // KEEP so rapid background/foreground toggling doesn't restart a run
+        // that is already queued or executing.
+        workManager.enqueueUniqueWork(
+            ONESHOT_NAME,
+            ExistingWorkPolicy.KEEP,
+            request,
+        )
+        Log.d(TAG, "One-time background catch-up enqueued")
+    }
+
+    companion object {
+        private const val TAG = "SyncWorkScheduler"
+        private const val PERIODIC_NAME = "sync-catch-up-periodic"
+        private const val ONESHOT_NAME = "sync-catch-up-oneshot"
+        private const val PERIODIC_INTERVAL_HOURS = 4L
+        private const val PERIODIC_FLEX_HOURS = 1L
+    }
+}

--- a/android/gradle/libs.versions.toml
+++ b/android/gradle/libs.versions.toml
@@ -8,6 +8,8 @@ composeBom = "2025.12.00"
 navigationCompose = "2.9.6"
 hilt = "2.57.2"
 hiltNavigationCompose = "1.3.0"
+androidxHilt = "1.2.0"
+work = "2.10.0"
 securityCrypto = "1.1.0"
 secp256k1 = "0.21.0"
 room = "2.8.4"
@@ -48,6 +50,11 @@ androidx-navigation-compose = { group = "androidx.navigation", name = "navigatio
 hilt-android = { group = "com.google.dagger", name = "hilt-android", version.ref = "hilt" }
 hilt-compiler = { group = "com.google.dagger", name = "hilt-compiler", version.ref = "hilt" }
 hilt-navigation-compose = { group = "androidx.hilt", name = "hilt-navigation-compose", version.ref = "hiltNavigationCompose" }
+
+# WorkManager (+ Hilt integration)
+androidx-work-runtime-ktx = { group = "androidx.work", name = "work-runtime-ktx", version.ref = "work" }
+androidx-hilt-work = { group = "androidx.hilt", name = "hilt-work", version.ref = "androidxHilt" }
+androidx-hilt-compiler = { group = "androidx.hilt", name = "hilt-compiler", version.ref = "androidxHilt" }
 
 # Security & Crypto
 androidx-biometric = { group = "androidx.biometric", name = "biometric", version.ref = "biometric" }


### PR DESCRIPTION
## What

Adds the Play build's background-sync mechanism. Since the Play build ships no foreground service (#427, merged), background freshness now comes from WorkManager. **Option D**: a ~4h periodic backstop plus a one-time catch-up enqueued when the app is backgrounded (syncs while the process is still warm — the freshness win). Any-network, battery-not-low, no expedited work.

All scheduling self-gates on `!BG_FGS_ENABLED`, so the GitHub/website build keeps its foreground service and there is exactly **one background mechanism per build**.

## Changes
- `SyncCatchUpWorker` (`@HiltWorker`): bounded (8 min) best-effort catch-up driving the native progress poller; probes for a live node and bails in a cold process.
- `SyncWorkScheduler`: periodic + one-time scheduling, self-gated.
- WorkManager + hilt-work deps; `HiltWorkerFactory` wired in `CkbWalletApp` with the default startup initializer removed from the manifest (on-demand init).
- Periodic scheduled at app start; one-time enqueued in `MainActivity.onStop`.

## Verification
- `assembleDebug` + `compilePlayReleaseKotlin` build; unit tests pass.
- **On-device (Play build, emulator):** app launches with no WorkManager/Hilt crash (proves the `Configuration.Provider` + `HiltWorkerFactory` wiring); the periodic job is registered in JobScheduler with the configured constraints (`BATTERY_NOT_LOW` + `CONNECTIVITY`, periodic).

## Scope / follow-up
The warm-process path (on-background trigger) is complete. Making the **periodic backstop sync in a fully cold process** needs a guarded idempotent native-node cold-start (touches the `OnceLock` lifecycle) and is deliberately left as a device-tested follow-up rather than coded blind.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic background wallet synchronization.
  * Sync runs periodically when network and battery conditions permit.
  * Added catch-up synchronization when the app moves to the background.
  * Sync retries automatically after temporary failures and avoids duplicate runs.
  * Background synchronization respects build settings and available wallets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->