### PR TITLE
fix(dao): populate consumedDepositOutPoints without header so dedup fires (#434)

### DIFF
--- a/android/app/src/main/java/com/rjnr/pocketnode/data/gateway/DaoDepositReader.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/gateway/DaoDepositReader.kt
@@ -176,6 +176,22 @@ class DaoDepositReader @Inject constructor(
         var apc = 0.0
         var consumedDepositOutPoints: List<com.rjnr.pocketnode.data.gateway.models.OutPoint> = emptyList()
 
+        // #434: read the phase-1 tx up front for withdrawing cells and record
+        // what it consumed, INDEPENDENT of header availability. This drives
+        // dedupeWithdrawnDeposits, which drops the original deposit's stale
+        // DEPOSITED entry the light client still lists until its spent-filter
+        // catches up. Previously this was only populated inside the
+        // `cellBlockHeader != null` branch below, so the moment right after a
+        // withdraw confirms — before the new withdrawing cell's header is
+        // fetched — it stayed empty, dedup couldn't fire, and the pending
+        // overlay painted the stale deposit a duplicate "Confirming…" card.
+        val withdrawTx = if (isWithdrawing) {
+            LightClientNative.nativeGetTransaction(cell.outPoint.txHash)
+                ?.let { json.decodeFromString<JniTransactionWithStatus>(it) }
+        } else null
+        consumedDepositOutPoints = withdrawTx?.transaction?.inputs
+            ?.map { it.previousOutput } ?: emptyList()
+
         // Get block header for compensation & epoch data (cache-first).
         val blockHash = daoHeaderResolver.getBlockHashForCell(cell.outPoint.txHash)
         val cellBlockHeader = if (blockHash != null) {
@@ -206,14 +222,9 @@ class DaoDepositReader @Inject constructor(
                 withdrawEpoch = cellBlockEpoch
                 depositBlockNumber = depositBlockNum
 
-                // Get original deposit header for compensation (cache-first)
-                val withdrawTxJson = LightClientNative.nativeGetTransaction(cell.outPoint.txHash)
-                val withdrawTx = withdrawTxJson?.let { json.decodeFromString<JniTransactionWithStatus>(it) }
-                // #357: record what this phase-1 tx consumed so the caller can
-                // drop the original deposit's stale DEPOSITED entry that the
-                // light client may still list until its spent-filter catches up.
-                consumedDepositOutPoints = withdrawTx?.transaction?.inputs
-                    ?.map { it.previousOutput } ?: emptyList()
+                // Original deposit header for compensation (cache-first). The
+                // phase-1 tx (`withdrawTx`) and its consumed outpoints were read
+                // up front (#434); reuse it here for the header dep.
                 val origDepositBlockHash = withdrawTx?.transaction?.headerDeps?.firstOrNull()
                 if (origDepositBlockHash != null) {
                     depositBlockHash = origDepositBlockHash


### PR DESCRIPTION
Closes #434.

## Problem
After a DAO phase-1 withdraw confirms, the DAO page briefly showed two entries for the same withdraw — `250 CKB / Withdrawal in progress` and `250 CKB / Confirming...` — doubling the Nervos DAO total to 500 CKB.

## Root cause
When phase-1 confirms, the light client briefly lists both the spent deposit cell and the new withdrawing cell. `dedupeWithdrawnDeposits` drops the stale `DEPOSITED` entry using the withdrawing cell's `consumedDepositOutPoints`, but that field was populated **only inside the `cellBlockHeader != null` branch** of `DaoDepositReader`. Right after confirmation the new withdrawing cell's header isn't fetched yet, so `consumedDepositOutPoints` stayed empty, dedup couldn't fire, and `applyPendingWithdrawOverlay` painted the stale deposit a duplicate `Confirming...` card.

## Fix
Read the phase-1 tx and its consumed outpoints up front for every withdrawing cell, independent of header availability; reuse the same tx in the header branch for the deposit header dep (one fewer JNI call). Dedup now drops the stale deposit before the overlay runs → single `Withdrawal in progress` entry, correct DAO total, and the pending marker retires.

## Testing
Debug build compiles; app installs, launches, no regression on emulator. Full reconciliation needs a funded testnet DAO deposit + withdraw to confirm live.