### PR TITLE
fix(dao): retire spent deposit from cache so DAO total isn't doubled (#434 follow-up)

### DIFF
--- a/android/app/src/main/java/com/rjnr/pocketnode/data/gateway/GatewayRepository.kt
+++ b/android/app/src/main/java/com/rjnr/pocketnode/data/gateway/GatewayRepository.kt
@@ -2507,6 +2507,22 @@ class GatewayRepository @Inject constructor(
 
         val windowStart = getExistingScriptBlock()
         val liveKeys = live.map { "${it.outPoint.txHash}:${it.outPoint.index}" }.toSet()
+
+        // #434: outpoints consumed by a live withdrawing cell's phase-1 tx.
+        // A cached deposit whose outpoint is here was spent by a withdraw and
+        // MUST be retired — never resurfaced as an outside-window entry.
+        // getExistingScriptBlock() returns the script's current sync head, not
+        // its registration start, so a just-spent recent deposit (block now
+        // behind the head) would otherwise fall into the `< windowStart` branch,
+        // reappear under "made before this wallet's sync window", and double the
+        // DAO total right after a withdraw confirms. Index formats are
+        // normalized (hex vs decimal) so the outpoint match is reliable.
+        fun normKey(txHash: String, index: String) =
+            "${txHash.lowercase()}:${index.removePrefix("0x").toLongOrNull(16) ?: index}"
+        val consumedByLive = live.flatMap { it.consumedDepositOutPoints }
+            .map { normKey(it.txHash, it.index) }
+            .toSet()
+
         val cached = runCatching { daoSyncManager.getActiveDeposits(network, walletId) }
             .getOrDefault(emptyList())
 
@@ -2517,7 +2533,13 @@ class GatewayRepository @Inject constructor(
             // DEPOSITING rows are optimistic pre-confirmation inserts with
             // blockNumber 0 — not windowing victims; leave them alone.
             if (entity.status == DaoCellStatus.DEPOSITING.name) continue
-            if (windowStart > 0 && entity.depositBlockNumber in 1 until windowStart) {
+            if (normKey(entity.txHash, entity.index) in consumedByLive) {
+                // Spent by a live withdraw — retire so it neither resurfaces as
+                // an outside-window entry nor double-counts the DAO total (#434).
+                runCatching {
+                    daoSyncManager.updateStatus(entity.txHash, entity.index, DaoCellStatus.COMPLETED.name)
+                }
+            } else if (windowStart > 0 && entity.depositBlockNumber in 1 until windowStart) {
                 outsideWindow += entity.toOutsideWindowDeposit()
             } else {
                 // Inside the window yet absent from the live scan: the cell


### PR DESCRIPTION
Follow-up to #437 (closes #434 fully).

## Found during on-device testnet verification
After PR #437, I drove the full deposit -> withdraw flow on a funded testnet wallet. The duplicate still appeared: right after the phase-1 withdraw confirmed, the DAO page showed **500.00 CKB / Active (2)** — two 250 CKB entries.

## Root cause (second path)
#437 fixed the LIVE-scan dedup. But `mergeWithCachedDaoDeposits` classifies a cached active deposit absent from the live scan by block number: before `windowStart` -> resurface as an *outside sync window* entry; else -> retire COMPLETED. `windowStart = getExistingScriptBlock()` returns the script's **current sync head**, not its registration start. A just-spent recent deposit — now behind the advancing head — fell into the *before window* branch, reappeared under "made before this wallet's sync window", and doubled the total.

## Fix
Retire any cached deposit whose outpoint was consumed by a live withdrawing cell (`consumedDepositOutPoints`) **before** the window classification. Outpoint keys normalized (hex vs decimal index) for a reliable match.

## Verified on testnet (emulator, this build)
Deposit 250 -> withdraw -> confirm. DAO now shows **250.00 CKB / Active (1) / single 'Withdrawal in progress'**, stable across polls. Also re-verified #433 (pending withdraw shows 'Dao Withdraw 250.00 CKB', not the fee) and #435 (sub-account balance updates without switching to it) in the same run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed deposit tracking to correctly recognize deposits consumed by withdrawals.
  * Completed deposits are now excluded from results outside the selected time window, preventing duplicate or outdated entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->