### PR TITLE
fix(dao): show pending DAO withdraw/deposit with true amount, not fee (#433)

### DIFF
--- a/android/app/src/main/java/com/rjnr/pocketnode/data/gateway/GatewayRepository.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/gateway/GatewayRepository.kt
@@ -1556,6 +1556,15 @@ class GatewayRepository @Inject constructor(
      */
     private suspend fun buildReserveAndSend(
         fromAddress: String,
+        // Pending activity-row overrides for DAO ops (#433). A plain transfer
+        // leaves these null and the row is a generic "out" whose balanceChange
+        // is the computed net debit. A DAO withdraw/deposit passes its true
+        // direction + amount so the pending row reads "Dao Withdraw 250 CKB"
+        // instead of surfacing the tiny fee as a "-0.001 Sent". Fee is stored
+        // separately so the detail view's fee line is populated.
+        pendingDirection: String = "out",
+        pendingAmountShannons: Long? = null,
+        pendingFeeShannons: Long? = null,
         build: (availableCells: List<Cell>, network: NetworkType) -> Transaction
     ): String {
         // Snapshot every piece of sender state at function entry. The user can
@@ -1687,9 +1696,9 @@ class GatewayRepository @Inject constructor(
                 txHash = txHash,
                 network = network,
                 walletId = walletId,
-                balanceChange = balanceChangeHex,
-                direction = "out",
-                fee = "0x0"
+                balanceChange = pendingAmountShannons?.let { "0x${it.toString(16)}" } ?: balanceChangeHex,
+                direction = pendingDirection,
+                fee = pendingFeeShannons?.let { "0x${it.toString(16)}" } ?: "0x0"
             )
             signed
         }
@@ -2544,7 +2553,14 @@ class GatewayRepository @Inject constructor(
 
         // Route through the shared mutex + reservation filter (#320) so a deposit
         // can't select inputs already reserved by an in-flight transfer.
-        val txHash = buildReserveAndSend(address) { availableCells, net ->
+        val txHash = buildReserveAndSend(
+            address,
+            // #433: pending deposit reads "Dao Deposit <amount> CKB" (matching the
+            // confirmed row) rather than a generic "Sent" carrying amount + fee.
+            pendingDirection = "dao_deposit",
+            pendingAmountShannons = amountShannons,
+            pendingFeeShannons = TransactionBuilder.DEFAULT_FEE,
+        ) { availableCells, net ->
             transactionBuilder.buildDaoDeposit(
                 amountShannons = amountShannons,
                 availableCells = availableCells,
@@ -2603,7 +2619,15 @@ class GatewayRepository @Inject constructor(
         // preserves the deposit capacity exactly, so a regular fee input cell is
         // mandatory (#119) — `availableCells` is the reservation-filtered regular
         // CKB set, ensuring the fee cell isn't one an in-flight transfer reserved.
-        val txHash = buildReserveAndSend(address) { availableCells, net ->
+        val txHash = buildReserveAndSend(
+            address,
+            // #433: show the pending withdraw as "Dao Withdraw <deposit> CKB"
+            // with the fee on its own line, not as a "-0.001 Sent". Phase-1
+            // preserves the deposit capacity exactly, so the fee is DEFAULT_FEE.
+            pendingDirection = "dao_withdraw",
+            pendingAmountShannons = deposit.capacity,
+            pendingFeeShannons = TransactionBuilder.DEFAULT_FEE,
+        ) { availableCells, net ->
             transactionBuilder.buildDaoWithdraw(
                 depositCell = depositCell,
                 depositBlockNumber = deposit.depositBlockNumber,


### PR DESCRIPTION
Closes #433.

## Problem
A pending DAO phase-1 withdraw showed in Activity as a plain `Sent -0.0010 CKB` — that value is the network fee, not the 250 CKB withdraw. It only became `Dao Withdraw 250.00 CKB` after the light client reclassified it on confirmation.

## Root cause
`buildReserveAndSend` always inserted the pending activity row as a generic `direction=out` with `balanceChange` = net debit. For a phase-1 withdraw the net debit is just the fee.

## Fix
Add optional `pendingDirection`/`pendingAmountShannons`/`pendingFeeShannons` overrides to `buildReserveAndSend`. DAO withdraw and deposit pass their true direction, the deposit capacity as the amount, and `DEFAULT_FEE` as the fee. The pending row now matches the confirmed row and the detail view populates the fee line (yanli's suggested layout).

## Testing
Debug build compiles; app installs, launches, onboarding renders on emulator (no regression). On-chain behaviour needs a funded testnet wallet to confirm live.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pending transaction details for DAO deposits and withdrawals.
  * Pending activity now accurately shows the transaction direction, amount, and applicable default fee.
  * Prevented DAO transactions from being displayed with generic outgoing-transfer information while processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->