### PR TITLE
chore(release): 1.8.3 (versionCode 25)

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -15,8 +15,8 @@ android {
         applicationId = "com.rjnr.pocketnode"
         minSdk = 26
         targetSdk = 35
-        versionCode = 24
-        versionName = "1.8.2"
+        versionCode = 25
+        versionName = "1.8.3"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 


### PR DESCRIPTION
Release cut for today's DAO + multi-wallet activity fixes.

Bumps versionCode 24 → 25, versionName 1.8.2 → 1.8.3.

Included:
- #433 (PR #436) pending DAO withdraw/deposit show true amount, not the fee
- #434 (PR #437) DAO withdraw confirm no longer creates a duplicate entry / doubled DAO total
- #435 (PR #438) non-active account balances refresh so the account switcher isn't stale

Deferred to follow-ups: #431 (address-based history, needs Room migration), #432 (explicit pending state machine).

Signed release build (AAB/APK) is produced manually with the release keystore after this merges.