### PR TITLE
chore(release): 1.8.2 (versionCode 24) for Play re-upload

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -15,8 +15,8 @@ android {
         applicationId = "com.rjnr.pocketnode"
         minSdk = 26
         targetSdk = 35
-        versionCode = 23
-        versionName = "1.8.1"
+        versionCode = 24
+        versionName = "1.8.2"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 

--- a/fastlane/metadata/android/en-US/changelogs/24.txt
+++ b/fastlane/metadata/android/en-US/changelogs/24.txt
@@ -1,0 +1,8 @@
+v1.8.2:
+Pocket Node keeps a CKB light client on your phone, with your keys and node on-device and no servers in between.
+
+This update makes background syncing lighter: it no longer shows an ongoing notification and refreshes your balance in the background when the system allows.
+
+Also includes minor stability improvements.
+
+Source: github.com/RaheemJnr/pocket-node/releases


### PR DESCRIPTION
versionCode 23 → 24, versionName 1.8.1 → 1.8.2.

Ships to the Play Store:
- **#427** — Play build removes the `dataSync` foreground service (clears the Google Play foreground-service policy rejection).
- **#428** — WorkManager background catch-up replaces the FGS on the Play build (periodic + on-background, foreground-first).

en-US changelog `24.txt` added; other locales fall back to en-US.

After merge, build the Play AAB with the release keystore: `./gradlew bundlePlayRelease` → `app/build/outputs/bundle/playRelease/*.aab`. The bundle carries no FGS permission, so no declaration/video is needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)