### PR TITLE
fix(wallet): refresh non-active account balances so switcher isn't stale (#435)

### DIFF
--- a/android/app/src/main/java/com/rjnr/pocketnode/data/gateway/GatewayRepository.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/gateway/GatewayRepository.kt
@@ -1327,6 +1327,71 @@ class GatewayRepository @Inject constructor(
         resp
     }
 
+    /**
+     * #435: recompute and cache the spendable balance for a wallet OTHER than
+     * the active one, keyed under [walletId], from its [address].
+     *
+     * The account switcher renders each account's balance from the balance
+     * cache. That cache was only written for a wallet while it was active (via
+     * [refreshBalance]), so a confirmed transfer INTO a sub-account left the
+     * sub-account's switcher balance stale until the user switched to it. All
+     * wallets' lock scripts are registered with the light client
+     * (SyncCoordinator), so the cell scan here sees the sub-account's cells
+     * even while it is inactive.
+     *
+     * Unlike [refreshBalance] this deliberately does NOT mutate [_balance]
+     * (that stream belongs to the active wallet) and does NOT run the zero-cell
+     * rescue rescan (an active-wallet-only recovery that rewinds the script).
+     */
+    suspend fun refreshBalanceForWallet(walletId: String, address: String): Result<BalanceResponse> = runCatching {
+        val script = AddressUtils.decode(address)
+        val searchKey = JniSearchKey(script = script)
+        val searchKeyJson = json.encodeToString(searchKey)
+
+        val responseJson = LightClientNative.nativeGetCellsCapacity(searchKeyJson)
+            ?: throw Exception(readPathNullMessage("get balance", lightClientReadyForRead()))
+        val cap = json.decodeFromString<JniCellsCapacity>(responseJson)
+        var capacityVal = cap.capacity.removePrefix("0x").toLongOrNull(16) ?: 0L
+
+        // Same live-cell filtering as refreshBalance: drop spent + typed cells.
+        try {
+            val spentOutpoints = fetchAllSpentOutpoints(searchKeyJson)
+            val allBalanceCells = mutableListOf<JniCell>()
+            var c: String? = null
+            var pages = 0
+            while (pages < MAX_CELL_PAGES) {
+                val pageJson = LightClientNative.nativeGetCells(searchKeyJson, "desc", 100, c) ?: break
+                val page = json.decodeFromString<JniPagination<JniCell>>(pageJson)
+                allBalanceCells.addAll(page.objects)
+                pages++
+                if (page.objects.isEmpty() || page.objects.size < 100 || page.lastCursor.isNullOrEmpty()) break
+                c = page.lastCursor
+            }
+            if (allBalanceCells.isNotEmpty()) {
+                var liveCapacity = 0L
+                allBalanceCells.forEach { cell ->
+                    val outpointKey = "${cell.outPoint.txHash}:${cell.outPoint.index}"
+                    if (outpointKey !in spentOutpoints) {
+                        val cellCapacity = cell.output.capacity.removePrefix("0x").toLongOrNull(16)
+                        if (cellCapacity != null && cell.output.type == null) liveCapacity += cellCapacity
+                    }
+                }
+                capacityVal = liveCapacity
+            }
+        } catch (e: Exception) {
+            Log.w(TAG, "refreshBalanceForWallet($walletId): live filter failed, using raw capacity: ${e.message}")
+        }
+
+        val resp = BalanceResponse(
+            address = address,
+            capacity = "0x${capacityVal.toString(16)}",
+            capacityCkb = (capacityVal / 100_000_000.0).toString(),
+            asOfBlock = cap.blockNumber
+        )
+        cacheManager.cacheBalance(resp, currentNetwork.name, walletId = walletId)
+        resp
+    }
+
     // Simplified Account Status - JNI doesn't give sync progress easily
     suspend fun getAccountStatus(): Result<AccountStatusResponse> = runCatching {
         val addr = getCurrentAddress() ?: throw Exception("No wallet")

--- a/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/home/HomeViewModel.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/ui/screens/home/HomeViewModel.kt
@@ -431,16 +431,35 @@ class HomeViewModel @Inject constructor(
 
             refreshTransactionsOnly()
 
+            // #435: keep the account switcher's per-account balances current,
+            // not just the active wallet's headline balance.
+            refreshWalletBalances(_uiState.value.wallets)
+
             _uiState.update { it.copy(isRefreshing = false) }
         }
     }
 
     private suspend fun refreshWalletBalances(wallets: List<WalletEntity>) {
-        val network = _uiState.value.currentNetwork.name
+        val network = _uiState.value.currentNetwork
+        val networkName = network.name
+        val activeWalletId = walletPreferences.getActiveWalletId()?.takeIf { it.isNotBlank() }
+
+        // #435: recompute non-active wallets' balances from the light client so
+        // the account switcher isn't stale after a confirmed transfer into
+        // another account. The active wallet's cache is kept fresh by
+        // refreshBalance(), so skip it here to avoid duplicate cell walks.
+        for (wallet in wallets) {
+            if (wallet.walletId == activeWalletId) continue
+            val address = if (network == NetworkType.MAINNET) wallet.mainnetAddress else wallet.testnetAddress
+            if (address.isBlank()) continue
+            runCatching { repository.refreshBalanceForWallet(wallet.walletId, address) }
+                .onFailure { Log.w(TAG, "Failed to refresh balance for ${wallet.walletId}", it) }
+        }
+
         val balanceMap = mutableMapOf<String, String>()
         for (wallet in wallets) {
             try {
-                val cached = cacheManager.getCachedBalance(network, walletId = wallet.walletId)
+                val cached = cacheManager.getCachedBalance(networkName, walletId = wallet.walletId)
                 if (cached != null) {
                     val ckb = cached.capacityAsCkb()
                     balanceMap[wallet.walletId] = String.format(Locale.US, "%,.2f CKB", ckb)


### PR DESCRIPTION
Closes #435.

## Problem
A confirmed transfer from the main account into a sub-account left the sub-account's balance stale in the account switcher until the user manually switched to it.

## Root cause
The account switcher renders each account's balance from the balance cache, but that cache was only written for a wallet **while it was active** (via `refreshBalance`). Non-active accounts never got recomputed.

## Fix
- `GatewayRepository.refreshBalanceForWallet(walletId, address)`: a live cell-capacity scan for any registered lock script, cached under that walletId, with no `_balance` mutation and no zero-cell rescue rescan (both active-only). All wallets' scripts are already registered with the light client (SyncCoordinator), so the scan sees a sub-account's cells while it is inactive.
- `HomeViewModel.refreshWalletBalances` recomputes every non-active wallet before reading the cache, and `refresh()` calls it each poll so the switcher tracks the chain, not just wallet-list changes.

## Testing
Debug build compiles; app installs, launches, onboarding renders on emulator (no regression). Multi-account balance update needs a funded testnet wallet + sub-account to confirm live.