### PR TITLE
chore(release): target Android 16 (API 36); bump to 1.8.4

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -14,9 +14,9 @@ android {
     defaultConfig {
         applicationId = "com.rjnr.pocketnode"
         minSdk = 26
-        targetSdk = 35
-        versionCode = 25
-        versionName = "1.8.3"
+        targetSdk = 36
+        versionCode = 26
+        versionName = "1.8.4"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 


### PR DESCRIPTION
## Why
Google Play flagged that the app must **target Android 16 (API 36)** by **Aug 31, 2026** or it can no longer ship updates. Current `targetSdk` was 35 (Android 15).

## What
- `targetSdk` 35 → **36** (`compileSdk` was already 36, so this just aligns target with compile).
- `versionCode` 25 → 26, `versionName` 1.8.3 → **1.8.4** for the compliant release.

## Android 16 behavior-change risk (low for this app)
- **Edge-to-edge** enforcement: already handled, `enableEdgeToEdge()` is in `MainActivity`.
- **Large-screen resizability/orientation**: the manifest has no `screenOrientation` lock or `resizableActivity=false`, so nothing to remove.
- `assembleDebug` passes.

## Before releasing
Recommend a quick on-device smoke test on a recent Android 16 device/emulator, especially: system-bar insets on the main screens (edge-to-edge), and the wallet's layout on a large screen/foldable, since apps targeting 36 are shown resizable there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)